### PR TITLE
refactor: generalize templates, platform selection, and workshop guide

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -4,7 +4,7 @@ description: Use this agent when you need to prioritize work items, manage the p
 
 <example>
 Context: New feature tickets have been added to the backlog.
-user: "I just created three new pattern implementation tickets"
+user: "I just created three new feature tickets"
 assistant: "I'm going to use the Task tool to launch the agile-backlog-prioritizer agent to analyze these new tickets and determine their priority."
 </example>
 
@@ -97,16 +97,16 @@ You are an expert Product Owner and Agile Coach specializing in agile digital pr
 **Memory MCP Server**: You have access to persistent knowledge storage for cross-session context.
 
 **Available Memory MCP Tools:**
-- `create_entities` - Store prioritization decisions, pattern dependencies, learning progression logic
-- `create_relations` - Link concepts (e.g., "Pattern X" → "depends on" → "Pattern Y")
+- `create_entities` - Store prioritization decisions, feature dependencies, sequencing logic
+- `create_relations` - Link concepts (e.g., "Feature X" → "depends on" → "Feature Y")
 - `search_nodes` - Query stored knowledge about past prioritization decisions
 - `open_nodes` - Retrieve specific knowledge items
 
 **Use Memory MCP to:**
-- Remember which patterns are prerequisites for others
-- Store educational sequencing logic across sessions
-- Record why certain patterns were prioritized or deferred
-- Track pattern complexity assessments
+- Remember which features are prerequisites for others
+- Store sequencing logic across sessions
+- Record why certain features were prioritized or deferred
+- Track implementation complexity assessments
 - Share context with other agents about strategic decisions
 
 ## Your Core Responsibilities

--- a/.claude/commands/bootstrap-architecture.md
+++ b/.claude/commands/bootstrap-architecture.md
@@ -19,6 +19,34 @@ The System Architect will read your PRD and help you define:
 
 ## Process
 
+### 0. Platform Selection
+
+Before diving into architecture, ask the user about their deployment platform:
+
+```
+What platform will you deploy to?
+
+1. Render (Recommended for this template)
+2. Cloudflare (Workers/Pages)
+3. Vercel
+4. Railway
+5. Fly.io
+6. Other (please specify)
+
+Enter a number (1-6):
+```
+
+Write the platform choice to `.claude/PROJECT.md`:
+
+```markdown
+## Platform
+- **Hosting**: [selected platform]
+- **Selected**: [date]
+```
+
+This file is read by the `devops-engineer` and `system-architect` agents
+to provide platform-specific guidance.
+
 ### 1. PRD Analysis
 The architect first analyzes your Product Requirements:
 - What features need to be built?

--- a/.claude/commands/bootstrap-product.md
+++ b/.claude/commands/bootstrap-product.md
@@ -16,6 +16,33 @@ For multiple-choice questions, present numbered options and ask the user to resp
 
 ## Questionnaire
 
+### Section 0: Your Domain
+
+**Question 0.1**
+```
+What is your product's domain? Describe it in one sentence.
+
+Example: "A fitness studio management platform for boutique gym owners"
+Example: "A developer tool for managing database migrations"
+Example: "An e-commerce marketplace for handmade crafts"
+
+Your domain:
+```
+
+**Question 0.2**
+```
+What is your core value proposition in one sentence?
+
+Example: "We help boutique gym owners fill every class slot automatically"
+Example: "Ship database changes safely with zero-downtime migrations"
+
+Your value proposition:
+```
+
+Use the domain and value proposition throughout the generated PRD and
+Roadmap to make them specific to the founder's product, not generic
+template content.
+
 ### Section 1: Product Type & Category
 
 **Question 1.1**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ approved, tests passing, no lint errors, PR merged to main.
 | `docs/CONTEXT-OPTIMIZATIONS.md` | Context engineering principles |
 | `docs/SENTRY-SETUP.md` | Sentry + GitHub integration setup |
 | `docs/CI-CD-GUIDE.md` | Workflows, secrets, troubleshooting |
+| `docs/PLATFORM-GUIDE.md` | Deployment platform options and setup |
+| `docs/WORKSHOP-GUIDE.md` | Instructor guide for 3-day workshop |
 | `docs/GETTING-STARTED.md` | First-time setup walkthrough |
 | `docs/AGENT-WORKFLOW-SUMMARY.md` | Complete workflow documentation |
 | `docs/MAINTENANCE.md` | Weekly audit and maintenance guide |

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -1,0 +1,110 @@
+# Platform Guide
+
+Agile Flow supports multiple deployment platforms. Your choice is stored
+in `.claude/PROJECT.md` and read by the `devops-engineer` and
+`system-architect` agents.
+
+## Supported Platforms
+
+| Platform | Best For | Free Tier | Preview Envs |
+|----------|----------|-----------|-------------|
+| Render | Full-stack web apps, APIs | Yes | Yes (built-in) |
+| Cloudflare | Edge computing, static sites | Yes | Yes (Workers) |
+| Vercel | Frontend apps, Next.js | Yes | Yes (automatic) |
+| Railway | Containers, databases | Trial | Yes |
+| Fly.io | Global edge containers | Yes | Manual |
+
+## Default: Render
+
+This template ships configured for Render:
+
+- `render.yaml` defines the service with preview environments enabled
+- `deploy.yml` deploys to Render on merge to main
+- `preview-deploy.yml` manages Render preview environments
+- `rollback-production.yml` rolls back via Render API
+
+## Choosing Your Platform
+
+Run `/bootstrap-architecture` to select your platform. The choice is
+written to `.claude/PROJECT.md`:
+
+```markdown
+## Platform
+- **Hosting**: render
+- **Selected**: 2026-02-17
+```
+
+## Switching Platforms
+
+To switch platforms after initial setup:
+
+1. Update `.claude/PROJECT.md` with the new platform
+2. Replace the platform-specific workflow files:
+   - `deploy.yml` -- production deployment
+   - `preview-deploy.yml` -- PR preview environments
+   - `preview-cleanup.yml` -- cleanup on PR close
+3. Update `render.yaml` / `vercel.json` / `fly.toml` as needed
+4. Update repository secrets in GitHub Settings
+
+## Platform-Specific Setup
+
+### Render
+
+**Required secrets:**
+
+| Secret | Where to Find |
+|--------|--------------|
+| `RENDER_API_KEY` | Render Dashboard > Account Settings > API Keys |
+| `RENDER_SERVICE_ID` | Render Dashboard > Service > Settings |
+
+**Configuration file:** `render.yaml`
+
+### Cloudflare
+
+**Required secrets:**
+
+| Secret | Where to Find |
+|--------|--------------|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare Dashboard > Profile > API Tokens |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare Dashboard > Overview (sidebar) |
+
+**Configuration file:** `wrangler.toml`
+
+### Vercel
+
+**Required secrets:**
+
+| Secret | Where to Find |
+|--------|--------------|
+| `VERCEL_TOKEN` | Vercel Dashboard > Settings > Tokens |
+| `VERCEL_ORG_ID` | Vercel Dashboard > Settings > General |
+| `VERCEL_PROJECT_ID` | Vercel Dashboard > Project > Settings |
+
+**Configuration file:** `vercel.json`
+
+### Railway
+
+**Required secrets:**
+
+| Secret | Where to Find |
+|--------|--------------|
+| `RAILWAY_TOKEN` | Railway Dashboard > Account > Tokens |
+
+**Configuration file:** `railway.toml`
+
+### Fly.io
+
+**Required secrets:**
+
+| Secret | Where to Find |
+|--------|--------------|
+| `FLY_API_TOKEN` | `fly tokens create deploy` |
+
+**Configuration file:** `fly.toml`
+
+## Adding a New Platform
+
+1. Create deployment workflow in `.github/workflows/`
+2. Add platform detection to `.claude/agents/devops-engineer.md`
+3. Add setup instructions to this guide
+4. Document required secrets in `docs/CI-CD-GUIDE.md`

--- a/docs/PRODUCT-REQUIREMENTS.md
+++ b/docs/PRODUCT-REQUIREMENTS.md
@@ -1,166 +1,112 @@
-# Product Requirements Document: Agile Flow
+# Product Requirements Document
 
-## Executive Summary
+<!--
+TEMPLATE: This is a template PRD. Run /bootstrap-product to fill it in
+with your product details through a guided questionnaire.
 
-Agile Flow is a project template for bootstrapping Claude Code projects with a complete agile workflow powered by specialized AI agents. It provides the configuration, policies, and commands needed to safely integrate AI agents into a trunk-based development workflow.
+Replace all [PLACEHOLDER] content with your actual product information.
+Remove the EXAMPLE markers when you replace the content.
+-->
 
-## Problem Statement
+## Product Overview
 
-Development teams adopting Claude Code face several challenges:
+- **Name**: [Your product name]
+- **Type**: [Web app | Mobile app | API service | CLI tool | Library | Other]
+- **Category**: [B2B SaaS | B2C Consumer | Developer tools | E-commerce | Other]
 
-1. **Safety Concerns**: AI agents can perform destructive actions (force push, merge, delete) without proper guardrails
-2. **Workflow Integration**: No clear pattern for integrating AI agents into existing agile workflows
-3. **Audit Trail**: Difficulty tracking which agent performed which action
-4. **Quality Control**: AI-generated code bypassing human review
-5. **Configuration Complexity**: Each project reinvents agent policies and permissions
+## Vision and Problem Statement
+
+### Problem
+
+[Describe the problem your product solves in 1-3 sentences.]
+
+<!-- EXAMPLE -- replace with your content:
+Development teams waste 40% of their time on repetitive coordination tasks
+that could be automated with AI agents, but lack safe guardrails for
+integrating AI into their workflows.
+-->
+
+### Vision
+
+[One sentence describing the ideal future state your product creates.]
+
+### How People Solve This Today
+
+[What alternatives or workarounds exist? Why are they inadequate?]
 
 ## Target Audience
 
 ### Primary Users
 
-**Development Teams** adopting Claude Code for AI-assisted development:
-- Teams practicing trunk-based development
-- Organizations requiring human oversight of AI actions
-- Projects needing clear separation of duties between agents and humans
+- **Who**: [Role, context, and goal in one sentence]
+- **Pain Point**: [The #1 problem they face]
+- **Current Solution**: [How they solve it today]
 
 ### Secondary Users
 
-**Platform Engineers** setting up AI development infrastructure:
-- Creating standardized agent configurations across projects
-- Establishing security policies for AI-assisted workflows
-- Building observability into agent actions
+[Other user types, or "None -- single user type"]
 
-## Product Vision
+## Features
 
-Enable safe, auditable, and productive AI-assisted development by providing:
+### MVP (Must Have)
 
-1. **Pre-configured agent policies** with explicit behavioral boundaries
-2. **Three-stage workflow** ensuring human control over code merging
-3. **Slash commands** for common agile operations
-4. **CI/CD integration** validating agent policy compliance
-5. **Observability tools** for monitoring agent actions
+<!-- List 3-5 features that MUST be in v1. Be specific and testable. -->
 
-## Core Value Propositions
+- [ ] [Feature 1 -- specific and measurable]
+- [ ] [Feature 2]
+- [ ] [Feature 3]
 
-### 1. Safety by Default
+### Out of Scope (v1)
 
-- NON-NEGOTIABLE PROTOCOL blocks prevent destructive actions
-- Agents cannot merge PRs, push to main, or close issues
-- Explicit deny rules for sensitive operations
+<!-- Equally important: what are you NOT building? -->
 
-### 2. Clear Separation of Duties
+- [Feature explicitly excluded from v1]
 
-| Role | Creates | Reviews | Merges |
-|------|---------|---------|--------|
-| github-ticket-worker | PRs | - | - |
-| pr-reviewer | - | Reviews | - |
-| Human | - | Final review | Merges |
+### Core Value Proposition
 
-### 3. Audit Trail
-
-- Dedicated bot accounts for worker and reviewer roles
-- All agent actions attributed to specific accounts
-- Clear distinction between AI and human actions
-
-### 4. Agile Integration
-
-- Project board integration (Ready → In Progress → In Review → Done)
-- Backlog prioritization with CD3 methodology
-- Sprint status and milestone tracking
-
-## Functional Requirements
-
-### FR-1: Agent Policies
-
-| ID | Requirement | Priority |
-|----|-------------|----------|
-| FR-1.1 | NON-NEGOTIABLE PROTOCOL blocks in all workflow agents | P0 |
-| FR-1.2 | GitHub account identity switching instructions | P0 |
-| FR-1.3 | Explicit "cannot do" boundaries for each agent | P0 |
-| FR-1.4 | Settings template with deny rules | P1 |
-
-### FR-2: Slash Commands
-
-| ID | Requirement | Priority |
-|----|-------------|----------|
-| FR-2.1 | /work-ticket - Pick up next ticket from Ready | P0 |
-| FR-2.2 | /review-pr - Review PRs in In Review column | P0 |
-| FR-2.3 | /groom-backlog - Prioritize and populate Ready | P0 |
-| FR-2.4 | /sprint-status - Board health overview | P1 |
-| FR-2.5 | /check-milestone - Milestone progress | P1 |
-
-### FR-3: CI/CD Integration
-
-| ID | Requirement | Priority |
-|----|-------------|----------|
-| FR-3.1 | Validate agent policy files have required sections | P0 |
-| FR-3.2 | Lint agent instructions for safety compliance | P1 |
-| FR-3.3 | Verify settings.template.json deny rules | P1 |
-
-### FR-4: Observability
-
-| ID | Requirement | Priority |
-|----|-------------|----------|
-| FR-4.1 | Agent action logging | P1 |
-| FR-4.2 | Policy violation detection | P1 |
-| FR-4.3 | Weekly audit workflows | P2 |
-
-## Non-Functional Requirements
-
-### NFR-1: Security
-
-- No hardcoded secrets in agent policies
-- PAT storage guidance for bot accounts
-- Explicit deny rules for sensitive file access
-
-### NFR-2: Extensibility
-
-- Template placeholders for project-specific customization
-- Clear separation between framework and project code
-- Documentation for adding new agents
-
-### NFR-3: Usability
-
-- Clear setup instructions in .claude/README.md
-- Settings template with explanatory comments
-- Troubleshooting FAQ
+[The ONE thing your product must do exceptionally well.]
 
 ## Success Metrics
 
-| Metric | Target |
-|--------|--------|
-| Agent policy violations | 0 per sprint |
-| PRs merged by agents | 0 (human-only) |
-| Setup time for new project | < 30 minutes |
-| Agent configuration reuse | > 90% across projects |
+| Metric | Target (3 months) |
+|--------|-------------------|
+| Primary: [e.g., Monthly active users] | [e.g., 500] |
+| Secondary: [e.g., Retention rate] | [e.g., 60%] |
 
-## Out of Scope
+## Competitive Analysis
 
-- Application-specific code (this is a template, not an app)
-- Runtime agent execution (handled by Claude Code)
-- GitHub account creation (manual setup required)
-- CI/CD pipeline execution (GitHub Actions handles this)
+| Competitor | Strength | Weakness | Your Differentiator |
+|-----------|----------|----------|---------------------|
+| [Name] | [What they do well] | [Where they fall short] | [Why you win] |
+
+## Constraints and Requirements
+
+- **Timeline**: [When do you need to launch?]
+- **Budget**: [Resource constraints]
+- **Technical**: [Must-use technologies, compliance requirements]
+- **Team**: [Available expertise]
+
+## Non-Functional Requirements
+
+| Category | Requirement |
+|----------|-------------|
+| Security | [Auth approach, data protection] |
+| Performance | [Latency, throughput targets] |
+| Scalability | [Expected load, growth] |
+| Accessibility | [WCAG level, requirements] |
 
 ## Dependencies
 
-- Claude Code CLI
-- GitHub repository with project board
-- GitHub Actions for CI/CD
-- MCP servers (GitHub, Memory)
+- [External service or tool this product depends on]
 
 ## Risks and Mitigations
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Agent bypasses NON-NEGOTIABLE PROTOCOL | High | Branch protection + policy linter |
-| Bot account credentials leaked | High | PAT rotation + security docs |
-| Stale agent policies | Medium | CI validation + audit workflows |
+| [Risk description] | High/Medium/Low | [How to prevent or handle] |
 
 ## Glossary
 
 | Term | Definition |
 |------|------------|
-| NON-NEGOTIABLE PROTOCOL | Override rules that agents must follow regardless of other instructions |
-| Three-stage workflow | Worker creates → Reviewer reviews → Human merges |
-| CD3 | Cost of Delay Divided by Duration - prioritization methodology |
-| Definition of Ready | Criteria a ticket must meet before development starts |
+| [Domain term] | [What it means in this product] |

--- a/docs/PRODUCT-ROADMAP.md
+++ b/docs/PRODUCT-ROADMAP.md
@@ -1,133 +1,89 @@
-# Product Roadmap: Agile Flow
+# Product Roadmap
+
+<!--
+TEMPLATE: This is a template roadmap. Run /bootstrap-product to generate
+a roadmap based on your PRD.
+
+Replace all [PLACEHOLDER] content with your actual product plans.
+Remove the EXAMPLE markers when you replace the content.
+-->
 
 ## Overview
 
-This roadmap outlines the phased development of Agile Flow, a project template for bootstrapping Claude Code projects with a complete agile workflow powered by specialized AI agents.
+[One paragraph describing the product direction and timeline.]
 
-## Roadmap Phases
+## Phase 1: MVP
 
-### Phase 1: Foundation (COMPLETE)
+- **Target**: [Date or timeframe]
+- **Goal**: Deliver core value proposition to first users
 
-**Goal**: Establish core agent architecture with safety guarantees.
+### Features
 
-| Epic | Description | Status |
-|------|-------------|--------|
-| #1 - Core Agent Safety Architecture | NON-NEGOTIABLE PROTOCOL, bot account separation, settings template | Done |
-| #6 - PR Workflow Improvements | Rename pr-reviewer-merger to pr-reviewer, clarify approval boundaries | Done |
+| Feature | Priority | Status |
+|---------|----------|--------|
+| [Feature from PRD] | P0 | Backlog |
+| [Feature from PRD] | P0 | Backlog |
+| [Feature from PRD] | P1 | Backlog |
 
-**Deliverables**:
-- Agent policies with explicit behavioral boundaries
-- Bot account documentation and setup guide
-- Settings template with deny rules for sensitive operations
-- Three-stage workflow (worker creates, reviewer reviews, human merges)
+### Success Criteria
 
-### Phase 2: Quality Infrastructure (IN PROGRESS)
+- [ ] [Primary metric from PRD] reaches [target]
+- [ ] [Acceptance criterion]
 
-**Goal**: Build validation and observability tooling.
+## Phase 2: Iteration
 
-| Epic | Description | Status |
-|------|-------------|--------|
-| #20 - CI/CD Pipeline | GitHub Actions workflow, validation scripts, policy linter | Done |
-| #11 - Safety & Observability | Agent action logging, audit trails, violation detection | Ready |
+- **Target**: Post-MVP (1-2 months after launch)
+- **Goal**: Expand based on user feedback
 
-**Deliverables**:
-- CI pipeline validating agent policies
-- Agent instruction linter
-- Audit logging infrastructure
-- Weekly audit workflows
+### Features
 
-### Phase 3: Integration & Extensibility
+| Feature | Priority | Status |
+|---------|----------|--------|
+| [Based on user feedback] | TBD | Backlog |
 
-**Goal**: Enable project integration and customization.
+### Success Criteria
 
-| Epic | Description | Status |
-|------|-------------|--------|
-| #16 - Cloudflare Integration | DevOps engineer agent, preview environments, infrastructure cleanup | Backlog |
-| Bootstrap Commands | /bootstrap-product, /bootstrap-architecture, /bootstrap-agents, /bootstrap-workflow | Backlog |
+- [ ] [Retention or engagement metric]
 
-**Deliverables**:
-- Infrastructure integration patterns
-- Project bootstrap workflow
-- Agent specialization automation
-- Template placeholders for customization
+## Phase 3: Growth
 
-### Phase 4: Documentation & Polish
+- **Target**: [3-6 months post-launch]
+- **Goal**: Scale and expand capabilities
 
-**Goal**: Production-ready documentation and tooling.
+### Features
 
-| Epic | Description | Status |
-|------|-------------|--------|
-| #24 - Documentation | Comprehensive README, setup guide, troubleshooting FAQ | Backlog |
-| Marketing Commands | Campaign planning, referral programs, GTM alignment | Backlog |
-
-**Deliverables**:
-- Complete setup documentation
-- Troubleshooting guide
-- Example configurations
-- Marketing agent documentation
+| Feature | Priority | Status |
+|---------|----------|--------|
+| [Growth feature] | TBD | Backlog |
 
 ## Milestone Definitions
 
-### M1: Safe Agent Operations (COMPLETE)
+| Milestone | Criteria | Target Date |
+|-----------|----------|-------------|
+| M1: MVP Launch | Core features live, first users onboarded | [Date] |
+| M2: Product-Market Fit | [Retention/engagement threshold] | [Date] |
+| M3: Growth | [Scale/revenue threshold] | [Date] |
 
-Agents cannot perform destructive actions:
-- No direct commits to main
-- No PR merges by agents
-- No issue closure by agents
-- Clear audit trail via bot accounts
-
-### M2: Validated Workflows (IN PROGRESS)
-
-All agent operations are validated:
-- CI validates agent policies on every PR
-- Policy violations detected before merge
-- Audit logging captures agent actions
-
-### M3: Production Ready
-
-Template is ready for adoption:
-- Complete documentation
-- Bootstrap automation
-- Integration examples
-- Troubleshooting resources
-
-## Success Criteria
-
-| Phase | Criteria |
-|-------|----------|
-| Phase 1 | Zero agent policy violations possible through NON-NEGOTIABLE PROTOCOL |
-| Phase 2 | CI catches 100% of policy compliance issues |
-| Phase 3 | New project setup < 30 minutes |
-| Phase 4 | Self-service adoption without support |
-
-## Dependencies
-
-```
-Phase 1: Foundation
-    |
-    v
-Phase 2: Quality Infrastructure
-    |
-    v
-Phase 3: Integration & Extensibility
-    |
-    v
-Phase 4: Documentation & Polish
-```
-
-Each phase builds on the previous. Phase 2 cannot validate what Phase 1 didn't define. Phase 3 cannot integrate what Phase 2 didn't validate.
-
-## Risk Register
+## Constraints and Risks
 
 | Risk | Phase | Mitigation |
 |------|-------|------------|
-| Agent bypasses safety controls | 1 | NON-NEGOTIABLE PROTOCOL + branch protection |
-| CI doesn't catch violations | 2 | Multiple validation layers + policy linter |
-| Complex setup deters adoption | 3-4 | Bootstrap automation + clear docs |
-| Stale documentation | 4 | CI validation of doc accuracy |
+| [Risk from PRD] | 1 | [Mitigation strategy] |
+
+## Dependencies
+
+```text
+Phase 1: MVP
+    |
+    v
+Phase 2: Iteration (requires user feedback from Phase 1)
+    |
+    v
+Phase 3: Growth (requires product-market fit from Phase 2)
+```
 
 ## Revision History
 
 | Date | Change | Author |
 |------|--------|--------|
-| 2025-12-07 | Initial roadmap creation | Claude |
+| [Date] | Initial roadmap creation | [Name] |

--- a/docs/WORKSHOP-GUIDE.md
+++ b/docs/WORKSHOP-GUIDE.md
@@ -1,0 +1,293 @@
+# Workshop Guide (Instructor)
+
+This guide prepares instructors to run a 3-day Agile Flow workshop where
+participants build a product from idea to deployed application using
+AI-assisted development.
+
+## Pre-Workshop Checklist
+
+### Per Participant
+
+- [ ] GitHub account with personal access token (fine-grained, repo + project scope)
+- [ ] Worker bot account (`{org}-worker`) with PAT
+- [ ] Reviewer bot account (`{org}-reviewer`) with PAT
+- [ ] Fork of `agile-flow` repository
+- [ ] GitHub Project board created (Backlog, Ready, In Progress, In Review, Done)
+- [ ] Branch protection rule on `main` (require PR, require status checks)
+- [ ] Claude Code CLI installed and authenticated
+
+### Per Participant (Optional, Enable When Ready)
+
+- [ ] Render account with service created
+- [ ] `RENDER_API_KEY` and `RENDER_SERVICE_ID` added to repo secrets
+- [ ] Sentry project created with DSN
+- [ ] `SENTRY_DSN` added to Render environment variables
+
+### Instructor Setup
+
+- [ ] Demo repository with completed bootstrap (for reference)
+- [ ] Slide deck covering Agile Flow concepts
+- [ ] Printed quick-reference cards (slash commands, workflow diagram)
+- [ ] Backup PATs in case participants lose theirs
+- [ ] Test all workflows on the demo repo before the workshop
+
+## Three-Account Setup
+
+Each participant needs three GitHub accounts to maintain separation of
+duties in the agent workflow.
+
+### Account Purposes
+
+| Account | Role | Creates | Reviews | Merges |
+|---------|------|---------|---------|--------|
+| Personal | Human | - | Final review | Yes |
+| Worker bot | Agent | PRs | - | - |
+| Reviewer bot | Agent | - | Reviews | - |
+
+### PAT Generation
+
+For each bot account, create a fine-grained personal access token:
+
+1. Go to **Settings > Developer settings > Personal access tokens > Fine-grained**
+2. Token name: `agile-flow-workshop`
+3. Repository access: Select the participant's fork
+4. Permissions:
+
+| Permission | Worker Bot | Reviewer Bot |
+|-----------|-----------|-------------|
+| Contents | Read and write | Read only |
+| Issues | Read and write | Read only |
+| Pull requests | Read and write | Read and write |
+| Projects | Read and write | Read only |
+| Metadata | Read only | Read only |
+
+### Configuring Account Switching
+
+Add bot accounts to `gh auth`:
+
+```bash
+# Login as worker bot
+gh auth login --with-token < worker-token.txt
+
+# Login as reviewer bot
+gh auth login --with-token < reviewer-token.txt
+
+# Verify all accounts
+gh auth status
+```
+
+Set environment variables in shell profile:
+
+```bash
+export AGILE_FLOW_WORKER_ACCOUNT="{org}-worker"
+export AGILE_FLOW_REVIEWER_ACCOUNT="{org}-reviewer"
+```
+
+## Sentry Setup
+
+1. Create a Sentry organization (free tier is sufficient)
+2. Create a project: **Python > FastAPI**
+3. Copy the DSN from **Settings > Client Keys**
+4. Add `SENTRY_DSN` to Render environment variables
+5. Test: Visit `/error` endpoint to trigger a deliberate error
+6. Verify: Error appears in Sentry dashboard within 30 seconds
+
+## Render Setup
+
+1. Create a Render account at render.com
+2. Connect GitHub repository
+3. Create a new **Web Service** from the repo
+4. Configure:
+   - Runtime: Python
+   - Build command: `pip install .`
+   - Start command: `uvicorn app.main:app --host 0.0.0.0 --port $PORT`
+5. Add environment variables: `SENTRY_DSN`, `PYTHON_VERSION=3.11`
+6. Enable preview environments in service settings
+7. Copy API key and service ID for GitHub secrets
+
+## Session Plans
+
+### Day 1: Foundation (4 hours)
+
+| Time | Activity | Commands Used |
+|------|----------|---------------|
+| 0:00-0:30 | Introduction and setup verification | `gh auth status` |
+| 0:30-1:00 | Product definition | `/bootstrap-product` |
+| 1:00-1:30 | Technical architecture | `/bootstrap-architecture` |
+| 1:30-2:00 | Agent specialization | `/bootstrap-agents` |
+| 2:00-2:30 | Break | - |
+| 2:30-3:00 | Workflow activation | `/bootstrap-workflow` |
+| 3:00-3:30 | First ticket: deploy and verify | `/work-ticket` |
+| 3:30-4:00 | Trigger deliberate error, verify Sentry | Visit `/error` |
+
+**Day 1 Success Criteria:**
+- App deployed to Render
+- Health check endpoint returns `{"status": "ok"}`
+- Sentry receives the deliberate error
+- First PR created and merged
+
+### Day 2: Development Workflow (4 hours)
+
+| Time | Activity | Commands Used |
+|------|----------|---------------|
+| 0:00-0:30 | Review Day 1, check board health | `/sprint-status` |
+| 0:30-1:00 | Backlog grooming | `/groom-backlog` |
+| 1:00-2:00 | Work on 2-3 tickets | `/work-ticket` |
+| 2:00-2:30 | Break | - |
+| 2:30-3:00 | PR review practice | `/review-pr` |
+| 3:00-3:30 | Handle CI failures and fixes | - |
+| 3:30-4:00 | Session logging | `/log-session` |
+
+**Day 2 Success Criteria:**
+- 2-3 tickets completed through full workflow
+- At least one PR reviewed by agent, merged by human
+- Preview environment tested for at least one PR
+- Session log posted
+
+### Day 3: Iteration and Independence (4 hours)
+
+| Time | Activity | Commands Used |
+|------|----------|---------------|
+| 0:00-0:30 | Review Day 2 session log | - |
+| 0:30-1:00 | Create tickets from user feedback | `/create-ticket` |
+| 1:00-2:00 | Independent development cycle | `/work-ticket` |
+| 2:00-2:30 | Break | - |
+| 2:30-3:00 | Milestone check and scope review | `/check-milestone` |
+| 3:00-3:30 | Release decision practice | `/release-decision` |
+| 3:30-4:00 | Retrospective and next steps | `/log-session` |
+
+**Day 3 Success Criteria:**
+- Participants can run the full workflow independently
+- At least one self-created ticket completed end-to-end
+- Release decision documented
+- Clear next steps for continued development
+
+## Common Failure Modes
+
+### Account Switching Errors
+
+**Symptom:** PR created by wrong account, or permission denied.
+
+**Fix:**
+```bash
+# Check which account is active
+gh auth status
+
+# Switch to correct account
+gh auth switch --user {worker-bot}
+```
+
+**Prevention:** The `ensure-github-account.sh` hook handles this
+automatically. Verify it is configured:
+```bash
+ls .claude/hooks/ensure-github-account.sh
+```
+
+### CI Failures
+
+**Symptom:** PR checks fail after push.
+
+**Diagnostic flowchart:**
+
+```text
+CI Failed
+  |
+  +--> Lint error?
+  |      --> Run: uv run ruff check . --fix
+  |      --> Stage, commit, push
+  |
+  +--> Test failure?
+  |      --> Run: uv run pytest --tb=short
+  |      --> Fix the failing test or code
+  |      --> Stage, commit, push
+  |
+  +--> Agent policy lint?
+  |      --> Run: ./scripts/lint-agent-policies.sh
+  |      --> Fix the flagged agent file
+  |
+  +--> Workflow file error?
+         --> Check YAML syntax
+         --> Verify no non-ASCII characters in workflow files
+```
+
+### Render Deploy Issues
+
+**Symptom:** Deploy fails or preview not available.
+
+**Diagnostic steps:**
+1. Check Render dashboard for build logs
+2. Verify `render.yaml` is valid
+3. Verify `RENDER_API_KEY` and `RENDER_SERVICE_ID` secrets exist
+4. Check if the service is within free tier limits
+5. Try manual deploy from Render dashboard
+
+### Pre-Push Hook Failures
+
+**Symptom:** `git push` rejected by pre-push hook.
+
+**Fix:**
+```bash
+# Read the error output
+# Fix the issue (often auto-fixable):
+uv run ruff check . --fix
+
+# Stage and amend:
+git add -A && git commit --amend --no-edit
+
+# Push again:
+git push origin <branch> --force-with-lease
+```
+
+## If Someone Is Stuck
+
+```text
+Participant is stuck
+  |
+  +--> Can't push code?
+  |      --> Check: git status, git remote -v
+  |      --> Check: gh auth status (correct account?)
+  |      --> Check: branch protection (on feature branch?)
+  |
+  +--> Agent not responding?
+  |      --> Check: Claude Code authenticated?
+  |      --> Check: MCP servers configured?
+  |      --> Try: restart Claude Code
+  |
+  +--> Board not updating?
+  |      --> Check: correct project board URL in commands
+  |      --> Check: PAT has project scope
+  |      --> Try: gh project item-list <project-number>
+  |
+  +--> Deploy not working?
+  |      --> Check: Render secrets configured?
+  |      --> Check: render.yaml valid?
+  |      --> Try: manual deploy from Render dashboard
+  |
+  +--> Everything else?
+         --> Check the error message carefully
+         --> Search GitHub Issues for the error
+         --> Ask the instructor
+```
+
+## Materials Checklist
+
+### To Project/Share on Screen
+
+- [ ] Agile Flow workflow diagram (3-stage: worker, reviewer, human)
+- [ ] Slash command quick reference
+- [ ] GitHub Project board (demo)
+- [ ] Render dashboard (demo)
+- [ ] Sentry dashboard (demo)
+
+### To Hand Out
+
+- [ ] Quick-reference card: slash commands and their purposes
+- [ ] Account setup checklist (3 accounts, PATs, env vars)
+- [ ] Troubleshooting flowchart (printed from this guide)
+
+### To Have Ready
+
+- [ ] Backup PATs for bot accounts
+- [ ] Pre-configured demo repo (completed bootstrap)
+- [ ] Wi-Fi credentials and network requirements
+- [ ] Power strips and adapters


### PR DESCRIPTION
## Summary
- **#35**: Replace domain-specific PRD and Roadmap with pure templates using `[PLACEHOLDER]` prompts and `<!-- EXAMPLE -->` markers. Documents work with `/bootstrap-product` to capture any founder's vision
- **#36**: Generalize backlog prioritizer agent — replace "patterns" domain language with "features" in Memory MCP section. All other agents reviewed; template placeholders are intentional (filled during bootstrap)
- **#37**: Update `/bootstrap-architecture` to ask platform preference (Render default) and write to `.claude/PROJECT.md`. Update `/bootstrap-product` to capture domain and value proposition upfront. Create `docs/PLATFORM-GUIDE.md` documenting all 5 supported platforms
- **#38**: Create `docs/WORKSHOP-GUIDE.md` — pre-workshop checklist (3 accounts, PATs, Sentry, Render), 3-day session plans with timing, common failure modes, troubleshooting flowcharts, materials checklist

## Test plan
- [ ] CI passes (lint, typecheck, build, test, python, lint-agent-policies)
- [ ] Agent policy linter passes after backlog prioritizer changes
- [ ] PRD template has no domain-specific content (all `[PLACEHOLDER]` or `<!-- EXAMPLE -->`)
- [ ] Roadmap template has no domain-specific content
- [ ] PLATFORM-GUIDE.md covers all 5 platforms with setup instructions
- [ ] WORKSHOP-GUIDE.md covers all 3 days with timing and troubleshooting

Closes #35 Closes #36 Closes #37 Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)