### PR TITLE
fix: graceful pre-push hook when stack tooling is missing

### DIFF
--- a/.claude/commands/bootstrap-architecture.md
+++ b/.claude/commands/bootstrap-architecture.md
@@ -47,6 +47,23 @@ Write the platform choice to `.claude/PROJECT.md`:
 This file is read by the `devops-engineer` and `system-architect` agents
 to provide platform-specific guidance.
 
+### 0b. Stack Cleanup
+
+The template ships with a Python starter app (`app/`, `pyproject.toml`,
+`uv.lock`, `tests/test_app.py`). **If the user chooses a non-Python
+stack**, remove the Python files before scaffolding the new stack:
+
+```bash
+# Remove Python template files when switching to a different stack
+rm -rf app/ tests/test_app.py tests/__init__.py pyproject.toml uv.lock
+```
+
+This prevents the pre-push hook from detecting `pyproject.toml` and
+trying to run Python checks on a non-Python project.
+
+After removing the Python files, scaffold the chosen stack's project
+structure (e.g., `npx create-next-app`, `npm init`, etc.).
+
 ### 1. PRD Analysis
 The architect first analyzes your Product Requirements:
 - What features need to be built?
@@ -135,6 +152,7 @@ This phase creates:
 - [Linting rules]
 - [Formatting rules]
 - [Naming conventions]
+- ESLint configs should include `.venv/**` in `globalIgnores` (if Python venvs may coexist)
 
 ### Testing Requirements
 - Unit test coverage: [e.g., 80%]

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -41,10 +41,18 @@ run_check() {
 
 # --- Python ---
 if [ -f "pyproject.toml" ]; then
-  echo "Detected Python project"
-  echo ""
-  run_check "ruff check" uv run ruff check .
-  run_check "pytest" uv run pytest --tb=short -q
+  # Only run Python checks if uv (or pip) is available
+  if command -v uv &>/dev/null; then
+    echo "Detected Python project"
+    echo ""
+    run_check "ruff check" uv run ruff check .
+    run_check "pytest" uv run pytest --tb=short -q
+  else
+    echo -e "${YELLOW}Detected pyproject.toml but uv is not installed — skipping Python checks.${NC}"
+    echo "  If this is a Python project, install uv: https://docs.astral.sh/uv/"
+    echo "  If you switched stacks, remove pyproject.toml and the app/ directory."
+    echo ""
+  fi
 
 # --- Node.js ---
 elif [ -f "package.json" ]; then
@@ -62,26 +70,35 @@ elif [ -f "package.json" ]; then
     runner="npx"
   fi
 
-  # Lint
+  # Lint (only if runner is available)
   if command -v "$runner" &>/dev/null; then
     if [ -f ".eslintrc" ] || [ -f ".eslintrc.js" ] || [ -f ".eslintrc.json" ] || [ -f "eslint.config.js" ] || [ -f "eslint.config.mjs" ]; then
       run_check "eslint" $runner eslint .
     fi
+  else
+    echo -e "${YELLOW}Package runner '$runner' not found — skipping lint.${NC}"
   fi
 
   # Test
-  if grep -q '"vitest"' package.json 2>/dev/null; then
-    run_check "vitest" $runner vitest run
-  elif grep -q '"jest"' package.json 2>/dev/null; then
-    run_check "jest" $runner jest
+  if command -v "$runner" &>/dev/null; then
+    if grep -q '"vitest"' package.json 2>/dev/null; then
+      run_check "vitest" $runner vitest run
+    elif grep -q '"jest"' package.json 2>/dev/null; then
+      run_check "jest" $runner jest
+    fi
   fi
 
 # --- Go ---
 elif [ -f "go.mod" ]; then
-  echo "Detected Go project"
-  echo ""
-  run_check "go vet" go vet ./...
-  run_check "go test" go test ./...
+  if command -v go &>/dev/null; then
+    echo "Detected Go project"
+    echo ""
+    run_check "go vet" go vet ./...
+    run_check "go test" go test ./...
+  else
+    echo -e "${YELLOW}Detected go.mod but go is not installed — skipping Go checks.${NC}"
+    echo ""
+  fi
 
 else
   echo "No recognized project file found — skipping pre-push checks."


### PR DESCRIPTION
## Summary

- Pre-push hook now gracefully skips when detected language tooling is not installed (e.g., `pyproject.toml` exists but `uv` is not available)
- Adds "Stack Cleanup" step to `bootstrap-architecture.md` so the system-architect agent removes Python template files when a non-Python stack is chosen
- Notes ESLint configs should include `.venv/**` in `globalIgnores`

Closes #59
Closes #68

## Test plan

- [ ] Run `scripts/hooks/pre-push` in a directory with `pyproject.toml` but no `uv` installed — should warn and skip, not fail
- [ ] Run `scripts/hooks/pre-push` in a directory with `package.json` but no `npm` installed — should warn and skip
- [ ] Run `scripts/hooks/pre-push` in a normal Python project with `uv` — should run ruff + pytest as before
- [ ] Verify `bootstrap-architecture.md` includes stack cleanup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)