### PR TITLE
feat: deploy workflow, CI enhancements, Memory MCP, and CI/CD docs

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -232,6 +232,57 @@ Escalate to the user when:
 - You encounter dependencies or blockers outside your control
 - Requirements conflict with established best practices
 
+## Post-Merge Recording (Memory MCP)
+
+After a PR is successfully merged, record the completed work using Memory MCP
+so institutional knowledge persists across sessions.
+
+**Record a CompletedTicket entity:**
+
+```bash
+# Entity name format: CompletedTicket-{issue-number}
+# Entity type: CompletedTicket
+#
+# Observations to record:
+# - Issue number and title
+# - PR number and branch name
+# - Summary of what was implemented
+# - Key files changed
+# - Patterns or conventions established
+# - Gotchas encountered during implementation
+```
+
+**Example MCP call:**
+
+```json
+{
+  "tool": "mcp__memory__create_entities",
+  "input": {
+    "entities": [
+      {
+        "name": "CompletedTicket-123",
+        "entityType": "CompletedTicket",
+        "observations": [
+          "Issue #123: Add health check endpoint",
+          "PR #456 merged to main",
+          "Added /health endpoint returning JSON {status: ok}",
+          "Used FastAPI dependency injection for DB health check",
+          "Key files: app/main.py, tests/test_app.py"
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Memory Schema:**
+
+| Entity Type | Naming Convention | When Created |
+|-------------|-------------------|--------------|
+| CompletedTicket | CompletedTicket-{issue} | After PR merge confirmed |
+| PatternDiscovered | Pattern-{short-name} | When a reusable pattern emerges |
+| LessonLearned | Lesson-{short-name} | When a gotcha or workaround is found |
+
 ## Communication Style
 
 - Provide clear progress updates in ticket comments

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -512,4 +512,39 @@ Use this template when reviewing PRs:
 - **Be consistent** - apply standards uniformly across all PRs
 - **Be constructive** - help developers improve, don't just criticize
 
+## Post-Review Recording (Memory MCP)
+
+After posting a review, record observations using Memory MCP so review
+patterns and quality trends persist across sessions.
+
+**Record a ReviewObservation entity:**
+
+```json
+{
+  "tool": "mcp__memory__create_entities",
+  "input": {
+    "entities": [
+      {
+        "name": "Review-PR-456",
+        "entityType": "ReviewObservation",
+        "observations": [
+          "PR #456 for issue #123: GO recommendation",
+          "Code quality: strong type safety, good test coverage (93%)",
+          "Pattern: used repository pattern for data access",
+          "Suggestion: consider extracting shared validation logic",
+          "No security concerns found"
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Memory Schema:**
+
+| Entity Type | Naming Convention | When Created |
+|-------------|-------------------|--------------|
+| ReviewObservation | Review-PR-{number} | After posting review comment |
+| QualityTrend | Trend-{topic} | When a recurring quality pattern emerges |
+
 Your role is to be a guardian of quality while enabling velocity. Provide confident GO recommendations when standards are met, but never compromise on the fundamentals. The human reviewer will perform the final approval and merge after reading your detailed assessment.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check for Python project
+        id: check_python
+        run: |
+          if [ -f "pyproject.toml" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No pyproject.toml found -- skipping Python checks."
+          fi
+
       - name: Install uv
+        if: steps.check_python.outputs.skip != 'true'
         uses: astral-sh/setup-uv@v4
 
       - name: Lint with ruff
+        if: steps.check_python.outputs.skip != 'true'
         run: uv run --extra dev ruff check .
 
-      - name: Run tests
-        run: uv run --extra dev pytest --tb=short -q
+      - name: Type check with mypy
+        if: steps.check_python.outputs.skip != 'true'
+        continue-on-error: true
+        run: |
+          uv run --extra dev pip install mypy 2>/dev/null || true
+          uv run --extra dev mypy . --ignore-missing-imports || echo "mypy not configured -- skipping"
+
+      - name: Run tests with coverage
+        if: steps.check_python.outputs.skip != 'true'
+        run: |
+          uv run --extra dev pytest --tb=short -q --cov --cov-report=term-missing --cov-fail-under=${COVERAGE_THRESHOLD:-80}
+
+      - name: Run BDD tests
+        if: steps.check_python.outputs.skip != 'true' && hashFiles('features/*.feature') != ''
+        run: uv run --extra dev pytest --tb=short -q features/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,117 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy to Render
+    runs-on: ubuntu-latest
+    if: github.repository != 'vibeacademy/agile-flow'
+    permissions:
+      contents: read
+    steps:
+      - name: Check for required secrets
+        id: check_secrets
+        run: |
+          if [ -z "${{ secrets.RENDER_API_KEY }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "RENDER_API_KEY not configured — skipping deployment."
+          elif [ -z "${{ secrets.RENDER_SERVICE_ID }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "RENDER_SERVICE_ID not configured — skipping deployment."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.check_secrets.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Store previous deployment info
+        if: steps.check_secrets.outputs.skip != 'true'
+        id: previous_deploy
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          PREV_DEPLOY=$(curl -s -X GET \
+            "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys?limit=1" \
+            -H "Authorization: Bearer ${RENDER_API_KEY}" \
+            -H "Accept: application/json" | jq -r '.[0].deploy.id // "none"')
+          echo "previous_deploy_id=$PREV_DEPLOY" >> "$GITHUB_OUTPUT"
+          echo "Previous deployment: $PREV_DEPLOY"
+
+      - name: Trigger deployment
+        if: steps.check_secrets.outputs.skip != 'true'
+        id: deploy
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          DEPLOY_RESPONSE=$(curl -s -X POST \
+            "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys" \
+            -H "Authorization: Bearer ${RENDER_API_KEY}" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json")
+
+          DEPLOY_ID=$(echo "$DEPLOY_RESPONSE" | jq -r '.id // empty')
+
+          if [ -z "$DEPLOY_ID" ]; then
+            echo "Failed to trigger deployment"
+            echo "$DEPLOY_RESPONSE"
+            exit 1
+          fi
+
+          echo "deploy_id=$DEPLOY_ID" >> "$GITHUB_OUTPUT"
+          echo "Triggered deployment: $DEPLOY_ID"
+
+      - name: Wait for deployment
+        if: steps.check_secrets.outputs.skip != 'true'
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          DEPLOY_ID="${{ steps.deploy.outputs.deploy_id }}"
+          MAX_ATTEMPTS=60
+          ATTEMPT=0
+
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+
+            STATUS=$(curl -s -X GET \
+              "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${DEPLOY_ID}" \
+              -H "Authorization: Bearer ${RENDER_API_KEY}" \
+              -H "Accept: application/json" | jq -r '.status // "unknown"')
+
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: status=$STATUS"
+
+            case "$STATUS" in
+              live)
+                echo "Deployment is live!"
+                exit 0
+                ;;
+              build_failed|update_failed|canceled)
+                echo "Deployment failed: $STATUS"
+                exit 1
+                ;;
+            esac
+
+            sleep 10
+          done
+
+          echo "Deployment timed out"
+          exit 1
+
+      - name: Run Supabase migrations
+        if: ${{ steps.check_secrets.outputs.skip != 'true' && hashFiles('supabase/migrations/*.sql') != '' }}
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          if [ -z "$SUPABASE_DB_URL" ]; then
+            echo "SUPABASE_DB_URL not configured — skipping migrations."
+            exit 0
+          fi
+          echo "Running Supabase migrations..."
+          npx supabase db push --db-url "$SUPABASE_DB_URL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ approved, tests passing, no lint errors, PR merged to main.
 | `docs/AGENTIC-CONTROLS.md` | 8-layer defense-in-depth controls |
 | `docs/CONTEXT-OPTIMIZATIONS.md` | Context engineering principles |
 | `docs/SENTRY-SETUP.md` | Sentry + GitHub integration setup |
+| `docs/CI-CD-GUIDE.md` | Workflows, secrets, troubleshooting |
 | `docs/GETTING-STARTED.md` | First-time setup walkthrough |
 | `docs/AGENT-WORKFLOW-SUMMARY.md` | Complete workflow documentation |
 | `docs/MAINTENANCE.md` | Weekly audit and maintenance guide |

--- a/docs/CI-CD-GUIDE.md
+++ b/docs/CI-CD-GUIDE.md
@@ -1,0 +1,120 @@
+# CI/CD Guide
+
+This document describes all GitHub Actions workflows, their triggers,
+required secrets, and default states.
+
+## Workflow Overview
+
+| Workflow | File | Trigger | Default State | Required Secrets |
+|----------|------|---------|---------------|------------------|
+| CI | `ci.yml` | Push/PR to main | Active | None |
+| Release | `release.yml` | Tag `v*` | Active | None |
+| Deploy | `deploy.yml` | Push to main | Inert | RENDER_API_KEY, RENDER_SERVICE_ID |
+| Preview Deploy | `preview-deploy.yml` | PR opened/updated | Inert | RENDER_API_KEY, RENDER_SERVICE_ID |
+| Preview Cleanup | `preview-cleanup.yml` | PR closed | Inert | RENDER_API_KEY, RENDER_SERVICE_ID |
+
+## Active by Default
+
+These workflows run without any configuration.
+
+### CI (`ci.yml`)
+
+Runs on every push and pull request to `main`.
+
+**Jobs:**
+
+| Job | What It Checks |
+|-----|----------------|
+| `lint` | Markdown formatting (markdownlint) |
+| `typecheck` | JSON file validity |
+| `build` | Shell script correctness (shellcheck) |
+| `test` | Command and agent file validation |
+| `lint-agent-policies` | Agent policy safety rules |
+| `python` | Ruff lint, mypy (non-blocking), pytest with coverage |
+
+The `python` job is conditional — it only runs when `pyproject.toml` exists.
+Coverage threshold defaults to 80% and can be overridden via the
+`COVERAGE_THRESHOLD` environment variable.
+
+If a `features/` directory with `.feature` files exists, BDD tests run
+automatically.
+
+### Release (`release.yml`)
+
+Triggers when a `v*` tag is pushed. Extracts the matching section from
+`CHANGELOG.md` and creates a GitHub Release.
+
+## Enable When Ready
+
+These workflows require secrets to be configured in the repository settings.
+Until configured, they skip gracefully with no red CI.
+
+### Deploy (`deploy.yml`)
+
+Deploys to Render production on merge to `main`.
+
+**To enable:**
+
+1. Go to **Settings > Secrets and variables > Actions**
+2. Add these repository secrets:
+
+| Secret | Where to Find |
+|--------|--------------|
+| `RENDER_API_KEY` | Render Dashboard > Account Settings > API Keys |
+| `RENDER_SERVICE_ID` | Render Dashboard > Service > Settings (starts with `srv-`) |
+
+The workflow stores the previous deployment ID before deploying, which can
+be used for rollback.
+
+If a `supabase/migrations/` directory exists and `SUPABASE_DB_URL` is
+configured, database migrations run automatically after deployment.
+
+### Preview Deploy (`preview-deploy.yml`)
+
+Creates a preview environment on Render for every pull request. Comments the
+preview URL on the PR.
+
+**Requires the same secrets as Deploy** (`RENDER_API_KEY`, `RENDER_SERVICE_ID`).
+
+Render must also have `previewsEnabled: true` in `render.yaml` (already
+configured in this template).
+
+### Preview Cleanup (`preview-cleanup.yml`)
+
+Cleans up preview environments when PRs are closed or merged.
+
+**Requires the same secrets as Deploy.**
+
+## Troubleshooting
+
+### Common CI Failures
+
+| Failure | Cause | Fix |
+|---------|-------|-----|
+| `lint` fails | Markdown formatting issues | Run `markdownlint --fix **/*.md` |
+| `python` lint fails | Ruff violations | Run `uv run ruff check . --fix` |
+| `python` tests fail | Test failures or coverage below threshold | Fix tests or lower `COVERAGE_THRESHOLD` |
+| `lint-agent-policies` fails | Agent file missing safety phrases | Check `scripts/verify-agent-restrictions.sh` output |
+| `build` fails | Shell script errors | Run `shellcheck <script>` locally |
+
+### Secret-Gated Workflows Show "Skipped"
+
+This is expected behavior. The workflow checked for secrets, found none
+configured, and skipped gracefully. Add the required secrets when you are
+ready to enable the workflow.
+
+### Preview URL Not Available
+
+If the preview deploy workflow runs but the URL is not ready:
+
+1. Check the Render dashboard for the preview service status
+2. Preview services follow the naming pattern `{service-name}-pr-{number}`
+3. First deploys take longer as Render provisions the service
+
+### Coverage Threshold Failures
+
+The default coverage threshold is 80%. To adjust:
+
+1. Set `COVERAGE_THRESHOLD` as a repository variable (not secret)
+2. Go to **Settings > Secrets and variables > Actions > Variables**
+3. Add `COVERAGE_THRESHOLD` with your desired percentage


### PR DESCRIPTION
## Summary
- **#26**: Add Memory MCP post-merge recording patterns to `github-ticket-worker` (CompletedTicket entities) and `pr-reviewer` (ReviewObservation entities) agents, with documented memory schema
- **#27**: Add `deploy.yml` — Render production deployment on merge to main, with secret gating (inert until configured), previous deployment tracking for rollback, and conditional Supabase migrations
- **#31**: Enhance `ci.yml` Python job — conditional on `pyproject.toml`, non-blocking mypy, coverage threshold (default 80%, configurable), conditional BDD test support
- **#32**: Create `docs/CI-CD-GUIDE.md` — documents all workflows with triggers, required secrets, default states, enable-when-ready instructions, and troubleshooting

## Test plan
- [ ] CI passes (lint, typecheck, build, test, python, lint-agent-policies)
- [ ] Deploy workflow skips gracefully (no RENDER_API_KEY in template repo)
- [ ] Python CI job runs with coverage reporting
- [ ] Agent files pass policy lint with Memory MCP additions
- [ ] CI-CD-GUIDE.md renders correctly and covers all workflows

Closes #26 Closes #27 Closes #31 Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)