### PR TITLE
Add explicit Labels vs. Columns distinction to prevent agent confusion

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -84,15 +84,27 @@ You are an expert Product Owner and Agile Coach specializing in agile digital pr
 
 ## Tools and Capabilities
 
-**GitHub MCP Server**: You have access to the GitHub MCP server with native tools for project board management. This is your **primary method** for all GitHub operations.
+**GitHub MCP Server**: You have access to the GitHub MCP server with native tools for issue management.
 
-**Available GitHub MCP Tools (Preferred):**
+**Available GitHub MCP Tools (for issues):**
 - Create, update, and manage issues
-- Move items between project board columns (Backlog, Ready, In Progress, In Review, Done, Icebox)
-- Update issue status, labels, priorities
+- Update issue labels and priorities
 - Add comments and assignees
 - Link issues to pull requests and create parent/child relationships
-- Bulk operations on project items
+
+**GitHub CLI (`gh`) for Board Operations**: Use the `gh` CLI for moving items between project board columns. See CLAUDE.md "Project Board Management" section for commands.
+
+**CRITICAL: Labels vs. Columns**
+
+NEVER use `mcp__github__update_issue(labels=[...])` to change workflow state. Labels are metadata ONLY - they do NOT move items on the project board.
+
+To move items between columns (Backlog, Ready, In Progress, In Review, Done, Icebox), use:
+```bash
+gh project item-edit --project-id {PROJECT_ID} --id {ITEM_ID} \
+  --field-id {STATUS_FIELD_ID} --single-select-option-id {COLUMN_OPTION_ID}
+```
+
+See CLAUDE.md for your project's specific IDs. After moving items, always verify the board state to confirm the move succeeded.
 
 **Memory MCP Server**: You have access to persistent knowledge storage for cross-session context.
 

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -65,19 +65,30 @@ Example: va-worker, myorg-worker, etc.
 See .claude/README.md for bot account setup instructions.
 -->
 
-**GitHub MCP Server**: You have access to the GitHub MCP server with native tools for interacting with issues, pull requests, and the project board. This is your **primary method** for all GitHub operations.
+**GitHub MCP Server**: You have access to the GitHub MCP server with native tools for interacting with issues and pull requests.
 
-**Available MCP Tools (Preferred):**
+**Available MCP Tools (for issues and PRs):**
 - Query and read issues from the project board
 - Create, update, and comment on issues
-- Move issues between project board columns (Ready, In Progress, In Review, Done)
 - Create and manage pull requests
 - Update PR status and labels
 - Link PRs to issues
 - Read file contents from the repository
 - Search code and issues
 
-**Fallback: GitHub CLI (`gh`)**: If MCP tools are unavailable or encounter errors, use the `gh` CLI for GitHub operations.
+**GitHub CLI (`gh`) for Board Operations**: Use the `gh` CLI for moving items between project board columns. See CLAUDE.md "Project Board Management" section for commands.
+
+**CRITICAL: Labels vs. Columns**
+
+NEVER use `mcp__github__update_issue(labels=[...])` to change workflow state. Labels are metadata ONLY - they do NOT move items on the project board.
+
+To move items between columns (Ready, In Progress, In Review), use:
+```bash
+gh project item-edit --project-id {PROJECT_ID} --id {ITEM_ID} \
+  --field-id {STATUS_FIELD_ID} --single-select-option-id {COLUMN_OPTION_ID}
+```
+
+See CLAUDE.md for your project's specific IDs.
 
 ## Your Core Responsibilities
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,71 @@ Agents use GitHub MCP for project board operations:
 }
 ```
 
+## Project Board Management (CRITICAL)
+
+### Labels vs. Columns (IMPORTANT DISTINCTION)
+
+**These are COMPLETELY SEPARATE SYSTEMS:**
+
+| Concept | What It Is | Tool to Use |
+|---------|-----------|-------------|
+| Labels | Metadata tags on issues (priority, type) | `mcp__github__update_issue(labels=[...])` |
+| Columns | Workflow state on project board | `gh project item-edit` CLI command |
+
+**Adding a label does NOT move an item on the board.** This is a common source of confusion for AI agents because both systems may use similar terminology (e.g., a "Ready" label vs. the "Ready" column).
+
+### Moving Items Between Columns
+
+To move an issue between project board columns, use the `gh` CLI:
+
+```bash
+# 1. Get the item's project item ID
+ITEM_ID=$(gh project item-list {PROJECT_NUMBER} --owner {ORG} --format json \
+  | jq -r '.items[] | select(.content.number == {ISSUE_NUMBER}) | .id')
+
+# 2. Move to target column using the Status field
+gh project item-edit \
+  --project-id {PROJECT_ID} \
+  --id "$ITEM_ID" \
+  --field-id {STATUS_FIELD_ID} \
+  --single-select-option-id {COLUMN_OPTION_ID}
+```
+
+<!--
+TEMPLATE: Fill in your project's board IDs:
+
+| Concept | ID |
+|---------|-----|
+| Project ID | `PVT_xxx` |
+| Status Field ID | `PVTSSF_xxx` |
+
+| Column | Option ID |
+|--------|-----------|
+| Backlog | `abc123` |
+| Ready | `def456` |
+| In Progress | `ghi789` |
+| In Review | `jkl012` |
+| Done | `mno345` |
+
+Get these IDs by running:
+```bash
+gh project field-list {PROJECT_NUMBER} --owner {ORG} --format json
+```
+-->
+
+### Source of Truth
+
+The GitHub Projects board is the ONLY source of truth for ticket workflow status. Issue labels are useful for categorization (priority, type, area) but do NOT represent pipeline state.
+
+### Verification Requirement
+
+After moving an item, always verify the board state:
+
+```bash
+gh project item-list {PROJECT_NUMBER} --owner {ORG} --format json \
+  | jq '.items[] | select(.content.number == {ISSUE_NUMBER}) | .status'
+```
+
 ## Formatting Standards
 
 ### No Emojis in ASCII Tables


### PR DESCRIPTION
## Summary

- Adds explicit documentation distinguishing GitHub Issue Labels from Project Board Columns
- Provides correct `gh project item-edit` commands for column moves
- Updates agent files with warnings to prevent the label/column confusion

## Context

This addresses a production incident documented in `vibeacademy/agentic-patterns/docs/content/label-column-confusion-incident.md` where an AI agent repeatedly confused labels with columns, causing workflow visibility failures.

## Test plan

- [ ] Verify CLAUDE.md changes render correctly
- [ ] Verify agent files have the warning section
- [ ] Test with an agent to confirm it uses correct commands

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)