### PR TITLE
feat(branding): add attribution and badges to Agile Flow

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -565,4 +565,5 @@ Next session: [date] - Focus on [specific area]
 
 Your goal is to ensure the team always has clear, high-value, well-defined work ready to pick up, while maintaining a healthy backlog that reflects the product vision.
 
+<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/agile-product-manager.md
+++ b/.claude/agents/agile-product-manager.md
@@ -473,4 +473,5 @@ When reporting on product decisions:
 
 Your goal is to ensure the product delivers value to customers and the business. You are the guardian of product-market fit, the voice of the customer, and the steward of strategic direction. Focus on outcomes over outputs, and always tie decisions back to customer value and business impact.
 
+<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -196,4 +196,5 @@ To add a new platform:
 4. Add rollback procedure to Rollback section
 5. Document required secrets in `docs/CI-CD-GUIDE.md`
 
+<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -362,4 +362,5 @@ from this template, since the template starts with a Python scaffolding.
 
 Remember: You are autonomous within the boundaries of the Ready column and trunk-based development workflow. Quality and correctness are more important than speed.
 
+<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -550,4 +550,5 @@ patterns and quality trends persist across sessions.
 
 Your role is to be a guardian of quality while enabling velocity. Provide confident GO recommendations when standards are met, but never compromise on the fundamentals. The human reviewer will perform the final approval and merge after reading your detailed assessment.
 
+<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -242,4 +242,5 @@ When delivering test reports, use this structure:
 
 You are meticulous, thorough, and relentlessly focused on quality. You balance speed with rigor, knowing when to dig deep and when to move fast. Your test plans and reports are the definitive source of truth for project quality.
 
+<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -556,4 +556,5 @@ When in doubt, ask clarifying questions. Architecture is about making informed t
 
 You are ready to provide expert architectural guidance on cloud patterns, distributed systems, and domain-driven design.
 
+<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- FRAMEWORK:START -->
 # Agile Flow
 
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-0.1.0-green.svg)](.agile-flow-version) [![Use this template](https://img.shields.io/badge/Use_this-template-2ea44f)](https://github.com/vibeacademy/agile-flow/generate)
 
 A Claude Code project template that bootstraps a complete agile development workflow with specialized AI agents.
 
@@ -492,6 +492,10 @@ This is a template project. To contribute:
 2. Make improvements to agent definitions or commands
 3. Submit PR with clear description of changes
 
+## Attribution
+
+Built with [Agile Flow](https://github.com/vibeacademy/agile-flow) by
+[VibeAcademy](https://vibeacademy.com).
 ## License
 
 Business Source License 1.1 — see [LICENSE](LICENSE) for full terms.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -976,6 +976,12 @@ show_completion() {
     echo "  - docs/PRODUCT-ROADMAP.md - Your roadmap"
     echo "  - docs/TECHNICAL-ARCHITECTURE.md - Your architecture"
     echo ""
+    local af_version="unknown"
+    if [ -f ".agile-flow-version" ]; then
+        af_version=$(jq -r '.version // "unknown"' .agile-flow-version 2>/dev/null)
+    fi
+    echo -e "Powered by ${CYAN}Agile Flow${NC} v${af_version} — https://github.com/vibeacademy/agile-flow"
+    echo ""
 }
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Add "Powered by Agile Flow vX.Y.Z" with link to bootstrap completion screen
- Add version badge and "Use this template" badge to README (alongside existing license badge)
- Add "Attribution" section to README linking to Agile Flow and VibeAcademy
- Add `<!-- Source: Agile Flow (...) -->` attribution comment to all 7 agent definition files

Closes vibeacademy/agile-flow-meta#60

## Test plan
- [ ] `bootstrap.sh` completion screen shows "Powered by Agile Flow" with version
- [ ] README renders 3 badges (license, version, template)
- [ ] README Attribution section links resolve
- [ ] No branding in user-content files
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)