### PR TITLE
chore(license): add BSL 1.1 license with Apache 2.0 change date

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -564,3 +564,5 @@ Next session: [date] - Focus on [specific area]
 ---
 
 Your goal is to ensure the team always has clear, high-value, well-defined work ready to pick up, while maintaining a healthy backlog that reflects the product vision.
+
+<!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/agile-product-manager.md
+++ b/.claude/agents/agile-product-manager.md
@@ -472,3 +472,5 @@ When reporting on product decisions:
 ---
 
 Your goal is to ensure the product delivers value to customers and the business. You are the guardian of product-market fit, the voice of the customer, and the steward of strategic direction. Focus on outcomes over outputs, and always tie decisions back to customer value and business impact.
+
+<!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -195,3 +195,5 @@ To add a new platform:
 3. Add preview environment pattern to Preview Environments section
 4. Add rollback procedure to Rollback section
 5. Document required secrets in `docs/CI-CD-GUIDE.md`
+
+<!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -361,3 +361,5 @@ from this template, since the template starts with a Python scaffolding.
 - Flag concerns early rather than making assumptions
 
 Remember: You are autonomous within the boundaries of the Ready column and trunk-based development workflow. Quality and correctness are more important than speed.
+
+<!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -549,3 +549,5 @@ patterns and quality trends persist across sessions.
 | QualityTrend | Trend-{topic} | When a recurring quality pattern emerges |
 
 Your role is to be a guardian of quality while enabling velocity. Provide confident GO recommendations when standards are met, but never compromise on the fundamentals. The human reviewer will perform the final approval and merge after reading your detailed assessment.
+
+<!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -241,3 +241,5 @@ When delivering test reports, use this structure:
 ```
 
 You are meticulous, thorough, and relentlessly focused on quality. You balance speed with rigor, knowing when to dig deep and when to move fast. Your test plans and reports are the definitive source of truth for project quality.
+
+<!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -555,3 +555,5 @@ When in doubt, ask clarifying questions. Architecture is about making informed t
 ---
 
 You are ready to provide expert architectural guidance on cloud patterns, distributed systems, and domain-driven design.
+
+<!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ TEMPLATE: Fill in project-specific details below when using this template.
 
 ### Project Information
 
+- **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
 - **Project Name**: [Your project name]
 - **Repository**: [GitHub repo URL]
 - **Project Board**: [GitHub project board URL]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,63 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor:             VibeAcademy
+Licensed Work:        Agile Flow (all versions)
+                      The Licensed Work is (c) 2026 VibeAcademy.
+Additional Use Grant: You may use the Licensed Work for any purpose,
+                      including production use, except for offering a
+                      commercial product that competes with the Licensed
+                      Work (a developer workflow automation framework).
+Change Date:          2029-03-06
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed
+Work, please contact VibeAcademy.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create
+derivative works, redistribute, and make non-production use of the
+Licensed Work. The Licensor may make an Additional Use Grant, above,
+permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first
+publicly available distribution of a specific version of the Licensed
+Work under this License, whichever comes first, the Licensor hereby
+grants you rights under the terms of the Change License, and the rights
+granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or
+authorized resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative
+works of the Licensed Work, are subject to this License. This License
+applies separately for each version of the Licensed Work and the Change
+Date may vary for each version of the Licensed Work released by
+Licensor.
+
+You must conspicuously display this License on each original or modified
+copy of the Licensed Work. If you receive the Licensed Work in original
+or modified form from a third party, the terms and conditions set forth
+in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will
+automatically terminate your rights under this License for the current
+and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or
+logo of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS
+PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES
+AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION)
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+NON-INFRINGEMENT, AND TITLE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agile Flow
 
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
+
 A Claude Code project template that bootstraps a complete agile development workflow with specialized AI agents.
 
 ## Why This Exists
@@ -491,4 +493,9 @@ This is a template project. To contribute:
 
 ## License
 
-MIT License - Use freely for any project.
+Business Source License 1.1 — see [LICENSE](LICENSE) for full terms.
+
+You may use Agile Flow for any purpose, including production use, except
+for offering a commercial product that competes with Agile Flow (a
+developer workflow automation framework). On 2029-03-06, this version
+converts to the Apache License 2.0.


### PR DESCRIPTION
## Summary
- Add `LICENSE` file with BSL 1.1 terms (Licensor: VibeAcademy, Change Date: 2029-03-06, Change License: Apache 2.0)
- Additional use grant permits all use except competing commercial developer workflow products
- Add license badge to README.md and license explanation section
- Add license line to CLAUDE.md Project Information
- Add SPDX license headers (`BUSL-1.1`) to all 7 agent definition files

Closes #55

## Test plan
- [ ] Verify LICENSE file matches official BSL 1.1 template structure
- [ ] Verify Change Date is 2029-03-06 (3 years from today)
- [ ] Verify README badge renders correctly
- [ ] Verify no user-content files have license headers
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)