### PR TITLE
Add ephemeral PR environments documentation

### DIFF
--- a/docs/EPHEMERAL-PR-ENVIRONMENTS.md
+++ b/docs/EPHEMERAL-PR-ENVIRONMENTS.md
@@ -1,0 +1,229 @@
+# Ephemeral PR Environments
+
+Every pull request gets its own isolated preview — a standalone Render
+web service connected to a dedicated Supabase branch database. When the
+PR closes, both are torn down automatically.
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Pull Request Opened                         │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+              ┌────────────────┴────────────────┐
+              │                                 │
+              ▼                                 ▼
+┌──────────────────────────┐      ┌──────────────────────────────┐
+│   Supabase GitHub        │      │   Render Native Previews     │
+│   Integration            │      │   (previewsEnabled: true)    │
+│                          │      │                              │
+│   Creates branch DB      │      │   Creates preview service    │
+│   automatically via      │      │   automatically from         │
+│   webhook                │      │   render.yaml blueprint      │
+└────────────┬─────────────┘      └──────────────┬───────────────┘
+             │                                    │
+             └────────────────┬───────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                  preview-deploy.yml (GitHub Actions)                │
+│                                                                     │
+│  1. CI checks pass                                                  │
+│  2. Wait for Supabase branch DB (up to 10 min)                     │
+│  3. Fetch branch credentials (URL, anon_key, service_role_key)     │
+│  4. Apply migrations (supabase db push)                            │
+│  5. Configure auth redirect URLs for preview                       │
+│  6. Find Render preview service via API                            │
+│  7. Inject Supabase credentials into Render env vars               │
+│  8. Trigger Render redeploy                                        │
+│  9. Health check (/api/health)                                     │
+│ 10. Post status comment on PR                                      │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                      PREVIEW LIVE                                   │
+│                                                                     │
+│   https://app-pr-{number}.onrender.com                             │
+│          │                                                          │
+│          └──── connected to ────► Supabase branch database         │
+│                                   (isolated Postgres instance)     │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                        PR merged/closed
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                preview-cleanup.yml (GitHub Actions)                  │
+│                                                                     │
+│   • Deletes Supabase branch DB                                     │
+│   • Render tears down preview service automatically                │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## What Creates What
+
+| Resource | Created By | Destroyed By |
+|----------|-----------|--------------|
+| Render preview service | Render (native, via `previewsEnabled: true` in `render.yaml`) | Render (automatic on PR close) |
+| Supabase branch database | Supabase GitHub integration (webhook) | `preview-cleanup.yml` via `supabase branches delete` |
+| Env var wiring between them | `preview-deploy.yml` (GitHub Actions) | N/A (destroyed with service) |
+
+---
+
+## Required Secrets
+
+Configure these in **Repository Settings > Secrets and variables > Actions**:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     GitHub Repository Secrets                       │
+├─────────────────────────────┬───────────────────────────────────────┤
+│  RENDER_API_KEY             │  Render Dashboard > Account Settings  │
+│                             │  > API Keys                          │
+├─────────────────────────────┼───────────────────────────────────────┤
+│  RENDER_SERVICE_ID          │  Render Dashboard > Service >        │
+│                             │  Settings (srv-xxxxx in URL)         │
+├─────────────────────────────┼───────────────────────────────────────┤
+│  SUPABASE_ACCESS_TOKEN      │  Supabase Dashboard > Account >     │
+│                             │  Access Tokens                       │
+├─────────────────────────────┼───────────────────────────────────────┤
+│  SUPABASE_PROJECT_REF       │  Supabase Dashboard > Project       │
+│                             │  Settings > General (Reference ID)   │
+├─────────────────────────────┼───────────────────────────────────────┤
+│  SUPABASE_DB_URL (optional) │  Supabase Dashboard > Project       │
+│                             │  Settings > Database > Connection    │
+│                             │  string (production migrations only) │
+└─────────────────────────────┴───────────────────────────────────────┘
+```
+
+### Which secrets are used where
+
+```
+preview-deploy.yml ──── RENDER_API_KEY
+                   ──── RENDER_SERVICE_ID
+                   ──── SUPABASE_ACCESS_TOKEN
+                   ──── SUPABASE_PROJECT_REF
+
+preview-cleanup.yml ─── SUPABASE_ACCESS_TOKEN
+                    ─── SUPABASE_PROJECT_REF
+
+deploy.yml (prod) ───── RENDER_API_KEY
+                  ───── RENDER_SERVICE_ID
+                  ───── SUPABASE_DB_URL
+```
+
+---
+
+## Detailed Flow: PR Opened
+
+### Step 1 — Native platforms create resources
+
+Two things happen in parallel, triggered by the PR branch push:
+
+**Render** reads `render.yaml`, sees `previewsEnabled: true`, and spins
+up a preview service named `{base-service}-pr-{number}`.
+
+**Supabase** GitHub integration (configured in Supabase Dashboard >
+Settings > Integrations > GitHub) detects the new branch and creates an
+isolated Postgres database with its own API endpoint, `anon_key`, and
+`service_role_key`.
+
+### Step 2 — GitHub Actions orchestrates the wiring
+
+`preview-deploy.yml` runs on `pull_request: [opened, synchronize, reopened]`:
+
+1. **CI checks** — lint, type-check, tests must pass first.
+
+2. **Wait for Supabase branch** — uses `0xbigboss/supabase-branch-gh-action@v1`
+   which polls the Supabase Management API until the branch DB is ready
+   (up to 10 minutes).
+
+3. **Fetch credentials** — extracts `api_url` and `anon_key` from the
+   action output. Calls the Supabase Management API directly to fetch
+   `service_role_key` (the action only returns `anon_key`).
+
+4. **Apply migrations** — runs `supabase link --project-ref $BRANCH_REF`
+   then `supabase db push` to apply all `supabase/migrations/*.sql`
+   files to the branch database.
+
+5. **Configure auth** — updates the branch's auth redirect URLs to allow
+   `https://app-pr-{number}.onrender.com/**` via the Management API.
+
+6. **Find Render preview** — queries the Render API, searching for a
+   service whose name matches `pr-{number}`. Polls up to 60 times
+   (10-second intervals).
+
+7. **Inject env vars** — PUTs the Supabase branch credentials into the
+   Render preview service:
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+
+8. **Redeploy** — triggers a Render redeploy so the preview picks up
+   the new credentials.
+
+9. **Health check** — GETs `/api/health` on the preview URL, retrying
+   up to 15 times.
+
+10. **PR comment** — posts (or updates) a status table on the PR with
+    links and pass/fail for each step.
+
+### Step 3 — Preview is live
+
+The preview app at `https://app-pr-{number}.onrender.com` is fully
+functional with its own database. Data changes are isolated from
+production and other PRs.
+
+---
+
+## Detailed Flow: PR Closed
+
+`preview-cleanup.yml` runs on `pull_request: [closed]`:
+
+1. **Delete Supabase branch** — runs
+   `supabase --experimental branches delete "$BRANCH_NAME" --yes`.
+   Continues on error (the branch may already be gone).
+
+2. **Render cleanup** — Render automatically tears down the preview
+   service. No API call needed.
+
+---
+
+## Detailed Flow: PR Merged (Production)
+
+`deploy.yml` runs on `push` to `main`:
+
+1. Deploys to the production Render service.
+2. If `supabase/migrations/` exists and `SUPABASE_DB_URL` is configured,
+   runs `npx supabase db push --db-url "$SUPABASE_DB_URL"` to apply
+   migrations to production.
+
+---
+
+## Graceful Degradation
+
+The system works even with partial configuration:
+
+| Missing Secret | Behavior |
+|---------------|----------|
+| `SUPABASE_ACCESS_TOKEN` | Supabase steps skipped; preview uses production DB (or no DB) |
+| `SUPABASE_PROJECT_REF` | Same as above |
+| `RENDER_API_KEY` | Workflow skipped entirely |
+| `RENDER_SERVICE_ID` | Workflow skipped entirely |
+| `SUPABASE_DB_URL` | Production migrations skipped; preview flow unaffected |
+
+---
+
+## Key Technical Detail: JWT Routing
+
+Supabase routes API requests based on the `ref` claim in the JWT, not
+the URL. This is why the workflow must fetch both `anon_key` and
+`service_role_key` from the Supabase Management API for the specific
+branch — using production keys against a branch URL would still route
+to the production database.


### PR DESCRIPTION
## Summary
- Adds `docs/EPHEMERAL-PR-ENVIRONMENTS.md` explaining how per-PR preview environments work
- ASCII architecture diagram showing the full lifecycle: PR opened → Render + Supabase create resources → GitHub Actions wires them together → preview live → PR closed → teardown
- Documents all 5 required secrets and which workflows use them
- Covers graceful degradation when secrets are missing
- Explains the JWT routing detail (why branch-specific keys are required)

## Test plan
- [ ] Diagram renders correctly in GitHub markdown preview
- [ ] All referenced workflow files (`preview-deploy.yml`, `preview-cleanup.yml`, `deploy.yml`) exist in the repo
- [ ] Secret names match what's in the actual workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)