### PR TITLE
fix: harden bootstrap.sh and document MCP/PAT requirements

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,9 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Agile Flow Bootstrap Wizard
 # Guides users through progressive refinement of project context
+#
+# Usage: bash bootstrap.sh
+#
+# Requires bash 3.2+ (ships with macOS) or zsh 5.0+.
+# The #!/usr/bin/env bash shebang ensures the user's bash is found on $PATH,
+# which may be a newer version installed via Homebrew (/opt/homebrew/bin/bash).
 
 set -e
+
+# Warn if running under a shell that may not support all features
+if [ -z "$BASH_VERSION" ] && [ -z "$ZSH_VERSION" ]; then
+    echo "Warning: This script is designed for bash or zsh."
+    echo "Run it with: bash bootstrap.sh"
+fi
 
 # Colors for output
 RED='\033[0;31m'
@@ -226,8 +238,13 @@ phase0_environment() {
     # -----------------------------------------------------------------------
     print_step 2 $total_steps "Verify Claude Code CLI (claude) is installed"
 
+    # Claude Code may be on $PATH or installed as a shell alias at ~/.claude/local/claude
     if command -v claude &>/dev/null; then
         print_success "Claude Code CLI found at $(command -v claude)"
+    elif [ -x "$HOME/.claude/local/claude" ]; then
+        print_success "Claude Code CLI found at ~/.claude/local/claude"
+        print_info "Note: Claude Code is installed as a local binary. If 'claude' is"
+        print_info "not available in scripts, add ~/.claude/local to your PATH."
     else
         print_error "Claude Code CLI is not installed."
         echo ""
@@ -568,8 +585,41 @@ phase0_environment() {
     print_info "Checking MCP server configuration..."
 
     if [ -f ".mcp.json" ]; then
-        print_success ".mcp.json already exists."
-    else
+        # Check for stale or unexpected MCP servers
+        local has_stale=false
+        if command -v jq &>/dev/null; then
+            local server_names
+            server_names=$(jq -r '.mcpServers | keys[]' .mcp.json 2>/dev/null || true)
+            local required_servers="github memory sequential-thinking"
+            for server in $server_names; do
+                case "$server" in
+                    github|memory|sequential-thinking) ;;
+                    *)
+                        has_stale=true
+                        print_warning "Unexpected MCP server found: ${server}"
+                        ;;
+                esac
+            done
+        fi
+
+        if [ "$has_stale" = true ]; then
+            echo ""
+            echo "  Your .mcp.json contains MCP servers not required by Agile Flow."
+            echo "  These may be left over from a previous project or session."
+            echo ""
+            read -p "  Reset .mcp.json to required servers only? (y/N): " reset_mcp
+            if [[ "$reset_mcp" =~ ^[Yy]$ ]]; then
+                # Fall through to the creation block below
+                rm -f .mcp.json
+            else
+                print_info "Keeping existing .mcp.json."
+            fi
+        else
+            print_success ".mcp.json already exists with required servers."
+        fi
+    fi
+
+    if [ ! -f ".mcp.json" ]; then
         if [ -f ".claude/settings.template.json" ]; then
             print_warning ".mcp.json not found."
             echo ""
@@ -587,30 +637,34 @@ phase0_environment() {
             echo "    - memory (for agent context persistence)"
             echo "    - sequential-thinking (for structured reasoning)"
             echo ""
-            print_info "Creating a minimal .mcp.json placeholder..."
+            print_info "Creating .mcp.json with required MCP servers..."
 
-            cat > .mcp.json << 'MCPEOF'
+            # Use the full path to npx to avoid shell alias/PATH issues
+            local npx_path
+            npx_path=$(command -v npx 2>/dev/null || echo "npx")
+
+            cat > .mcp.json << MCPEOF
 {
   "mcpServers": {
     "github": {
-      "command": "npx",
+      "command": "${npx_path}",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     },
     "memory": {
-      "command": "npx",
+      "command": "${npx_path}",
       "args": ["-y", "@modelcontextprotocol/server-memory"]
     },
     "sequential-thinking": {
-      "command": "npx",
+      "command": "${npx_path}",
       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
     }
   }
 }
 MCPEOF
-            print_success "Created .mcp.json with default MCP servers."
+            print_success "Created .mcp.json with default MCP servers (npx: ${npx_path})."
             print_info "Edit .mcp.json to customize paths or add servers for your setup."
         else
             print_warning ".claude/settings.template.json not found — skipping .mcp.json creation."

--- a/docs/FIRST-DAY.md
+++ b/docs/FIRST-DAY.md
@@ -21,9 +21,16 @@ Before you start, confirm:
 
 - Phase 0-3 of `./bootstrap.sh` completed (product, architecture, agents)
 - Three GitHub accounts ready (personal, `{org}-worker`, `{org}-reviewer`)
+- All three PATs have both `repo` AND `project` scope (the worker bot
+  needs `project` scope to move tickets between columns on the board)
+- `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable set (for MCP servers)
 - Claude Code CLI installed and authenticated
+- Supabase account created with GitHub integration enabled
 - Render account created, service connected to your fork
 - Sentry project created with DSN added to Render environment variables
+
+> **Missing something?** See [PRE-WORK-CHECKLIST.md](PRE-WORK-CHECKLIST.md)
+> for detailed setup instructions.
 
 ---
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -28,8 +28,21 @@ talk to GitHub on your behalf. To create one:
 
 1. Go to <https://github.com/settings/tokens>.
 2. Click **"Generate new token (classic)"**.
-3. Check the `repo` and `project` boxes.
+3. Check the `repo` and `project` boxes. **Both are required** -- `repo`
+   for code access and `project` for moving tickets on the project board.
 4. Click **Generate token** and copy it somewhere safe.
+
+Set the token as an environment variable so MCP servers can use it:
+
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN=paste_your_token_here
+```
+
+Add this to your shell profile (`~/.zshrc` or `~/.bashrc`) to persist it.
+
+> **Workshop participants**: See
+> [PRE-WORK-CHECKLIST.md](PRE-WORK-CHECKLIST.md) for the full setup
+> guide including bot accounts, Supabase, and Render.
 
 ---
 
@@ -87,6 +100,30 @@ echo $GITHUB_TOKEN
 ```
 
 You should see your token printed back.
+
+### MCP Servers
+
+Claude Code uses MCP (Model Context Protocol) servers to interact with
+GitHub, maintain memory, and perform structured reasoning. The bootstrap
+wizard creates `.mcp.json` automatically, but the GitHub MCP server
+requires `GITHUB_PERSONAL_ACCESS_TOKEN` to be set in your environment.
+
+Make sure this is in your shell profile:
+
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN=paste_your_token_here
+```
+
+This is the same token you created above for `GITHUB_TOKEN`. The MCP
+server reads `GITHUB_PERSONAL_ACCESS_TOKEN` from the environment.
+
+**Required MCP servers** (created by `./bootstrap.sh`):
+
+| Server | Package | Purpose |
+|--------|---------|---------|
+| github | `@modelcontextprotocol/server-github` | Issue/PR management |
+| memory | `@modelcontextprotocol/server-memory` | Agent context persistence |
+| sequential-thinking | `@modelcontextprotocol/server-sequential-thinking` | Structured reasoning |
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix Claude Code CLI detection for alias-based installs (`~/.claude/local/claude` fallback)
- Use `#!/usr/bin/env bash` shebang for better macOS/Homebrew bash compatibility
- Detect stale MCP servers in `.mcp.json` and offer to reset to required servers only
- Use full `npx` path in generated `.mcp.json` to avoid shell PATH issues
- Document `GITHUB_PERSONAL_ACCESS_TOKEN` env var requirement for MCP servers
- Clarify that PATs need both `repo` AND `project` scope (worker bot needs project scope for board operations)
- Add reference to PRE-WORK-CHECKLIST.md from FIRST-DAY.md

Closes #60
Closes #61
Closes #63
Closes #64
Closes #67

## Test plan

- [ ] Run `bootstrap.sh` with Claude Code installed via alias — should detect at `~/.claude/local/claude`
- [ ] Run `bootstrap.sh` with a stale `.mcp.json` containing a `filesystem` server — should warn and offer reset
- [ ] Run `bootstrap.sh` fresh (no `.mcp.json`) — should create with full `npx` path
- [ ] Verify GETTING-STARTED.md mentions `GITHUB_PERSONAL_ACCESS_TOKEN` and MCP servers
- [ ] Verify FIRST-DAY.md prerequisites mention `project` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)