### PR TITLE
fix: resolve doctor.sh false positives in restricted PATH

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -84,6 +84,32 @@ section() {
 }
 
 # ───────────────────────────────────────────────────────────────────
+#  resolve_cmd — find a CLI tool even in restricted PATH environments
+# ───────────────────────────────────────────────────────────────────
+# Usage: resolve_cmd <name>
+# Prints the resolved path on stdout.  Returns 0 if found, 1 if not.
+resolve_cmd() {
+    local cmd="$1"
+    # Try PATH first
+    local found
+    found=$(command -v "$cmd" 2>/dev/null) && { echo "$found"; return 0; }
+    # Probe well-known install locations
+    local dir
+    for dir in \
+        /opt/homebrew/bin \
+        /usr/local/bin \
+        "$HOME/.local/bin" \
+        "$HOME/.cargo/bin" \
+        "$HOME/.claude/local"; do
+        if [ -x "$dir/$cmd" ]; then
+            echo "$dir/$cmd"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ───────────────────────────────────────────────────────────────────
 #  Header
 # ───────────────────────────────────────────────────────────────────
 echo ""
@@ -92,43 +118,49 @@ echo -e "${CYAN}║${NC}              ${BLUE}Agile Flow Doctor${NC}             
 echo -e "${CYAN}╚════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
+# ───────────────────────────────────────────────────────────────────
+#  Restricted PATH banner
+# ───────────────────────────────────────────────────────────────────
+if [[ ":$PATH:" != *":/opt/homebrew/bin:"* ]] && [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
+    echo -e "${YELLOW}Note: Running with restricted PATH — using fallback path detection${NC}"
+    echo ""
+fi
+
 # ═══════════════════════════════════════════════════════════════════
 #  1. CLI Tools
 # ═══════════════════════════════════════════════════════════════════
 section "CLI Tools"
 
 # git (FAIL)
-if command -v git &>/dev/null; then
-    pass "CLI Tools" "git found ($(git --version | head -1))"
+if GIT_CMD=$(resolve_cmd git); then
+    pass "CLI Tools" "git found ($("$GIT_CMD" --version | head -1))"
 else
     fail "CLI Tools" "git not found" "Install from https://git-scm.com/downloads"
 fi
 
 # gh (FAIL)
-if command -v gh &>/dev/null; then
-    pass "CLI Tools" "gh found ($(gh --version | head -1))"
+if GH_CMD=$(resolve_cmd gh); then
+    pass "CLI Tools" "gh found ($("$GH_CMD" --version | head -1))"
 else
     fail "CLI Tools" "gh not found" "brew install gh  or  https://cli.github.com"
 fi
 
-# claude (FAIL) — check both PATH and ~/.claude/local/claude
-if command -v claude &>/dev/null; then
-    pass "CLI Tools" "claude found at $(command -v claude)"
-elif [ -x "$HOME/.claude/local/claude" ]; then
-    warn "CLI Tools" "claude found at ~/.claude/local/claude but not in PATH" "Add ~/.claude/local to your PATH"
+# claude (FAIL)
+if CLAUDE_CMD=$(resolve_cmd claude); then
+    pass "CLI Tools" "claude found at $CLAUDE_CMD"
 else
     fail "CLI Tools" "claude not found" "npm install -g @anthropic-ai/claude-code"
 fi
 
 # jq (FAIL)
-if command -v jq &>/dev/null; then
+if JQ_CMD=$(resolve_cmd jq); then
     pass "CLI Tools" "jq found"
 else
     fail "CLI Tools" "jq not found" "brew install jq  or  https://jqlang.github.io/jq/download/"
 fi
 
 # npx (WARN)
-if command -v npx &>/dev/null; then
+if NPX_CMD=$(resolve_cmd npx); then
     pass "CLI Tools" "npx found"
 else
     warn "CLI Tools" "npx not found" "Install Node.js from https://nodejs.org (needed for MCP servers)"
@@ -136,7 +168,7 @@ fi
 
 # uv — WARN if pyproject.toml exists
 if [ -f "pyproject.toml" ]; then
-    if command -v uv &>/dev/null; then
+    if resolve_cmd uv &>/dev/null; then
         pass "CLI Tools" "uv found (Python project detected)"
     else
         warn "CLI Tools" "uv not found but pyproject.toml exists" "curl -LsSf https://astral.sh/uv/install.sh | sh"
@@ -145,8 +177,8 @@ fi
 
 # node — WARN if package.json exists
 if [ -f "package.json" ]; then
-    if command -v node &>/dev/null; then
-        pass "CLI Tools" "node found ($(node --version))"
+    if NODE_CMD=$(resolve_cmd node); then
+        pass "CLI Tools" "node found ($("$NODE_CMD" --version))"
     else
         warn "CLI Tools" "node not found but package.json exists" "Install from https://nodejs.org"
     fi
@@ -205,16 +237,16 @@ fi
 # ═══════════════════════════════════════════════════════════════════
 section "GitHub Auth"
 
-if ! command -v gh &>/dev/null; then
+if ! GH_CMD=$(resolve_cmd gh); then
     skip "GitHub Auth" "All checks" "gh CLI not installed"
 else
 
 # Save current gh user for safe restore after switch tests
-ORIGINAL_GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+ORIGINAL_GH_USER=$("$GH_CMD" api user --jq '.login' 2>/dev/null || echo "")
 
 # Human account (FAIL)
-if gh auth status &>/dev/null 2>&1; then
-    current_user=$(gh api user --jq '.login' 2>/dev/null || echo "unknown")
+if "$GH_CMD" auth status &>/dev/null 2>&1; then
+    current_user=$("$GH_CMD" api user --jq '.login' 2>/dev/null || echo "unknown")
     pass "GitHub Auth" "Human account authenticated: $current_user"
 else
     fail "GitHub Auth" "Not authenticated with gh" "Run: gh auth login"
@@ -225,11 +257,11 @@ if [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ]; then
     pass "GitHub Auth" "AGILE_FLOW_WORKER_ACCOUNT set: $AGILE_FLOW_WORKER_ACCOUNT"
 
     # Test worker account is in keyring
-    if gh auth switch --user "$AGILE_FLOW_WORKER_ACCOUNT" &>/dev/null 2>&1; then
+    if "$GH_CMD" auth switch --user "$AGILE_FLOW_WORKER_ACCOUNT" &>/dev/null 2>&1; then
         pass "GitHub Auth" "Worker account ($AGILE_FLOW_WORKER_ACCOUNT) in gh keyring"
         # Restore original user
         if [ -n "$ORIGINAL_GH_USER" ]; then
-            gh auth switch --user "$ORIGINAL_GH_USER" &>/dev/null 2>&1 || true
+            "$GH_CMD" auth switch --user "$ORIGINAL_GH_USER" &>/dev/null 2>&1 || true
         fi
     else
         warn "GitHub Auth" "Worker account ($AGILE_FLOW_WORKER_ACCOUNT) not in gh keyring" "Run: gh auth login for this account"
@@ -243,11 +275,11 @@ if [ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ]; then
     pass "GitHub Auth" "AGILE_FLOW_REVIEWER_ACCOUNT set: $AGILE_FLOW_REVIEWER_ACCOUNT"
 
     # Test reviewer account is in keyring
-    if gh auth switch --user "$AGILE_FLOW_REVIEWER_ACCOUNT" &>/dev/null 2>&1; then
+    if "$GH_CMD" auth switch --user "$AGILE_FLOW_REVIEWER_ACCOUNT" &>/dev/null 2>&1; then
         pass "GitHub Auth" "Reviewer account ($AGILE_FLOW_REVIEWER_ACCOUNT) in gh keyring"
         # Restore original user
         if [ -n "$ORIGINAL_GH_USER" ]; then
-            gh auth switch --user "$ORIGINAL_GH_USER" &>/dev/null 2>&1 || true
+            "$GH_CMD" auth switch --user "$ORIGINAL_GH_USER" &>/dev/null 2>&1 || true
         fi
     else
         warn "GitHub Auth" "Reviewer account ($AGILE_FLOW_REVIEWER_ACCOUNT) not in gh keyring" "Run: gh auth login for this account"
@@ -258,7 +290,7 @@ fi
 
 # Final restore — ensure we always end on the original user
 if [ -n "$ORIGINAL_GH_USER" ]; then
-    gh auth switch --user "$ORIGINAL_GH_USER" &>/dev/null 2>&1 || true
+    "$GH_CMD" auth switch --user "$ORIGINAL_GH_USER" &>/dev/null 2>&1 || true
 fi
 
 fi  # end gh guard
@@ -272,28 +304,34 @@ section "MCP Config"
 if [ -f ".mcp.json" ]; then
     pass "MCP Config" ".mcp.json exists"
 
-    if ! command -v jq &>/dev/null; then
+    if ! JQ_CMD=$(resolve_cmd jq); then
         skip "MCP Config" "Content checks (github server, memory server, npx path)" "jq not installed"
     else
         # github server (FAIL)
-        if jq -e '.mcpServers.github' .mcp.json &>/dev/null; then
+        if "$JQ_CMD" -e '.mcpServers.github' .mcp.json &>/dev/null; then
             pass "MCP Config" "github server configured"
         else
             fail "MCP Config" "github server missing from .mcp.json" "Run bootstrap.sh Phase 0 or add github server manually"
         fi
 
         # memory server (WARN)
-        if jq -e '.mcpServers.memory' .mcp.json &>/dev/null; then
+        if "$JQ_CMD" -e '.mcpServers.memory' .mcp.json &>/dev/null; then
             pass "MCP Config" "memory server configured"
         else
             warn "MCP Config" "memory server missing from .mcp.json" "Optional but recommended for agent context"
         fi
 
         # npx path resolves (WARN)
-        mcp_npx_path=$(jq -r '.mcpServers.github.command // empty' .mcp.json 2>/dev/null)
+        mcp_npx_path=$("$JQ_CMD" -r '.mcpServers.github.command // empty' .mcp.json 2>/dev/null)
         if [ -n "$mcp_npx_path" ]; then
-            if [ -x "$mcp_npx_path" ] || command -v "$mcp_npx_path" &>/dev/null; then
+            if resolve_cmd "$mcp_npx_path" &>/dev/null; then
                 pass "MCP Config" "npx command in .mcp.json resolves: $mcp_npx_path"
+                # Also check that node is available (npx shim needs it)
+                if resolve_cmd node &>/dev/null; then
+                    pass "MCP Config" "node available (required by npx)"
+                else
+                    warn "MCP Config" "npx found but node not resolvable" "npx requires node — install from https://nodejs.org"
+                fi
             else
                 warn "MCP Config" "npx path in .mcp.json does not resolve: $mcp_npx_path" "Update .mcp.json command path or install npx"
             fi
@@ -325,18 +363,22 @@ settings_file=".claude/settings.local.json"
 if [ -f "$settings_file" ]; then
     pass "Claude Settings" "$settings_file exists"
 
-    # merge-PR deny rule (WARN)
-    if jq -e '.deny // [] | map(select(test("merge|Merge";"i"))) | length > 0' "$settings_file" &>/dev/null 2>&1; then
-        pass "Claude Settings" "Merge-PR deny rule present"
-    else
-        warn "Claude Settings" "No merge-PR deny rule found" "Add a deny rule to prevent agents from merging PRs"
-    fi
+    if JQ_CMD=$(resolve_cmd jq); then
+        # merge-PR deny rule (WARN)
+        if "$JQ_CMD" -e '.deny // [] | map(select(test("merge|Merge";"i"))) | length > 0' "$settings_file" &>/dev/null 2>&1; then
+            pass "Claude Settings" "Merge-PR deny rule present"
+        else
+            warn "Claude Settings" "No merge-PR deny rule found" "Add a deny rule to prevent agents from merging PRs"
+        fi
 
-    # .env read deny rule (WARN)
-    if jq -e '.deny // [] | map(select(test("\\.env|dotenv";"i"))) | length > 0' "$settings_file" &>/dev/null 2>&1; then
-        pass "Claude Settings" ".env read deny rule present"
+        # .env read deny rule (WARN)
+        if "$JQ_CMD" -e '.deny // [] | map(select(test("\\.env|dotenv";"i"))) | length > 0' "$settings_file" &>/dev/null 2>&1; then
+            pass "Claude Settings" ".env read deny rule present"
+        else
+            warn "Claude Settings" "No .env read deny rule found" "Add a deny rule to prevent agents from reading .env files"
+        fi
     else
-        warn "Claude Settings" "No .env read deny rule found" "Add a deny rule to prevent agents from reading .env files"
+        skip "Claude Settings" "Deny rule checks" "jq not installed"
     fi
 else
     if [ -f ".claude/settings.template.json" ]; then


### PR DESCRIPTION
## Summary
- Add `resolve_cmd()` helper that tries `command -v` first, then probes well-known install paths (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`, `~/.cargo/bin`, `~/.claude/local`)
- Replace all `command -v` checks in CLI Tools section with `resolve_cmd`, eliminating false FAIL/WARN when run from Claude Code's sandboxed Bash tool (PATH restricted to `/usr/bin:/bin:/usr/sbin:/sbin`)
- Use resolved absolute paths for `gh`/`jq` calls in GitHub Auth, MCP Config, and Claude Settings sections
- Add yellow restricted PATH banner when neither `/opt/homebrew/bin` nor `/usr/local/bin` is in PATH
- Simplify claude check — `resolve_cmd` already covers `~/.claude/local`, no special-case WARN needed

## Test plan
- [x] `bash scripts/doctor.sh` from normal terminal — all CLI tools PASS, no regressions
- [x] `PATH=/usr/bin:/bin:/usr/sbin:/sbin bash scripts/doctor.sh` — banner shown, all tools found via fallback, 0 false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)