### PR TITLE
fix: add Node.js support across CI, docs, and validation

### DIFF
--- a/.claude/commands/bootstrap-architecture.md
+++ b/.claude/commands/bootstrap-architecture.md
@@ -53,7 +53,8 @@ When the user selects a non-Python stack (e.g., Node.js/Next.js, Go), you
 MUST clean up the default Python scaffolding before proceeding:
 
 1. **Remove Python files**: Delete `pyproject.toml`, `uv.lock`, `app/`
-   (if it contains Python code), and `tests/` (if Python tests).
+   (if it contains Python code), `tests/` (if Python tests), and any
+   `tests/test_*.py` files.
 2. **Update `render.yaml`**: Replace the Python build/start commands with
    the appropriate runtime. Reference templates:
    - **Node.js**: `buildCommand: npm install && npm run build`,
@@ -61,18 +62,21 @@ MUST clean up the default Python scaffolding before proceeding:
    - **Go**: `buildCommand: go build -o server .`,
      `startCommand: ./server`
 3. **Scaffold a minimal starter app**: Include at minimum:
+   - A root `/` route serving a landing page
    - A `/health` endpoint returning `{"status": "ok"}`
    - A `/error` endpoint that raises a deliberate error (for Sentry testing)
    - One passing test
 4. **Update `CLAUDE.md`**: Replace the build/test commands section with
    commands for the new stack.
-5. **Rewrite `.github/workflows/ci.yml`**: Replace the Python-specific
-   CI jobs with stack-appropriate jobs. For Node.js/Next.js projects,
-   the CI workflow should have: lint (ESLint + markdownlint with
+5. **Rewrite CI workflows (`ci.yml` and `auto-fix.yml`)**: Replace the
+   Python-specific CI jobs with stack-appropriate jobs. For Node.js/Next.js
+   projects, the CI workflow should have: lint (ESLint + markdownlint with
    `!node_modules`), typecheck (`tsc --noEmit`), test (`npm test`),
    build (`npm run build`), and lint-agent-policies (kept from template).
    Remove the `python`, `test`, `typecheck`, and `build` jobs that
-   reference Python validation scripts.
+   reference Python validation scripts. Update `auto-fix.yml` to use
+   `npx eslint . --fix` instead of (or in addition to) `ruff` for
+   Node.js projects.
 6. **Initialize UI component library** (if selected): When the
    architecture includes shadcn/ui, run `npx shadcn@latest init --yes`
    and install base components (`button`, `input`, `label`, `card`)

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -38,6 +38,29 @@ jobs:
           uv run --extra dev ruff check . --fix --exit-zero
           uv run --extra dev ruff format . --check || uv run --extra dev ruff format .
 
+      - name: Check for Node.js project
+        id: check_node
+        run: |
+          if [ -f "package.json" ]; then
+            echo "is_node=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_node=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js
+        if: steps.check_node.outputs.is_node == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        if: steps.check_node.outputs.is_node == 'true'
+        run: npm ci
+
+      - name: Run eslint fix
+        if: steps.check_node.outputs.is_node == 'true'
+        run: npx eslint . --fix --no-error-on-unmatched-pattern || true
+
       - name: Check for changes
         id: changes
         run: |

--- a/docs/CI-CD-GUIDE.md
+++ b/docs/CI-CD-GUIDE.md
@@ -41,6 +41,12 @@ The `python` job is conditional — it only runs when `pyproject.toml` exists.
 Coverage threshold defaults to 80% and can be overridden via the
 `COVERAGE_THRESHOLD` environment variable.
 
+For **Node.js projects** (after stack transition), the `python` job is
+removed and replaced with stack-appropriate jobs: `lint` (ESLint),
+`typecheck` (`tsc --noEmit`), `test` (`npm test`), and `build`
+(`npm run build`). See the Stack Transition section of
+`bootstrap-architecture.md` for details.
+
 If a `features/` directory with `.feature` files exists, BDD tests run
 automatically.
 
@@ -56,9 +62,14 @@ Posts a review reminder comment on new PRs, prompting the team to run
 
 ### Auto Fix (`auto-fix.yml`)
 
-Automatically fixes lint issues on PR branches. For Python projects,
-runs `ruff check --fix` and `ruff format`, then commits the results
-back to the PR branch.
+Automatically fixes lint issues on PR branches. Detects the project
+type and runs the appropriate fixer:
+
+- **Python** (when `pyproject.toml` exists): runs `ruff check --fix`
+  and `ruff format`
+- **Node.js** (when `package.json` exists): runs `npx eslint . --fix`
+
+Fixed files are committed back to the PR branch automatically.
 
 ## Enable When Ready
 
@@ -152,6 +163,10 @@ Emergency rollback triggered manually via GitHub Actions UI.
 | `python` tests fail | Test failures or coverage below threshold | Fix tests or lower `COVERAGE_THRESHOLD` |
 | `lint-agent-policies` fails | Agent file missing safety phrases | Check `scripts/verify-agent-restrictions.sh` output |
 | `build` fails | Shell script errors | Run `shellcheck <script>` locally |
+| `lint` fails (ESLint) | ESLint violations (Node.js) | Run `npx eslint . --fix` |
+| `typecheck` fails (tsc) | TypeScript type errors (Node.js) | Run `npx tsc --noEmit` and fix reported errors |
+| `test` fails (Node.js) | Test failures (Node.js) | Run `npm test` locally |
+| `auto-fix` skips your stack | No fixer detected | Ensure `pyproject.toml` (Python) or `package.json` (Node.js) exists in the repo root |
 
 ### Secret-Gated Workflows Show "Skipped"
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -78,8 +78,12 @@ npx markdownlint --fix **/*.md
 # Fix Python code style issues (if your project uses Python)
 uv run ruff check . --fix
 
+# Fix Node.js code style issues (if your project uses Node.js)
+npx eslint . --fix
+
 # Re-run tests locally to see what broke
-uv run pytest
+uv run pytest          # Python
+npm test               # Node.js
 ```
 
 If you are stuck, look at the CI error message -- it usually tells you

--- a/docs/TICKET-FORMAT.md
+++ b/docs/TICKET-FORMAT.md
@@ -54,7 +54,7 @@ Tell the agent the Input, Logic, and Output flow.
 Tell the agent how to PROVE it succeeded. Not "it works." Not "tests pass."
 
 - **Specific test assertions** -- "Assert that `GET /api/foo` returns HTTP 200 with body `{\"bar\": \"baz\"}`."
-- **Lint and type checks** -- "Zero errors from `mypy --strict` and `ruff check`."
+- **Lint and type checks** -- Zero errors from the project's configured linter and type checker (e.g., `ruff check` + `mypy` for Python, `eslint` + `tsc` for TypeScript).
 - **Integration verification** -- "The new endpoint is callable from the existing API gateway config."
 - **Reviewer checklist** -- what the PR reviewer should be able to verify by inspection or by running one command.
 
@@ -107,6 +107,11 @@ Priority: P1
 - render.yaml health-check path is updated to /ping (or verified already correct).
 - PR reviewer can run `curl localhost:8000/ping` and see {"ping": "pong"}.
 ```
+
+> **Note:** This example shows a Python/FastAPI project. Adapt file paths
+> (e.g., `src/routes/` → `src/app/api/`), lint commands (e.g., `ruff` →
+> `eslint`, `mypy` → `tsc`), and test runners (e.g., `pytest` → `vitest`)
+> to match your project's actual stack as defined in TECHNICAL-ARCHITECTURE.md.
 
 ---
 

--- a/tests/validate-json.sh
+++ b/tests/validate-json.sh
@@ -20,7 +20,7 @@ validate_json() {
     fi
 
     # Check JSON syntax
-    if ! python3 -m json.tool "$file" > /dev/null 2>&1; then
+    if ! node -e "JSON.parse(require('fs').readFileSync('$file','utf8'))" 2>/dev/null; then
         echo "FAIL: $filename - Invalid JSON syntax"
         return 1
     fi


### PR DESCRIPTION
## Summary

- **`tests/validate-json.sh`**: Replace `python3 -m json.tool` with `node -e` so JSON validation works without Python installed
- **`.github/workflows/auto-fix.yml`**: Add Node.js detection and `npx eslint . --fix` auto-fix path alongside the existing Python/ruff path
- **`.claude/commands/bootstrap-architecture.md`**: Expand Stack Transition checklist to include deleting Python tests, adding a root `/` route, and rewriting `auto-fix.yml`
- **`docs/FAQ.md`**: Add `npx eslint . --fix` and `npm test` alongside Python commands in "What if CI fails?"
- **`docs/TICKET-FORMAT.md`**: Make Definition of Done lint/type-check bullet generic; add stack-agnostic note after the Python example
- **`docs/CI-CD-GUIDE.md`**: Update auto-fix description for both stacks, add Node.js CI note, add ESLint/tsc/npm troubleshooting rows

## Test plan

- [ ] Run `bash tests/validate-json.sh` — passes without `python3`
- [ ] Inspect `auto-fix.yml` has both Python and Node.js detection paths
- [ ] Stack Transition section mentions deleting tests, index route, and `auto-fix.yml`
- [ ] FAQ shows both Python and Node.js commands in CI failure section
- [ ] Ticket format example has stack-agnostic note
- [ ] CI-CD guide troubleshooting covers both Python and Node.js failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)