### PR TITLE
fix: harden agent commands against protocol violations

### DIFF
--- a/.claude/commands/bootstrap-workflow.md
+++ b/.claude/commands/bootstrap-workflow.md
@@ -13,6 +13,14 @@ Set up GitHub project board, branch protection, and create initial backlog from 
 
 This is the final bootstrap phase. It activates the full agent workflow.
 
+## Ticket Format Requirement
+
+Before creating any issues, read `docs/TICKET-FORMAT.md` in full. Every issue
+created in this phase — epics and features alike — MUST follow the Agentic PRD
+Lite format. Tickets without the 4 Power Sections (A. Environment Context,
+B. Guardrails, C. Happy Path, D. Definition of Done) will not pass grooming
+and will have to be rewritten.
+
 ## What This Phase Does
 
 ### 1. GitHub Project Board Setup
@@ -34,11 +42,16 @@ Verify or configure branch protection on `main`:
 
 ### 3. Initial Backlog Creation
 
-Convert PRD features into GitHub issues:
-- Create epics for major feature areas
-- Create issues for MVP features
+Convert PRD features into GitHub issues following `docs/TICKET-FORMAT.md`:
+- Create epics for major feature areas (epics use Problem Statement + high-level scope)
+- Create feature issues with ALL required fields:
+  - Problem Statement, Parent Epic, Effort Estimate, Priority
+  - A. Environment Context (from `docs/TECHNICAL-ARCHITECTURE.md`)
+  - B. Guardrails (from `docs/AGENTIC-CONTROLS.md` + PRD constraints)
+  - C. Happy Path (numbered steps: Input → Logic → Output)
+  - D. Definition of Done (specific test assertions, lint commands, reviewer checks)
 - Link issues to epics
-- Add initial priority labels
+- Add priority labels (P0/P1/P2/P3)
 
 ### 4. Ready Column Population
 
@@ -63,6 +76,23 @@ Before running this phase, ensure you have:
 - [ ] GitHub personal access token with repo and project permissions
 - [ ] Permission to create project boards
 - [ ] Permission to configure branch protection
+
+## Pre-Flight Verification (REQUIRED)
+
+Before any board or ticket operations, verify the following. STOP and report
+to the user if any check fails — do not continue with partial tooling.
+
+1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
+   list repos). If the MCP server is not connected, STOP. Do not fall back to
+   CLI-only mode silently.
+2. **GitHub account is correct** — Run `gh auth status` and confirm the active
+   account matches the expected worker/bot account. If only a personal account
+   is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
+3. **Claude hooks are registered** — Check that hook files referenced in
+   `.claude/settings.local.json` exist and are executable. WARN if any hook is
+   missing or not executable.
+4. **Project board is accessible** — Attempt to read the project board. If
+   access is denied or the board does not exist, STOP and report.
 
 ## Configuration Required
 
@@ -93,10 +123,14 @@ The workflow activation agent will:
    - Verify configuration
 
 4. **Generate Backlog**
-   - Read PRD features
-   - Create epic issues
-   - Create feature issues
-   - Set initial priorities
+   - Read `docs/TICKET-FORMAT.md` for the canonical ticket format
+   - Read PRD features from `docs/PRODUCT-REQUIREMENTS.md`
+   - Read `docs/TECHNICAL-ARCHITECTURE.md` for Environment Context content
+   - Read `docs/AGENTIC-CONTROLS.md` for Guardrails content
+   - Create epic issues (Problem Statement + scope description)
+   - Create feature issues with all 4 Power Sections populated
+   - Set initial priorities (P0-P3)
+   - Self-check: before creating each issue, verify it contains sections A through D
 
 5. **Populate Ready Column**
    - Select MVP tickets
@@ -109,26 +143,61 @@ The workflow activation agent will:
 
 ## Example Backlog Generation
 
-From PRD features like:
+> Every issue MUST follow `docs/TICKET-FORMAT.md`. The example below shows the
+> expected structure. Do NOT create bare-title issues without Power Sections.
+
+From a PRD feature like:
 ```markdown
 ### MVP Features
 - User authentication (email/password)
-- User profile management
-- Core dashboard
 ```
 
-Creates issues like:
+Create an epic:
 ```
 Epic: User Authentication
-  - Issue: Implement email/password signup
-  - Issue: Implement login flow
-  - Issue: Implement password reset
-  - Issue: Add session management
 
-Epic: User Profile
-  - Issue: Create profile page
-  - Issue: Implement profile editing
-  - Issue: Add avatar upload
+Problem Statement:
+The application has no way to identify users. All routes are public.
+We need email/password authentication to gate access to user-specific data.
+
+Scope: signup, login, password reset, session management.
+Priority: P0
+```
+
+Then create feature issues with full Power Sections:
+```
+TICKET: Implement email/password signup
+
+Problem Statement:
+New users cannot create accounts. We need a signup endpoint that accepts
+email + password, validates input, and creates a user record.
+
+Parent Epic: #<epic-number>
+Effort Estimate: M
+Priority: P0
+
+--- A. Environment Context ---
+- Stack: (from TECHNICAL-ARCHITECTURE.md)
+- Existing pattern: (reference a similar route in the codebase)
+- Files to create/modify: (list explicitly)
+
+--- B. Guardrails ---
+- (from AGENTIC-CONTROLS.md + PRD constraints)
+- Do NOT store plaintext passwords
+- Do NOT modify existing auth middleware
+
+--- C. Happy Path ---
+1. Client sends POST /auth/signup with {email, password}
+2. Server validates email format and password strength
+3. Server hashes password, creates user record
+4. Server returns 201 with {id, email}
+
+--- D. Definition of Done ---
+- Test asserts POST /auth/signup with valid data returns 201
+- Test asserts duplicate email returns 409
+- Test asserts weak password returns 422
+- Lint and type checks pass with zero errors
+- PR reviewer can run the signup flow manually
 ```
 
 ## What Gets Unlocked

--- a/.claude/commands/create-ticket.md
+++ b/.claude/commands/create-ticket.md
@@ -4,6 +4,20 @@ description: Create a well-structured ticket that meets Definition of Ready
 
 Create a new ticket on the project board with guided workflow.
 
+## Pre-Flight Verification (REQUIRED)
+
+Before creating any ticket, verify the following. STOP and report to the user
+if any check fails — do not continue with partial tooling.
+
+1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
+   list repos). If the MCP server is not connected, STOP. Do not fall back to
+   CLI-only mode silently.
+2. **GitHub account is correct** — Run `gh auth status` and confirm the active
+   account matches the expected worker/bot account. If only a personal account
+   is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
+3. **Project board is accessible** — Attempt to read the project board. If
+   access is denied or the board does not exist, STOP and report.
+
 ## Critical Rules
 
 1. **Every ticket must meet Definition of Ready** before being added to the board
@@ -22,39 +36,33 @@ Create a new ticket on the project board with guided workflow.
 7. **Create** — Create the GitHub issue and add it to the project board
 8. **Categorize** — Set priority, size estimate, and move to Backlog
 
-## Ticket Template
+## Ticket Format
 
-```markdown
-## Problem
-[What problem does this solve? Why does it matter? 2-3 sentences max.]
+**Do not use an inline template.** Read `docs/TICKET-FORMAT.md` before drafting
+any ticket — it is the single source of truth and contains the full specification
+with examples.
 
-## A. Environment Context
-[Tech stack, integration points, existing patterns to follow, files to modify.
-Populate from TECHNICAL-ARCHITECTURE.md and existing codebase.]
+Every ticket MUST include these 5 components:
 
-## B. Guardrails
-[Explicit constraints: security rules, performance targets, what NOT to do.
-Populate from AGENTIC-CONTROLS.md and PRD non-functional requirements.]
+1. **Standard Fields** — Problem Statement, Parent Epic, Effort Estimate, Priority
+2. **A. Environment Context** — Populate from `docs/TECHNICAL-ARCHITECTURE.md`
+   and the existing codebase (stack, integration points, files to modify)
+3. **B. Guardrails** — Populate from `docs/AGENTIC-CONTROLS.md` and PRD
+   non-functional requirements (security rules, performance targets, prohibitions)
+4. **C. Happy Path** — Numbered steps: Input → Logic → Output. One flow per ticket.
+5. **D. Definition of Done** — Specific test assertions, lint/type commands,
+   reviewer-verifiable outcomes. Not vague.
 
-## C. Happy Path
-[Step-by-step Input → Logic → Output flow. One clear flow per ticket.]
+### Self-Check Before Presenting Draft
 
-## D. Definition of Done
-[Concrete proof of completion: specific tests, assertions, endpoints to verify.
-Not vague — the PR reviewer must be able to check each item.]
-
-## Acceptance Criteria
-- [ ] [Specific, testable criterion]
-- [ ] [Another criterion]
-
-## Parent Epic
-#[epic-number] (if applicable)
-
-## Effort Estimate
-[XS (<30 min) | S (1-2 hours) | M (2-4 hours) | L (4-8 hours) | XL (1+ days)]
-```
-
-See `docs/TICKET-FORMAT.md` for the canonical format specification and examples.
+Before showing the draft to the user, verify:
+- [ ] Problem Statement is 2-3 sentences, not a paragraph
+- [ ] Sections A-D are all present and non-empty
+- [ ] Environment Context references specific files, not generic descriptions
+- [ ] Guardrails include at least one explicit prohibition
+- [ ] Happy Path has numbered steps with data shapes
+- [ ] Definition of Done has concrete assertions (not "tests pass")
+- [ ] Effort estimate is provided; if XL, suggest decomposition
 
 ## Usage
 

--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -6,6 +6,23 @@ Launch the github-ticket-worker agent to implement the next prioritized ticket.
 
 > **Reference**: See `docs/TICKET-FORMAT.md` for the expected ticket format.
 
+## Pre-Flight Verification (REQUIRED)
+
+Before starting work on any ticket, verify the following. STOP and report to
+the user if any check fails — do not continue with partial tooling.
+
+1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
+   list repos). If the MCP server is not connected, STOP. Do not fall back to
+   CLI-only mode silently.
+2. **GitHub account is correct** — Run `gh auth status` and confirm the active
+   account matches the expected worker/bot account. If only a personal account
+   is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
+3. **Claude hooks are registered** — Check that hook files referenced in
+   `.claude/settings.local.json` exist and are executable. WARN if any hook is
+   missing or not executable.
+4. **Project board is accessible** — Attempt to read the project board. If
+   access is denied or the board does not exist, STOP and report.
+
 ## Critical Rules
 
 1. **Branch from main**: `feature/issue-{number}-short-description`
@@ -22,10 +39,14 @@ Launch the github-ticket-worker agent to implement the next prioritized ticket.
 2. **Validate Ticket Format** — Check the ticket body for the 4 Power Sections:
    - **A. Environment Context**, **B. Guardrails**, **C. Happy Path**, **D. Definition of Done**
    - If any section is missing or empty:
-     1. Read `docs/TECHNICAL-ARCHITECTURE.md`, `docs/PRODUCT-REQUIREMENTS.md`, and the parent epic
-     2. Fill in the missing sections (best-effort)
-     3. Update the GitHub issue with the fleshed-out version
-     4. Present the completed spec to the user for confirmation before coding
+     1. **STOP** and report to the user exactly which sections are missing —
+        make the upstream formatting failure visible as a process problem
+     2. Read `docs/TICKET-FORMAT.md`, `docs/TECHNICAL-ARCHITECTURE.md`,
+        `docs/AGENTIC-CONTROLS.md`, and the parent epic
+     3. Draft the missing sections following `docs/TICKET-FORMAT.md` exactly
+     4. Present the draft to the user with a clear diff showing what was added —
+        **do not proceed until the user explicitly approves**
+     5. Update the GitHub issue with the user-approved version
    - If all 4 sections are present → proceed normally (no delay)
 3. **Setup** — Create branch, move to In Progress
 4. **Implement** — Follow CLAUDE.md standards, write clean code, follow existing patterns

--- a/docs/SORTING-AND-BATCHING.md
+++ b/docs/SORTING-AND-BATCHING.md
@@ -1,0 +1,61 @@
+# Sorting and Batching
+
+Sorting work before executing it is the single highest-leverage improvement you can make to delivery cadence. Everything else in agile-flow — ticket format, branching, backlog grooming — is downstream of this principle.
+
+---
+
+## The Laundry Analogy
+
+Your dryer just finished. The goal is simple: socks in the sock drawer, shirts in the shirt drawer, towels on the shelf.
+
+**The amateur approach:** grab the first item off the pile, fold it, walk it to the right drawer, put it away, walk back. Grab the next item — different type, different folding pattern, different drawer. Repeat. Every single item forces a context switch: new motor pattern, new destination.
+
+**The professional approach:** sort the pile first. All socks together, all shirts together, all towels together. Now fold each batch. Your hands lock into one folding pattern and stay there. You walk to each drawer once, not twenty times.
+
+The professional finishes faster *and* with less mental effort. Not because they fold faster — because they eliminated the switching cost.
+
+---
+
+## Why Sorting Reduces Context-Switching
+
+The same dynamic plays out in software delivery. The focus required for a database migration is fundamentally different from the focus for a UI component, which is different again from a CI pipeline fix. Each type of work has its own mental model, its own tools, its own failure modes.
+
+If you attack tickets in random order, every transition forces a full context reload — different files, different concerns, different risk profiles. This is expensive for humans and even more expensive for agents.
+
+**For human developers:** each switch burns 10–20 minutes of ramp-up time that produces zero output.
+
+**For AI agents:** each switch means the context window fills with irrelevant instructions from the previous task. The agent's attention is split between the current problem and leftover context from something unrelated.
+
+Sort tickets by type or area *before* you start executing. Each batch keeps you — or the agent — in the same headspace. Database work stays with database work. UI stays with UI. The switching cost drops to near zero.
+
+---
+
+## Why Batching Normalizes Complexity
+
+Unsorted work hides risk. When tickets aren't grouped by concern, a single ticket can quietly absorb three different types of work — a schema change, a UI update, and a deploy config tweak — without anyone noticing until it blows up mid-sprint.
+
+Sorting forces you to see the real shape of the work *before* you commit to it. When you group by area, a ticket that crosses boundaries becomes immediately visible: it doesn't fit neatly into any batch. That's your signal to split it.
+
+Properly sorted and batched tickets have predictable size. An XS stays XS and an S stays S because each ticket does one kind of thing. There are no surprise L tickets hiding inside what looked like an S.
+
+This is why effort estimates hold and budgets don't blow up. The variance in ticket size collapses because sorting eliminates the hidden complexity that causes blowups in the first place.
+
+---
+
+## How agile-flow Enforces This
+
+Sorting and batching aren't just advice — they're built into the workflow at multiple points:
+
+- **Backlog grooming** (`/groom-backlog`) is where sorting happens. The Backlog Prioritizer reads the full backlog and groups work by area and type, surfacing tickets that need splitting before they enter a sprint.
+- **The agile board** makes batches visible. Columns show what's in-flight, so you can see at a glance whether a sprint's work is coherent or scattered across unrelated concerns.
+- **Ticket format** ([TICKET-FORMAT.md](TICKET-FORMAT.md)) constrains scope to one concern per ticket. A ticket that tries to do two kinds of work violates the format by definition.
+- **Branching strategy** ([BRANCHING-STRATEGY.md](BRANCHING-STRATEGY.md)) maps one ticket to one branch to one PR. This keeps batches clean all the way through delivery — no branch accumulates unrelated changes.
+
+---
+
+## Related Documentation
+
+- [TICKET-FORMAT.md](TICKET-FORMAT.md) — ticket structure and scope constraints
+- [ARTIFACT-FLOW.md](ARTIFACT-FLOW.md) — how documents, tickets, and code move through the system
+- [CONTEXT-OPTIMIZATIONS.md](CONTEXT-OPTIMIZATIONS.md) — context engineering strategy for agent workflows
+- [BRANCHING-STRATEGY.md](BRANCHING-STRATEGY.md) — trunk-based development and the one-ticket-one-branch rule


### PR DESCRIPTION
## Summary

- **Pre-flight verification** added to `bootstrap-workflow`, `create-ticket`, and `work-ticket` — agents now STOP if MCP GitHub server is unreachable, wrong GitHub account is active, hooks are missing, or project board is inaccessible
- **TICKET-FORMAT.md compliance enforced** in `bootstrap-workflow` — bulk backlog creation now requires reading the canonical format, and the example shows full Power Sections instead of bare titles
- **Duplicate inline template removed** from `create-ticket` — replaced with a read-first directive pointing to `docs/TICKET-FORMAT.md` plus a self-check list
- **Silent best-effort fill-in replaced** in `work-ticket` — agent now stops and reports missing sections to the user, drafts them per TICKET-FORMAT.md, and waits for explicit approval before proceeding
- **docs/SORTING-AND-BATCHING.md** added

## Test plan

- [ ] Read each modified command file end-to-end — confirm no broken markdown or orphaned sections
- [ ] Grep `.claude/commands/*.md` for `TICKET-FORMAT.md` — every ticket-creating command references it
- [ ] Verify `docs/TICKET-FORMAT.md` is unchanged (canonical source not modified)
- [ ] Run `scripts/lint-agent-policies.sh` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)