### PR TITLE
feat(versioning): add .agile-flow-version manifest file

### DIFF
--- a/.agile-flow-version
+++ b/.agile-flow-version
@@ -1,0 +1,13 @@
+{
+  "version": "0.1.0",
+  "installedAt": null,
+  "distribution": "template",
+  "syncDirectories": [
+    ".claude/agents",
+    ".claude/commands",
+    ".claude/hooks",
+    ".claude/skills",
+    "scripts",
+    "starters"
+  ]
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -931,6 +931,19 @@ phase4_workflow() {
 
     mark_phase_complete "phase4"
     print_success "Phase 4 complete! Workflow activated."
+
+    # Stamp installedAt in .agile-flow-version if not already set
+    if [ -f ".agile-flow-version" ]; then
+        local current_val
+        current_val=$(jq -r '.installedAt // "null"' .agile-flow-version 2>/dev/null)
+        if [ "$current_val" = "null" ]; then
+            local timestamp
+            timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            jq --arg ts "$timestamp" '.installedAt = $ts' .agile-flow-version > .agile-flow-version.tmp \
+                && mv .agile-flow-version.tmp .agile-flow-version
+            print_success "Stamped install time: $timestamp"
+        fi
+    fi
 }
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Create `.agile-flow-version` JSON manifest at repo root with version `0.1.0`, `installedAt: null`, `distribution: "template"`, and `syncDirectories` listing framework-owned paths
- Update `bootstrap.sh` to stamp `installedAt` with ISO 8601 timestamp on first run (only when field is null, idempotent on subsequent runs)
- Version synced to `package.json` version field

Closes #58

## Test plan
- [ ] `jq . .agile-flow-version` outputs valid JSON
- [ ] `version` field matches `package.json` version (`0.1.0`)
- [ ] `installedAt` is `null` in the template
- [ ] `syncDirectories` aligns with framework directories from DISTRIBUTION.md (#56)
- [ ] Run `bootstrap.sh` phase 4 and verify `installedAt` is populated
- [ ] Run `bootstrap.sh` again and verify `installedAt` is NOT overwritten
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)