### PR TITLE
feat(safety): add GitHub account switching hook and pre-push hook

### DIFF
--- a/.claude/hooks/ensure-github-account.sh
+++ b/.claude/hooks/ensure-github-account.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Claude Code PreToolUse Hook: GitHub Account Switcher
+#
+# Automatically switches to the correct GitHub account before PR creation
+# and review operations. Prevents the wrong account from being attributed
+# to automated work.
+#
+# Account model (configure these for your org):
+#   - WORKER_ACCOUNT: Used for ticket work, commits, PRs
+#   - REVIEWER_ACCOUNT: Used for PR reviews
+#
+# Configure via environment variables or edit the defaults below.
+#
+
+set -euo pipefail
+
+WORKER_ACCOUNT="${AGILE_FLOW_WORKER_ACCOUNT:-va-worker}"
+REVIEWER_ACCOUNT="${AGILE_FLOW_REVIEWER_ACCOUNT:-va-reviewer}"
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Extract tool name and command (for Bash tool)
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+tool_command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Determine required account based on tool
+required_account=""
+case "$tool_name" in
+  *create_pull_request|*update_pull_request_branch)
+    required_account="$WORKER_ACCOUNT"
+    ;;
+  *create_pull_request_review)
+    required_account="$REVIEWER_ACCOUNT"
+    ;;
+  Bash)
+    case "$tool_command" in
+      *"gh pr create"*)
+        required_account="$WORKER_ACCOUNT"
+        ;;
+      *"gh pr review"*)
+        required_account="$REVIEWER_ACCOUNT"
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# Get current active account
+current_account=$(gh auth status 2>&1 | grep -B2 "Active account: true" | grep "Logged in to" | sed 's/.*account \([^ ]*\).*/\1/')
+
+# Switch if needed
+if [[ "$current_account" != "$required_account" ]]; then
+  echo "Switching GitHub account from '$current_account' to '$required_account' for $tool_name" >&2
+
+  if gh auth switch --user "$required_account" 2>&1; then
+    echo "Successfully switched to $required_account" >&2
+  else
+    echo "ERROR: Failed to switch to $required_account account" >&2
+    echo "Please ensure $required_account is authenticated: gh auth login --user $required_account" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,25 @@ Configure branch protection on `main`:
 - Require status checks to pass (CI/CD)
 - Do not allow bypassing the above settings
 
+### Pre-push Hook (REQUIRED)
+
+A pre-push hook prevents broken code from reaching the remote. It auto-detects the language stack and runs the appropriate lint + test commands.
+
+```bash
+git config core.hooksPath scripts/hooks
+```
+
+**`--no-verify` is forbidden.** Never use `git push --no-verify` to bypass pre-push checks. Fix the failing checks instead.
+
+### GitHub Account Switching Hook
+
+The `.claude/hooks/ensure-github-account.sh` hook automatically switches GitHub accounts before PR operations:
+
+- **Worker account** (`AGILE_FLOW_WORKER_ACCOUNT`, default: `va-worker`) — used for PR creation
+- **Reviewer account** (`AGILE_FLOW_REVIEWER_ACCOUNT`, default: `va-reviewer`) — used for PR reviews
+
+This prevents the wrong account from being attributed to automated work. Override the account names via environment variables for your org.
+
 ## Agent Configuration
 
 ### Agent Roles and Boundaries

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Pre-push hook: Runs lint and tests before allowing push.
+# Prevents broken code from reaching the remote.
+#
+# Installation:
+#   git config core.hooksPath scripts/hooks
+#
+# Language auto-detection:
+#   Python  — detected via pyproject.toml → runs ruff + pytest
+#   Node.js — detected via package.json  → runs eslint + jest/vitest
+#   Go      — detected via go.mod        → runs go vet + go test
+#
+# Falls through gracefully if no recognized project file is found.
+#
+
+set -e
+
+echo "Running pre-push checks..."
+echo ""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+FAILED=0
+
+run_check() {
+  local label="$1"
+  shift
+  echo "  $label"
+  if "$@" 2>&1; then
+    echo -e "  ${GREEN}passed${NC}"
+  else
+    echo -e "  ${RED}failed${NC}"
+    FAILED=1
+  fi
+  echo ""
+}
+
+# --- Python ---
+if [ -f "pyproject.toml" ]; then
+  echo "Detected Python project"
+  echo ""
+  run_check "ruff check" uv run ruff check .
+  run_check "pytest" uv run pytest --tb=short -q
+
+# --- Node.js ---
+elif [ -f "package.json" ]; then
+  echo "Detected Node.js project"
+  echo ""
+
+  # Determine package runner
+  if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    runner="bun"
+  elif [ -f "pnpm-lock.yaml" ]; then
+    runner="pnpm"
+  elif [ -f "yarn.lock" ]; then
+    runner="yarn"
+  else
+    runner="npx"
+  fi
+
+  # Lint
+  if command -v "$runner" &>/dev/null; then
+    if [ -f ".eslintrc" ] || [ -f ".eslintrc.js" ] || [ -f ".eslintrc.json" ] || [ -f "eslint.config.js" ] || [ -f "eslint.config.mjs" ]; then
+      run_check "eslint" $runner eslint .
+    fi
+  fi
+
+  # Test
+  if grep -q '"vitest"' package.json 2>/dev/null; then
+    run_check "vitest" $runner vitest run
+  elif grep -q '"jest"' package.json 2>/dev/null; then
+    run_check "jest" $runner jest
+  fi
+
+# --- Go ---
+elif [ -f "go.mod" ]; then
+  echo "Detected Go project"
+  echo ""
+  run_check "go vet" go vet ./...
+  run_check "go test" go test ./...
+
+else
+  echo "No recognized project file found — skipping pre-push checks."
+  exit 0
+fi
+
+if [ $FAILED -eq 1 ]; then
+  echo ""
+  echo -e "${RED}Pre-push checks failed. Fix errors before pushing.${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}All pre-push checks passed.${NC}"
+exit 0


### PR DESCRIPTION
## Summary

- Add `.claude/hooks/ensure-github-account.sh` — auto-switches GitHub account before PR creation (worker) and PR review (reviewer) operations. Account names configurable via env vars.
- Add `scripts/hooks/pre-push` — runs lint + tests before push with language auto-detection (Python, Node.js, Go). Falls through gracefully for unrecognized stacks.
- Update `CLAUDE.md` with hook setup instructions and `--no-verify` prohibition.

## Test plan

- [ ] Verify `ensure-github-account.sh` switches accounts on `gh pr create` (requires multi-account gh setup)
- [ ] Verify `pre-push` detects Python project and runs `ruff check` + `pytest`
- [ ] Verify `pre-push` falls through gracefully in a directory with no recognized project file
- [ ] Verify CLAUDE.md renders correctly with new sections

Closes #15, Closes #16
Parent epic: #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)