### PR TITLE
Add rule against hardcoded application URLs

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -412,6 +412,7 @@ The following issues are grounds for immediate rejection:
 
 **Critical:**
 - Hardcoded secrets or API keys
+- Hardcoded application URLs (must use `window.location.origin` or request headers — hardcoded URLs break PR preview environments)
 - Security vulnerabilities (XSS, code injection)
 - Failing tests or build errors
 - Type errors without justification (if applicable)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 5. **Switch accounts before PR operations.** The `.claude/hooks/ensure-github-account.sh` hook handles this automatically.
 6. **No emojis in ASCII tables.** They break column alignment. Emojis OK in prose and headings.
 7. **One canonical location per fact.** Don't duplicate content across CLAUDE.md, agent files, and skills.
+8. **Never hardcode application URLs.** Use `window.location.origin` (client-side) or request headers (server-side) so code works in both production and PR preview environments.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds critical rule #8 to `CLAUDE.md`: "Never hardcode application URLs"
- Adds "Hardcoded application URLs" to the PR reviewer's red flags (automatic rejection) list
- Both layers catch the same mistake: worker won't write it, reviewer will flag it

## Context
Ephemeral PR environments get their own Supabase branch database with unique auth credentials. If application code hardcodes a production URL (e.g. `redirectTo: 'https://myapp.com/auth/callback'`), magic links and OAuth flows will redirect to production instead of the preview — and the token won't work because it was issued by the branch DB. Using `window.location.origin` makes auth work in every environment automatically.

## Test plan
- [ ] `CLAUDE.md` rule #8 is visible and clear
- [ ] PR reviewer red flags list includes hardcoded URLs with explanation
- [ ] Existing rules are not disrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)