### PR TITLE
fix: harden bootstrap.sh, MCP guidance, branch protection

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -72,13 +72,16 @@ Create two bot accounts for your organization:
 
 **Purpose:** Creates code changes, branches, and pull requests
 
-**Recommended Permissions:**
-- Repository access: Write
-- Fine-grained PAT permissions:
-  - Contents: Read and write (for branches)
-  - Issues: Read and write
-  - Pull requests: Read and write
-  - Metadata: Read-only
+**Recommended Permissions (Classic PAT):**
+- `repo` — full repository access (branches, PRs, issues)
+- `project` — project board access (moving tickets between columns)
+
+**Recommended Permissions (Fine-Grained PAT):**
+- Contents: Read and write (for branches)
+- Issues: Read and write
+- Pull requests: Read and write
+- Metadata: Read-only
+- Projects: Read and write
 
 **What the worker bot CAN do:**
 - Create feature branches
@@ -96,13 +99,16 @@ Create two bot accounts for your organization:
 
 **Purpose:** Reviews pull requests and provides GO/NO-GO recommendations
 
-**Recommended Permissions:**
-- Repository access: Write (required for approvals to count)
-- Fine-grained PAT permissions:
-  - Contents: Read-only
-  - Issues: Read and write
-  - Pull requests: Read and write
-  - Metadata: Read-only
+**Recommended Permissions (Classic PAT):**
+- `repo` — full repository access (PR reviews, approvals)
+- `project` — project board access (reading ticket status)
+
+**Recommended Permissions (Fine-Grained PAT):**
+- Contents: Read-only
+- Issues: Read and write
+- Pull requests: Read and write
+- Metadata: Read-only
+- Projects: Read and write (required for approvals to count)
 
 **What the reviewer bot CAN do:**
 - Review pull requests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,19 @@ The `.claude/hooks/ensure-github-account.sh` hook auto-switches accounts:
 Configure in `.claude/settings.local.json`. See `.claude/settings.template.json`
 for the deny rules and allowed tools.
 
+MCP servers are defined in `.mcp.json` (project root). The bootstrap
+wizard creates this file automatically.
+
+| Server | Required | Token | Scopes |
+|--------|----------|-------|--------|
+| `github` | Yes | `GITHUB_PERSONAL_ACCESS_TOKEN` | `repo` + `project` |
+| `memory` | Yes | none | -- |
+| `sequential-thinking` | No | none | -- |
+
+The `GITHUB_PERSONAL_ACCESS_TOKEN` must be a classic PAT with `repo` and
+`project` scopes, or a fine-grained PAT with Contents, Issues, Pull
+requests, Metadata (read), and Projects permissions.
+
 ---
 
 ## Formatting Standards

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,11 @@
 
 set -e
 
+# Ensure this script runs under bash even if invoked as `zsh bootstrap.sh`
+if [ -z "$BASH_VERSION" ]; then
+    exec bash "$0" "$@"
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -228,6 +233,9 @@ phase0_environment() {
 
     if command -v claude &>/dev/null; then
         print_success "Claude Code CLI found at $(command -v claude)"
+    elif [ -x "$HOME/.claude/local/claude" ]; then
+        print_success "Claude Code CLI found at ~/.claude/local/claude"
+        print_info "Tip: Add ~/.claude/local to your PATH for easier access."
     else
         print_error "Claude Code CLI is not installed."
         echo ""
@@ -328,6 +336,19 @@ phase0_environment() {
             }
             persist_env_var "AGILE_FLOW_WORKER_ACCOUNT" "$worker_account"
             print_success "Worker account set: ${worker_account}"
+
+            # Verify project scope on worker account
+            print_info "Verifying PAT scopes for ${worker_account}..."
+            if gh project list --limit 1 &>/dev/null 2>&1; then
+                print_success "Worker PAT has 'project' scope."
+            else
+                print_warning "Worker PAT may be missing the 'project' scope."
+                echo "  Board operations (moving tickets between columns) require"
+                echo "  the 'project' scope on a classic PAT, or the 'Projects'"
+                echo "  permission on a fine-grained PAT."
+                echo "  Re-create the PAT at https://github.com/settings/tokens"
+                echo "  and check both 'repo' and 'project'."
+            fi
         fi
     fi
 
@@ -396,6 +417,18 @@ phase0_environment() {
             }
             persist_env_var "AGILE_FLOW_REVIEWER_ACCOUNT" "$reviewer_account"
             print_success "Reviewer account set: ${reviewer_account}"
+
+            # Verify project scope on reviewer account
+            print_info "Verifying PAT scopes for ${reviewer_account}..."
+            if gh project list --limit 1 &>/dev/null 2>&1; then
+                print_success "Reviewer PAT has 'project' scope."
+            else
+                print_warning "Reviewer PAT may be missing the 'project' scope."
+                echo "  Board operations require the 'project' scope on a classic"
+                echo "  PAT, or the 'Projects' permission on a fine-grained PAT."
+                echo "  Re-create the PAT at https://github.com/settings/tokens"
+                echo "  and check both 'repo' and 'project'."
+            fi
         fi
     fi
 
@@ -562,32 +595,51 @@ phase0_environment() {
     fi
 
     # -----------------------------------------------------------------------
-    #  Create .mcp.json if it does not exist
+    #  Create or validate .mcp.json
     # -----------------------------------------------------------------------
     echo ""
     print_info "Checking MCP server configuration..."
 
+    local mcp_needs_create=false
+
     if [ -f ".mcp.json" ]; then
-        print_success ".mcp.json already exists."
+        # Validate that required servers are present
+        local mcp_valid=true
+        if ! grep -q '"github"' .mcp.json 2>/dev/null; then
+            print_warning ".mcp.json is missing the 'github' server (required)."
+            mcp_valid=false
+        fi
+        if ! grep -q '"memory"' .mcp.json 2>/dev/null; then
+            print_warning ".mcp.json is missing the 'memory' server (required)."
+            mcp_valid=false
+        fi
+
+        if [ "$mcp_valid" = true ]; then
+            print_success ".mcp.json exists with required servers (github, memory)."
+        else
+            echo ""
+            echo "  Your .mcp.json appears to be stale or incomplete."
+            read -p "  Reset to defaults? A backup will be saved to .mcp.json.bak (Y/n): " reset_mcp
+            if [[ ! "$reset_mcp" =~ ^[Nn]$ ]]; then
+                cp .mcp.json .mcp.json.bak
+                print_info "Backed up existing .mcp.json to .mcp.json.bak"
+                mcp_needs_create=true
+            else
+                print_warning "Keeping existing .mcp.json. Add missing servers manually."
+            fi
+        fi
     else
+        mcp_needs_create=true
+    fi
+
+    if [ "$mcp_needs_create" = true ]; then
         if [ -f ".claude/settings.template.json" ]; then
-            print_warning ".mcp.json not found."
+            print_warning ".mcp.json not found or being reset."
             echo ""
             echo "  Agile Flow uses MCP (Model Context Protocol) servers to give"
             echo "  Claude Code access to GitHub, memory, and other integrations."
             echo ""
-            echo "  A template exists at .claude/settings.template.json but MCP"
-            echo "  server configuration (.mcp.json) is specific to your machine."
-            echo ""
-            echo "  You should configure it in Claude Code. When you first run"
-            echo "  'claude' it will prompt you to set up MCP servers."
-            echo ""
-            echo "  For reference, your .mcp.json should include at minimum:"
-            echo "    - github (for issue/PR management)"
-            echo "    - memory (for agent context persistence)"
-            echo "    - sequential-thinking (for structured reasoning)"
-            echo ""
-            print_info "Creating a minimal .mcp.json placeholder..."
+            print_info "Creating .mcp.json with default MCP servers..."
 
             cat > .mcp.json << 'MCPEOF'
 {
@@ -611,11 +663,38 @@ phase0_environment() {
 }
 MCPEOF
             print_success "Created .mcp.json with default MCP servers."
-            print_info "Edit .mcp.json to customize paths or add servers for your setup."
         else
             print_warning ".claude/settings.template.json not found — skipping .mcp.json creation."
             print_info "You can create .mcp.json manually. See Claude Code docs for format."
         fi
+    fi
+
+    # -----------------------------------------------------------------------
+    #  MCP token and server guidance
+    # -----------------------------------------------------------------------
+    echo ""
+    echo "  MCP Server Reference:"
+    echo ""
+    echo "  Server                Required?   Token Needed"
+    echo "  ────────────────────  ─────────   ────────────────────────────────"
+    echo "  github                REQUIRED    GITHUB_PERSONAL_ACCESS_TOKEN"
+    echo "                                    (needs 'repo' + 'project' scopes)"
+    echo "  memory                REQUIRED    none"
+    echo "  sequential-thinking   optional    none"
+    echo ""
+    echo "  To set your token, add this to your shell profile:"
+    echo "    export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxx"
+    echo ""
+    echo "  Create a classic PAT at https://github.com/settings/tokens"
+    echo "  and check the 'repo' and 'project' scope boxes."
+    echo ""
+
+    if [ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
+        print_success "GITHUB_PERSONAL_ACCESS_TOKEN is set."
+    else
+        print_warning "GITHUB_PERSONAL_ACCESS_TOKEN is not set."
+        echo "  The github MCP server will not work without it."
+        echo "  Set it now or add it to your shell profile before running Claude Code."
     fi
 
     # -----------------------------------------------------------------------
@@ -801,6 +880,55 @@ phase4_workflow() {
 
     read -p "Press Enter when Phase 4 is complete..."
 
+    # -------------------------------------------------------------------
+    #  Ensure branch protection exists on main (idempotent)
+    # -------------------------------------------------------------------
+    echo ""
+    print_info "Checking branch protection on main..."
+
+    local remote_url
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [ -n "$remote_url" ]; then
+        local repo_slug
+        repo_slug=$(echo "$remote_url" | sed -E 's#(https://github\.com/|git@github\.com:)##' | sed 's/\.git$//')
+
+        if [ -n "$repo_slug" ]; then
+            # Check for existing rulesets that protect main
+            local existing_rulesets
+            existing_rulesets=$(gh api "repos/${repo_slug}/rulesets" --jq 'length' 2>/dev/null || echo "0")
+
+            if [ "$existing_rulesets" -gt 0 ] 2>/dev/null; then
+                print_success "Repository has ${existing_rulesets} ruleset(s) — branch protection likely configured."
+            else
+                print_info "No rulesets found. Creating branch protection ruleset for main..."
+                if gh api "repos/${repo_slug}/rulesets" \
+                    --method POST \
+                    --field name="Protect main" \
+                    --field target="branch" \
+                    --field enforcement="active" \
+                    --field 'conditions[ref_name][include][]=refs/heads/main' \
+                    --field 'conditions[ref_name][exclude][]=' \
+                    --field 'rules[][type]=pull_request' \
+                    --field 'rules[][type]=required_status_checks' \
+                    &>/dev/null 2>&1; then
+                    print_success "Branch protection ruleset created for main."
+                else
+                    print_warning "Could not create ruleset automatically."
+                    echo "  You may not have admin permissions, or the repo may be on"
+                    echo "  a plan that does not support rulesets via API."
+                    echo ""
+                    echo "  Manual fallback — go to your repo on GitHub:"
+                    echo "    Settings > Rules > Rulesets > New ruleset"
+                    echo "    - Name: Protect main"
+                    echo "    - Target: main branch"
+                    echo "    - Rules: Require pull request, Require status checks"
+                fi
+            fi
+        fi
+    else
+        print_warning "No git remote — skipping branch protection check."
+    fi
+
     mark_phase_complete "phase4"
     print_success "Phase 4 complete! Workflow activated."
 }
@@ -905,7 +1033,7 @@ main() {
             run_phase 0
             ;;
         q|Q)
-            print_info "Exiting. Run ./bootstrap.sh to continue later."
+            print_info "Exiting. Run 'bash bootstrap.sh' to continue later."
             exit 0
             ;;
         *)
@@ -925,7 +1053,7 @@ main() {
         echo ""
         read -p "Continue to Phase $current? (Y/n): " cont
         if [[ $cont =~ ^[Nn]$ ]]; then
-            print_info "Pausing. Run ./bootstrap.sh to continue later."
+            print_info "Pausing. Run 'bash bootstrap.sh' to continue later."
             exit 0
         fi
 

--- a/docs/FIRST-DAY.md
+++ b/docs/FIRST-DAY.md
@@ -1,7 +1,7 @@
 # Day 1 Walkthrough: Fork to Production Bug Ticket
 
 This is a step-by-step guide for workshop participants. It assumes you have
-already completed the bootstrap wizard (`./bootstrap.sh`, Phases 0-3) and
+already completed the bootstrap wizard (`bash bootstrap.sh`, Phases 0-3) and
 that your instructor has walked through the three-account setup. If you are
 an instructor, see [WORKSHOP-GUIDE.md](./WORKSHOP-GUIDE.md) for session
 plans and troubleshooting flowcharts.
@@ -19,9 +19,11 @@ By the end of Day 1, you will have:
 
 Before you start, confirm:
 
-- Phase 0-3 of `./bootstrap.sh` completed (product, architecture, agents)
+- Phase 0-3 of `bash bootstrap.sh` completed (product, architecture, agents)
 - Three GitHub accounts ready (personal, `{org}-worker`, `{org}-reviewer`)
 - Claude Code CLI installed and authenticated
+- MCP servers working — run `claude` and verify `github` and `memory` servers connect
+- `GITHUB_PERSONAL_ACCESS_TOKEN` exported with `repo` + `project` scopes
 - Render account created, service connected to your fork
 - Sentry project created with DSN added to Render environment variables
 
@@ -90,6 +92,12 @@ If any account is missing, log it in now:
 gh auth login --with-token < worker-token.txt
 gh auth login --with-token < reviewer-token.txt
 ```
+
+> **PAT scopes**: Each bot account's PAT needs **`repo`** + **`project`**
+> scopes (classic PAT) so the agent can manage issues, PRs, and move
+> tickets on the project board. If you used fine-grained PATs, enable
+> `Contents`, `Issues`, `Pull requests`, `Metadata` (read), and
+> `Projects` permissions.
 
 Verify the environment variables are set:
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -90,6 +90,52 @@ You should see your token printed back.
 
 ---
 
+## Step 2b: Configure Claude Code MCP Servers
+
+Claude Code uses MCP (Model Context Protocol) servers to interact with
+GitHub, persist agent memory, and perform structured reasoning. The
+bootstrap wizard creates a `.mcp.json` file for you, but the GitHub
+server requires a personal access token.
+
+### Create your `GITHUB_PERSONAL_ACCESS_TOKEN`
+
+1. Go to <https://github.com/settings/tokens>.
+2. Click **"Generate new token (classic)"**.
+3. Check the **`repo`** and **`project`** scope boxes.
+   - `repo` — lets agents read/write code, issues, and pull requests.
+   - `project` — lets agents move tickets on the project board.
+4. Click **Generate token** and copy it.
+5. Add it to your shell profile:
+
+```bash
+echo 'export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxx' >> ~/.zshrc
+source ~/.zshrc
+```
+
+### MCP Servers
+
+| Server | Required? | What It Does | Token |
+|--------|-----------|--------------|-------|
+| `github` | Yes | Issue/PR management, project board | `GITHUB_PERSONAL_ACCESS_TOKEN` |
+| `memory` | Yes | Agent context persistence across sessions | none |
+| `sequential-thinking` | No | Structured reasoning for complex tasks | none |
+
+### Verify MCP is working
+
+After running `claude` for the first time, you should see MCP servers
+listed in the startup output. If the github server fails to connect,
+check that your token is exported in the current terminal session:
+
+```bash
+echo $GITHUB_PERSONAL_ACCESS_TOKEN
+```
+
+> **Bot accounts**: If you are using separate worker and reviewer bot
+> accounts, each bot's PAT also needs `repo` + `project` scopes. See
+> `.claude/README.md` for full bot account setup.
+
+---
+
 ## Step 3: Run the Bootstrap Wizard
 
 The bootstrap wizard walks you through setting up your project in four
@@ -97,7 +143,7 @@ phases. It asks you questions and generates configuration files based on
 your answers.
 
 ```bash
-./bootstrap.sh
+bash bootstrap.sh
 ```
 
 **You should see:** A welcome screen with four phases listed.
@@ -168,21 +214,30 @@ Ready, In Progress, In Review, and Done.
 
 ## Step 4: Protect Your Main Branch
 
-This step makes sure nobody (including the AI) can push changes directly
-to your main codebase without review. You do this once in GitHub settings.
+The bootstrap wizard (`bash bootstrap.sh`, Phase 4) automatically
+creates a GitHub **Ruleset** that protects your `main` branch. It
+requires pull requests and passing status checks before code can be
+merged.
+
+If the automated step fails (e.g., insufficient permissions), you can
+create the ruleset manually:
 
 1. Go to your repository on GitHub.
 2. Click **Settings** (top menu bar).
-3. Click **Branches** (left sidebar).
-4. Click **Add rule**.
-5. Type `main` in the branch name pattern.
-6. Check these boxes:
+3. Click **Rules > Rulesets** (left sidebar).
+4. Click **New ruleset > New branch ruleset**.
+5. Name it `Protect main`.
+6. Under **Target branches**, add `main`.
+7. Enable these rules:
    - "Require a pull request before merging"
    - "Require status checks to pass before merging" (if you have CI)
-   - "Do not allow bypassing the above settings"
-7. Click **Create**.
+   - "Block force pushes"
+8. Click **Create**.
 
-**You should see:** A protection rule listed for the `main` branch.
+**You should see:** A ruleset listed under Settings > Rules > Rulesets.
+
+> **Note:** The legacy Settings > Branches page still works but GitHub
+> recommends Rulesets for new repositories.
 
 ---
 


### PR DESCRIPTION
## Summary

- **#60**: Add fallback Claude CLI detection at `~/.claude/local/claude`
- **#61**: Print MCP server reference table after `.mcp.json` creation; add token guidance to CLAUDE.md, GETTING-STARTED.md, FIRST-DAY.md
- **#63**: Verify `project` scope on worker/reviewer PATs after login; update `.claude/README.md` with explicit `repo` + `project` scope requirements
- **#64**: Add zsh guard that auto-relaunches under bash; change `./bootstrap.sh` → `bash bootstrap.sh` in docs
- **#67**: Validate existing `.mcp.json` has required servers (`github`, `memory`); offer reset with backup to `.mcp.json.bak`
- **Branch protection**: Automate ruleset creation via `gh api` in Phase 4; update GETTING-STARTED.md with modern Rulesets UI as manual fallback

## Test plan

- [ ] Run `bash bootstrap.sh` from a fresh template copy
- [ ] Verify Claude CLI detected via `~/.claude/local/claude` fallback
- [ ] Verify MCP token guidance prints after `.mcp.json` creation
- [ ] Verify worker account scope check warns when `project` scope missing
- [ ] Verify stale `.mcp.json` detection and reset works
- [ ] Verify branch protection ruleset created via `gh api`
- [ ] Verify script works when invoked as `zsh bootstrap.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)