### PR TITLE
fix: rewrite pre-push hook for stack coexistence, add agent guidance

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -283,6 +283,65 @@ so institutional knowledge persists across sessions.
 | PatternDiscovered | Pattern-{short-name} | When a reusable pattern emerges |
 | LessonLearned | Lesson-{short-name} | When a gotcha or workaround is found |
 
+## Framework-Specific Testing Patterns
+
+### React / Next.js with Vitest
+
+When working on a React or Next.js project that uses Vitest and React
+Testing Library, every test file that renders components MUST call
+`cleanup()` after each test. This is typically handled via a setup file:
+
+```typescript
+// vitest.setup.ts
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+```
+
+If a `vitest.setup.ts` file exists and includes this cleanup, you do NOT
+need to add `cleanup()` in individual test files. If no setup file exists,
+add cleanup directly:
+
+```typescript
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+
+afterEach(() => { cleanup(); });
+```
+
+## Non-Interactive Scaffolding
+
+When scaffolding new projects or adding dependencies via CLI tools, always
+use non-interactive flags. Interactive prompts will hang the agent.
+
+| Tool | Non-Interactive Flag |
+|------|---------------------|
+| `create-next-app` | `--yes` or explicit flags (`--ts --eslint --app`) |
+| `npm init` | `-y` |
+| `create-vite` | Pass template via `--template react-ts` |
+| `npx create-react-app` | Non-interactive by default |
+| `go mod init` | Non-interactive by default |
+| `uv init` | Non-interactive by default |
+
+## ESLint Ignore Patterns
+
+When working in a repository that may have artifacts from a previous stack
+(e.g., Python `.venv/` directory), ensure the ESLint config ignores them:
+
+```javascript
+// eslint.config.mjs
+export default [
+  { ignores: ['.venv/', 'node_modules/', '.next/', 'dist/'] },
+  // ... rest of config
+];
+```
+
+Always include `.venv/` in ESLint ignores for any Node.js project created
+from this template, since the template starts with a Python scaffolding.
+
 ## Communication Style
 
 - Provide clear progress updates in ticket comments

--- a/.claude/commands/bootstrap-architecture.md
+++ b/.claude/commands/bootstrap-architecture.md
@@ -47,6 +47,36 @@ Write the platform choice to `.claude/PROJECT.md`:
 This file is read by the `devops-engineer` and `system-architect` agents
 to provide platform-specific guidance.
 
+### Stack Transition
+
+When the user selects a non-Python stack (e.g., Node.js/Next.js, Go), you
+MUST clean up the default Python scaffolding before proceeding:
+
+1. **Remove Python files**: Delete `pyproject.toml`, `uv.lock`, `app/`
+   (if it contains Python code), and `tests/` (if Python tests).
+2. **Update `render.yaml`**: Replace the Python build/start commands with
+   the appropriate runtime. Reference templates:
+   - **Node.js**: `buildCommand: npm install && npm run build`,
+     `startCommand: npm start`
+   - **Go**: `buildCommand: go build -o server .`,
+     `startCommand: ./server`
+3. **Scaffold a minimal starter app**: Include at minimum:
+   - A `/health` endpoint returning `{"status": "ok"}`
+   - A `/error` endpoint that raises a deliberate error (for Sentry testing)
+   - One passing test
+4. **Update `CLAUDE.md`**: Replace the build/test commands section with
+   commands for the new stack.
+
+**Non-Interactive Scaffolding**: When running scaffolding tools, always use
+non-interactive flags to avoid blocking the agent:
+
+| Tool | Flag |
+|------|------|
+| `create-next-app` | `--yes` (or `--ts --tailwind --eslint --app --src-dir --no-import-alias`) |
+| `npm init` | `--yes` or `-y` |
+| `create-vite` | Pass all options via CLI flags |
+| `go mod init` | Non-interactive by default |
+
 ### 1. PRD Analysis
 The architect first analyzes your Product Requirements:
 - What features need to be built?
@@ -221,4 +251,49 @@ The architect will recommend patterns based on your needs:
 4. Review the proposed architecture
 5. Iterate until satisfied
 
-When complete, run `./bootstrap.sh` to continue to Phase 3.
+When complete, run `bash bootstrap.sh` to continue to Phase 3.
+
+## React/Next.js Testing Guidance
+
+When the chosen stack includes React (e.g., Next.js with Vitest and React
+Testing Library), the Vitest setup file MUST include cleanup after each
+test to prevent DOM leaks:
+
+```typescript
+// vitest.setup.ts
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+```
+
+Register this file in `vitest.config.ts`:
+
+```typescript
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});
+```
+
+## ESLint Configuration for Template Projects
+
+When scaffolding a Node.js project in a repo that previously had Python
+files, the `.venv/` directory may still exist. ESLint must be configured
+to ignore it:
+
+```javascript
+// eslint.config.mjs
+export default [
+  {
+    ignores: ['.venv/', 'node_modules/', '.next/', 'dist/'],
+  },
+  // ... other config
+];
+```
+
+This prevents ESLint from attempting to parse Python virtualenv files.

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -6,10 +6,16 @@
 # Installation:
 #   git config core.hooksPath scripts/hooks
 #
-# Language auto-detection:
-#   Python  — detected via pyproject.toml → runs ruff + pytest
-#   Node.js — detected via package.json  → runs eslint + jest/vitest
-#   Go      — detected via go.mod        → runs go vet + go test
+# Language auto-detection (priority order):
+#   1. Node.js — package.json exists AND contains vitest/jest/test script
+#   2. Python  — pyproject.toml exists AND uv is available
+#   3. Go      — go.mod exists
+#   4. Node.js — package.json exists (fallback, no test deps detected)
+#   5. Python  — pyproject.toml exists (fallback, uv not available)
+#
+# This ordering handles the common case where a project switches stacks
+# (e.g., Python template → Next.js) and both pyproject.toml and
+# package.json coexist during the transition.
 #
 # Falls through gracefully if no recognized project file is found.
 #
@@ -39,54 +45,89 @@ run_check() {
   echo ""
 }
 
-# --- Python ---
-if [ -f "pyproject.toml" ]; then
-  echo "Detected Python project"
-  echo ""
-  run_check "ruff check" uv run ruff check .
-  run_check "pytest" uv run pytest --tb=short -q
+# ---------------------------------------------------------------------------
+#  Detect stack — priority order handles coexistence of config files
+# ---------------------------------------------------------------------------
+STACK=""
 
-# --- Node.js ---
-elif [ -f "package.json" ]; then
-  echo "Detected Node.js project"
-  echo ""
-
-  # Determine package runner
-  if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-    runner="bun"
-  elif [ -f "pnpm-lock.yaml" ]; then
-    runner="pnpm"
-  elif [ -f "yarn.lock" ]; then
-    runner="yarn"
-  else
-    runner="npx"
+if [ -f "package.json" ]; then
+  # Check if package.json has test-related dependencies or a test script
+  if grep -qE '"vitest"|"jest"|"mocha"|"ava"' package.json 2>/dev/null || \
+     grep -qE '"test"\s*:' package.json 2>/dev/null; then
+    STACK="node"
   fi
-
-  # Lint
-  if command -v "$runner" &>/dev/null; then
-    if [ -f ".eslintrc" ] || [ -f ".eslintrc.js" ] || [ -f ".eslintrc.json" ] || [ -f "eslint.config.js" ] || [ -f "eslint.config.mjs" ]; then
-      run_check "eslint" $runner eslint .
-    fi
-  fi
-
-  # Test
-  if grep -q '"vitest"' package.json 2>/dev/null; then
-    run_check "vitest" $runner vitest run
-  elif grep -q '"jest"' package.json 2>/dev/null; then
-    run_check "jest" $runner jest
-  fi
-
-# --- Go ---
-elif [ -f "go.mod" ]; then
-  echo "Detected Go project"
-  echo ""
-  run_check "go vet" go vet ./...
-  run_check "go test" go test ./...
-
-else
-  echo "No recognized project file found — skipping pre-push checks."
-  exit 0
 fi
+
+if [ -z "$STACK" ] && [ -f "pyproject.toml" ] && command -v uv &>/dev/null; then
+  STACK="python"
+fi
+
+if [ -z "$STACK" ] && [ -f "go.mod" ]; then
+  STACK="go"
+fi
+
+# Fallbacks: config file exists but no strong signal above
+if [ -z "$STACK" ] && [ -f "package.json" ]; then
+  STACK="node"
+fi
+
+if [ -z "$STACK" ] && [ -f "pyproject.toml" ]; then
+  STACK="python"
+fi
+
+# ---------------------------------------------------------------------------
+#  Run checks for the detected stack
+# ---------------------------------------------------------------------------
+case "$STACK" in
+  node)
+    echo "Detected Node.js project"
+    echo ""
+
+    # Determine package runner
+    if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+      runner="bun"
+    elif [ -f "pnpm-lock.yaml" ]; then
+      runner="pnpm"
+    elif [ -f "yarn.lock" ]; then
+      runner="yarn"
+    else
+      runner="npx"
+    fi
+
+    # Lint
+    if command -v "$runner" &>/dev/null; then
+      if [ -f ".eslintrc" ] || [ -f ".eslintrc.js" ] || [ -f ".eslintrc.json" ] || [ -f "eslint.config.js" ] || [ -f "eslint.config.mjs" ]; then
+        run_check "eslint" $runner eslint .
+      fi
+    fi
+
+    # Test
+    if grep -q '"vitest"' package.json 2>/dev/null; then
+      run_check "vitest" $runner vitest run
+    elif grep -q '"jest"' package.json 2>/dev/null; then
+      run_check "jest" $runner jest
+    fi
+    ;;
+
+  python)
+    echo "Detected Python project"
+    echo ""
+    run_check "ruff check" uv run ruff check .
+    run_check "pytest" uv run pytest --tb=short -q
+    ;;
+
+  go)
+    echo "Detected Go project"
+    echo ""
+    run_check "go vet" go vet ./...
+    run_check "go test" go test ./...
+    ;;
+
+  *)
+    echo "No recognized project file found — skipping pre-push checks."
+    exit 0
+    ;;
+esac
 
 if [ $FAILED -eq 1 ]; then
   echo ""


### PR DESCRIPTION
## Summary

- **#59**: Rewrite pre-push hook with priority-based stack detection that handles coexistence of `pyproject.toml` and `package.json`. Add stack transition section to `bootstrap-architecture.md`.
- **#65**: Add React/Next.js testing guidance (Vitest RTL cleanup) to both `bootstrap-architecture.md` and `github-ticket-worker.md`.
- **#66**: Add non-interactive scaffolding flags table to prevent agent hangs during `create-next-app` and similar tools.
- **#68**: Add ESLint `.venv/` ignore guidance for projects transitioning from Python to Node.js.

## Test plan

- [ ] In a repo with both `pyproject.toml` and `package.json` (with vitest), verify Node.js checks run (not Python)
- [ ] In a Python-only repo, verify Python checks still run
- [ ] In a Go-only repo, verify Go checks still run
- [ ] Run `/bootstrap-architecture`, choose Next.js, verify Python files cleanup instructions are present
- [ ] Verify non-interactive scaffolding flags documented
- [ ] Verify RTL cleanup guidance in both architecture and worker agent docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)