### PR TITLE
docs: add release infrastructure (CHANGELOG, VERSIONING, release workflow)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          version="${{ steps.version.outputs.tag }}"
+          # Strip leading 'v' for changelog lookup
+          semver="${version#v}"
+          # Extract the section for this version from CHANGELOG.md
+          section=$(awk -v ver="$semver" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) found=1
+              next
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          if [ -z "$section" ]; then
+            section="Release ${version}"
+          fi
+
+          # Write to file to preserve multiline content
+          echo "$section" > /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes-file /tmp/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to Agile Flow will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.9.0] - 2025-12-07
+
+Pre-upgrade baseline — the first tagged release of Agile Flow.
+
+### Added
+
+- Core agent definitions: Product Manager, Product Owner, Ticket Worker, PR Reviewer, Quality Engineer, System Architect, Growth Marketing Strategist
+- Structured agile workflow with progressive refinement (Product Definition → Technical Architecture → Agent Specialization → Workflow Activation)
+- Trunk-based development workflow with feature branches and PR-based merges
+- GitHub Project board integration with Icebox, Backlog, Ready, In Progress, Review, Done columns
+- Slash commands for agent interactions (`/lock-scope`, marketing commands)
+- `bootstrap.sh` interactive wizard for project initialization
+- CI pipeline with validation tests (`.github/workflows/ci.yml`)
+- Bot permissions verification script (`scripts/verify-bot-permissions.sh`)
+- Hardened agent policies with NON-NEGOTIABLE PROTOCOL and bot account identity
+- Agent action logging and audit trail (`scripts/analyze-agent-actions.sh`)
+- Weekly agent restriction verification workflow
+- Agent instruction linter (`scripts/lint-agent-policies.sh`)
+- Weekly audit workflows and maintenance documentation
+- Comprehensive Agent Workflow Summary documentation
+- Product documentation templates (PRD, Roadmap)
+- Getting Started guide
+
+[Unreleased]: https://github.com/vibeacademy/agile-flow/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/vibeacademy/agile-flow/releases/tag/v0.9.0

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,39 @@
+# Versioning Policy
+
+Agile Flow follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+## Version Format
+
+```
+MAJOR.MINOR.PATCH
+```
+
+| Increment | When | Example |
+|-----------|------|---------|
+| **Patch** | Bug fixes, typo corrections, non-functional changes | Agent prompt fix, script bug fix, docs correction |
+| **Minor** | New capabilities that are backward-compatible | New agent, new slash command, new workflow, new script |
+| **Major** | Breaking changes that require user migration | Renamed/removed agents, restructured directories, changed bootstrap flow |
+
+## Compatibility Promise
+
+- **Patch** releases are always safe to adopt.
+- **Minor** releases are additive — existing agent definitions, commands, and scripts continue to work without modification.
+- **Major** releases may require migration. A migration guide will be included in the release notes and in `CHANGELOG.md`.
+
+## What Constitutes a Breaking Change
+
+- Renaming or removing an agent definition
+- Changing the expected directory structure (`.claude/`, `docs/`, `scripts/`)
+- Modifying `bootstrap.sh` in a way that changes required inputs
+- Removing or renaming slash commands
+- Changing CI workflow file names or trigger conditions that downstream forks depend on
+
+## Release Process
+
+1. All changes land on `main` via pull request.
+2. When ready to release, a maintainer creates an annotated tag (`git tag -a vX.Y.Z`).
+3. Pushing the tag triggers the GitHub Release workflow, which publishes a release with the relevant `CHANGELOG.md` section.
+
+## Current Version
+
+See the latest [GitHub Release](https://github.com/vibeacademy/agile-flow/releases) or the top entry in [CHANGELOG.md](./CHANGELOG.md).


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` with retroactive v0.9.0 history in [Keep a Changelog](https://keepachangelog.com) format
- Add `VERSIONING.md` documenting semver policy, compatibility promise, and what constitutes a breaking change
- Add `.github/workflows/release.yml` that triggers on `v*` tag push, extracts the relevant changelog section, and creates a GitHub Release

## Test plan

- [ ] Verify CHANGELOG.md renders correctly and links resolve
- [ ] Verify VERSIONING.md policy is clear and complete
- [ ] After merge, push a `v0.9.0` tag and confirm the release workflow creates a GitHub Release with the correct notes

Closes #10, Closes #11
Parent epic: #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)