### PR TITLE
docs: make landing page and workshop docs stack-neutral

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,11 @@
 export default function Home() {
   return (
     <main>
-      <h1>Agile Flow Starter</h1>
-      <p>Your agentic development workflow is ready.</p>
+      <h1>Agile Flow</h1>
+      <p>
+        Your deployment pipeline is live. Configure your stack with{" "}
+        <code>/bootstrap-architecture</code>.
+      </p>
 
       <h2>Endpoints</h2>
       <ul>
@@ -16,6 +19,13 @@ export default function Home() {
           <code>POST /api/error-events</code> — Error event receiver
         </li>
       </ul>
+
+      <p>
+        <small>
+          This is the deploy-first starter. Your tech stack will be configured
+          during the bootstrap phase.
+        </small>
+      </p>
     </main>
   );
 }

--- a/docs/FIRST-DAY.md
+++ b/docs/FIRST-DAY.md
@@ -59,7 +59,7 @@ Deploy before cloning — see your app live in under 15 minutes.
 Wait for the first deploy to complete (2-5 minutes on free tier).
 
 You should see: Your app at `https://agile-flow-starter.onrender.com`
-showing "Agile Flow Starter".
+showing "Agile Flow".
 
 Verify the health check:
 
@@ -216,6 +216,12 @@ Inside the Claude Code session, run each phase in order:
 /bootstrap-agents
 /bootstrap-workflow
 ```
+
+> **Stack swap:** During `/bootstrap-architecture`, you will choose your
+> tech stack (Next.js, FastAPI, etc.). If you choose something other than
+> Next.js, the agent swaps the app files automatically and Render redeploys
+> with your chosen stack. The initial deploy you did in Step 2 was a
+> pipeline verification — not your final stack.
 
 The workflow phase will ask you for:
 

--- a/docs/WORKSHOP-GUIDE.md
+++ b/docs/WORKSHOP-GUIDE.md
@@ -138,19 +138,21 @@ Note: Sentry SaaS is optional. The app ships with zero-config error telemetry th
 
 | Time | Activity | Commands Used |
 |------|----------|---------------|
-| 0:00-0:30 | Introduction, `/doctor` diagnostic, setup verification | `/doctor`, `gh auth status` |
+| 0:00-0:15 | Introduction, setup verification | `/doctor`, `gh auth status` |
+| 0:15-0:30 | Deploy to Render (deploy-first) | Render dashboard |
 | 0:30-1:00 | Product definition | `/bootstrap-product` |
-| 1:00-1:30 | Technical architecture | `/bootstrap-architecture` |
+| 1:00-1:30 | Technical architecture (stack selection) | `/bootstrap-architecture` |
 | 1:30-2:00 | Agent specialization | `/bootstrap-agents` |
 | 2:00-2:30 | Break | - |
 | 2:30-3:00 | Workflow activation | `/bootstrap-workflow` |
-| 3:00-3:30 | First ticket: deploy and verify | `/work-ticket` |
+| 3:00-3:30 | First ticket: implement and create PR | `/work-ticket` |
 | 3:30-4:00 | Trigger deliberate error, verify auto-created issue | `curl /error`, `gh issue list` |
 
 **Day 1 Success Criteria:**
 - `/doctor` reports zero FAILs
 - App deployed to Render
 - Health check endpoint returns `{"status": "ok"}`
+- Stack swap completed (if non-Next.js chosen)
 - Deliberate error auto-creates a GitHub issue
 - First PR created and merged
 


### PR DESCRIPTION
## Summary
- Update `app/page.tsx` landing page from "Agile Flow Starter" to "Agile Flow" with deploy-first messaging and `/bootstrap-architecture` callout
- Add stack-swap callout to `docs/FIRST-DAY.md` Step 5 explaining that non-Next.js stacks are swapped automatically during bootstrap
- Revise `docs/WORKSHOP-GUIDE.md` Day 1 timeline to show deploy at 0:15 (deploy-first) and add stack-swap success criterion

## Test plan
- [x] `npm test` — all 6 tests pass
- [x] `npm run build` — production build succeeds
- [ ] Verify `app/page.tsx` has no mention of "Starter" or any specific stack
- [ ] Verify `docs/FIRST-DAY.md` Step 5 explains stack swap
- [ ] Verify `docs/WORKSHOP-GUIDE.md` Day 1 timeline shows deploy at 0:15

🤖 Generated with [Claude Code](https://claude.com/claude-code)