### PR TITLE
fix(ci): skip preview workflows on template repo

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   cleanup:
     name: Cleanup Preview Resources
+    if: github.repository != 'vibeacademy/agile-flow'
     runs-on: ubuntu-latest
     steps:
       - name: Setup Supabase CLI

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -7,10 +7,12 @@ on:
 jobs:
   ci:
     name: CI Checks
+    if: github.repository != 'vibeacademy/agile-flow'
     uses: ./.github/workflows/ci.yml
 
   wait-for-supabase:
     name: Wait for Supabase Branch
+    if: github.repository != 'vibeacademy/agile-flow'
     runs-on: ubuntu-latest
     outputs:
       branch_ready: ${{ steps.check.outputs.conclusion || 'skipped' }}


### PR DESCRIPTION
## Summary
- Add repository guard (`github.repository != 'vibeacademy/agile-flow'`) to all jobs in `preview-deploy.yml` and `preview-cleanup.yml`
- Matches the existing pattern in `deploy.yml` (line 11)
- Stops the spurious workflow failures on every PR in the template repo
- Repos created from the template have a different name, so their preview workflows run normally

## Test plan
- [ ] Next PR on this repo should show preview-deploy as skipped (not failed)
- [ ] Verify a repo created from the template still runs preview-deploy normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)