### PR TITLE
fix(preview): clarify SUPABASE_PROJECT_REF docs and harden jq error handling

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -177,6 +177,13 @@ jobs:
               -H "Authorization: Bearer ${RENDER_API_KEY}" \
               -H "Accept: application/json")
 
+            if ! echo "$SERVICES_RESPONSE" | jq -e 'type' > /dev/null 2>&1; then
+              echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Render API returned non-JSON response"
+              echo "Response (first 500 chars): ${SERVICES_RESPONSE:0:500}"
+              sleep 10
+              continue
+            fi
+
             PREVIEW_SERVICE=$(echo "$SERVICES_RESPONSE" | jq -r --arg pr "$PR_NUMBER" \
               '[.[] | select(.service.name | test("pr-" + $pr + "$"; "i") or test("pr " + $pr + "$"; "i") or test("#" + $pr + "$"))] | .[0]')
 
@@ -191,10 +198,17 @@ jobs:
                 echo "preview_found=true" >> "$GITHUB_OUTPUT"
 
                 # Check current deploy status
-                DEPLOY_STATUS=$(curl -s -X GET \
+                DEPLOY_RESPONSE=$(curl -s -X GET \
                   "https://api.render.com/v1/services/${SVC_ID}/deploys?limit=1" \
                   -H "Authorization: Bearer ${RENDER_API_KEY}" \
-                  -H "Accept: application/json" | jq -r '.[0].deploy.status // "unknown"')
+                  -H "Accept: application/json")
+
+                if ! echo "$DEPLOY_RESPONSE" | jq -e 'type' > /dev/null 2>&1; then
+                  echo "WARNING: Deploy status API returned non-JSON: ${DEPLOY_RESPONSE:0:500}"
+                  DEPLOY_STATUS="unknown"
+                else
+                  DEPLOY_STATUS=$(echo "$DEPLOY_RESPONSE" | jq -r '.[0].deploy.status // "unknown"')
+                fi
 
                 echo "Current deploy status: $DEPLOY_STATUS"
                 echo "deploy_status=$DEPLOY_STATUS" >> "$GITHUB_OUTPUT"
@@ -224,10 +238,16 @@ jobs:
           elif [ -z "$SVC_ID" ] || [ "$SVC_ID" = "null" ]; then
             echo "WARNING: Could not find preview service after $MAX_ATTEMPTS attempts"
             echo "preview_found=false" >> "$GITHUB_OUTPUT"
-            BASE_NAME=$(curl -s -X GET \
+            BASE_NAME_RESPONSE=$(curl -s -X GET \
               "https://api.render.com/v1/services/${RENDER_SERVICE_ID}" \
               -H "Authorization: Bearer ${RENDER_API_KEY}" \
-              -H "Accept: application/json" | jq -r '.name // "app"')
+              -H "Accept: application/json")
+            if echo "$BASE_NAME_RESPONSE" | jq -e 'type' > /dev/null 2>&1; then
+              BASE_NAME=$(echo "$BASE_NAME_RESPONSE" | jq -r '.name // "app"')
+            else
+              echo "WARNING: Could not fetch base service name: ${BASE_NAME_RESPONSE:0:500}"
+              BASE_NAME="app"
+            fi
             echo "preview_url=https://${BASE_NAME}-pr-${PR_NUMBER}.onrender.com" >> "$GITHUB_OUTPUT"
           else
             # Service was found but deploy didn't reach terminal state in time
@@ -252,6 +272,13 @@ jobs:
             "https://api.render.com/v1/services/${PREVIEW_SERVICE_ID}/env-vars" \
             -H "Authorization: Bearer ${RENDER_API_KEY}" \
             -H "Accept: application/json")
+
+          if ! echo "$CURRENT_VARS" | jq -e 'type' > /dev/null 2>&1; then
+            echo "ERROR: Render env-vars API returned non-JSON response"
+            echo "Response (first 500 chars): ${CURRENT_VARS:0:500}"
+            echo "env_updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           echo "Current env vars count: $(echo "$CURRENT_VARS" | jq 'length')"
 
@@ -300,6 +327,13 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{"clearCache": "do_not_clear"}')
 
+          if ! echo "$DEPLOY_RESPONSE" | jq -e 'type' > /dev/null 2>&1; then
+            echo "ERROR: Render deploy API returned non-JSON response"
+            echo "Response (first 500 chars): ${DEPLOY_RESPONSE:0:500}"
+            echo "redeploy_triggered=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           DEPLOY_ID=$(echo "$DEPLOY_RESPONSE" | jq -r '.id // empty')
 
           if [ -n "$DEPLOY_ID" ] && [ "$DEPLOY_ID" != "null" ]; then
@@ -329,10 +363,17 @@ jobs:
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))
 
-            STATUS=$(curl -s -X GET \
+            POLL_RESPONSE=$(curl -s -X GET \
               "https://api.render.com/v1/services/${PREVIEW_SERVICE_ID}/deploys/${DEPLOY_ID}" \
               -H "Authorization: Bearer ${RENDER_API_KEY}" \
-              -H "Accept: application/json" | jq -r '.status // "unknown"')
+              -H "Accept: application/json")
+
+            if ! echo "$POLL_RESPONSE" | jq -e 'type' > /dev/null 2>&1; then
+              echo "WARNING: Deploy poll returned non-JSON: ${POLL_RESPONSE:0:500}"
+              STATUS="unknown"
+            else
+              STATUS=$(echo "$POLL_RESPONSE" | jq -r '.status // "unknown"')
+            fi
 
             echo "Deploy status: $STATUS (attempt $ATTEMPT/$MAX_ATTEMPTS)"
 
@@ -356,12 +397,17 @@ jobs:
           PREVIEW_SERVICE_ID="${{ steps.render_preview.outputs.preview_service_id }}"
 
           if [ -n "$PREVIEW_SERVICE_ID" ] && [ "$PREVIEW_SERVICE_ID" != "null" ]; then
-            FETCHED_URL=$(curl -s -X GET \
+            SVC_DETAIL_RESPONSE=$(curl -s -X GET \
               "https://api.render.com/v1/services/${PREVIEW_SERVICE_ID}" \
               -H "Authorization: Bearer ${RENDER_API_KEY}" \
-              -H "Accept: application/json" | jq -r '.serviceDetails.url // empty')
-            if [ -n "$FETCHED_URL" ]; then
-              PREVIEW_URL="$FETCHED_URL"
+              -H "Accept: application/json")
+            if echo "$SVC_DETAIL_RESPONSE" | jq -e 'type' > /dev/null 2>&1; then
+              FETCHED_URL=$(echo "$SVC_DETAIL_RESPONSE" | jq -r '.serviceDetails.url // empty')
+              if [ -n "$FETCHED_URL" ]; then
+                PREVIEW_URL="$FETCHED_URL"
+              fi
+            else
+              echo "WARNING: Could not fetch service details: ${SVC_DETAIL_RESPONSE:0:500}"
             fi
           fi
 

--- a/docs/CI-CD-GUIDE.md
+++ b/docs/CI-CD-GUIDE.md
@@ -113,7 +113,7 @@ configured in this template).
 | Secret | Where to Find |
 |--------|--------------|
 | `SUPABASE_ACCESS_TOKEN` | Supabase Dashboard > Account > Access Tokens |
-| `SUPABASE_PROJECT_REF` | Supabase Dashboard > Project Settings > General (Reference ID) |
+| `SUPABASE_PROJECT_REF` | Supabase Dashboard > Project Settings > General (Reference ID). Use the project where the GitHub integration is installed (creates branch DBs on PR) -- typically production, NOT staging. |
 
 When Supabase is configured, the workflow:
 

--- a/docs/EPHEMERAL-PR-ENVIRONMENTS.md
+++ b/docs/EPHEMERAL-PR-ENVIRONMENTS.md
@@ -94,7 +94,12 @@ Configure these in **Repository Settings > Secrets and variables > Actions**:
 │                             │  Access Tokens                        │
 ├─────────────────────────────┼───────────────────────────────────────┤
 │  SUPABASE_PROJECT_REF       │  Supabase Dashboard > Project         │
-│                             │  Settings > General (Reference ID)    │
+│                             │  Settings > General (Reference ID).   │
+│                             │  Use the project where the GitHub     │
+│                             │  integration is installed (the one    │
+│                             │  that creates branch databases on     │
+│                             │  PR). Typically production, NOT       │
+│                             │  staging.                             │
 ├─────────────────────────────┼───────────────────────────────────────┤
 │  SUPABASE_DB_URL (optional) │  Supabase Dashboard > Project         │
 │                             │  Settings > Database > Connection     │
@@ -217,6 +222,32 @@ The system works even with partial configuration:
 | `RENDER_API_KEY` | Workflow skipped entirely |
 | `RENDER_SERVICE_ID` | Workflow skipped entirely |
 | `SUPABASE_DB_URL` | Production migrations skipped; preview flow unaffected |
+
+---
+
+## Troubleshooting
+
+### PostgREST schema cache not refreshed
+
+If you apply DDL changes to a branch database outside of `supabase db push`
+(e.g., via the Management API or a direct SQL connection), PostgREST may
+continue serving the old schema. Reload the cache by running this SQL
+against the branch database:
+
+```sql
+NOTIFY pgrst, 'reload schema';
+```
+
+The standard `supabase db push` migration flow handles this automatically.
+
+### Wrong `SUPABASE_PROJECT_REF`
+
+If your preview environment silently falls back to production data instead
+of using an isolated branch database, check that `SUPABASE_PROJECT_REF`
+points to the project where the Supabase GitHub integration is installed.
+Users with multiple Supabase projects (staging + production) commonly set
+this to the wrong one. See the [Required Secrets](#required-secrets) table
+above.
 
 ---
 

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -215,7 +215,7 @@ Postgres cannot do this (all preview environments share the same database).
 | Secret | Where to Find |
 |--------|--------------|
 | `SUPABASE_ACCESS_TOKEN` | Supabase Dashboard > Account > Access Tokens |
-| `SUPABASE_PROJECT_REF` | Supabase Dashboard > Project Settings > General (the `Reference ID`) |
+| `SUPABASE_PROJECT_REF` | Supabase Dashboard > Project Settings > General (the `Reference ID`). Use the project where the GitHub integration is installed (creates branch DBs on PR) -- typically production, NOT staging. |
 
 1. **For production deploys**, also add:
 


### PR DESCRIPTION
## Summary

- Clarifies `SUPABASE_PROJECT_REF` across all docs to specify it must point to the project where the Supabase GitHub integration is installed (typically production, NOT staging). Fixes silent fallback to non-isolated data for users with multiple Supabase projects.
- Adds JSON type-check guards (`jq -e 'type'`) before every `jq` call in `preview-deploy.yml`. When APIs return HTML error pages, rate-limit responses, or empty bodies, the workflow now produces clear diagnostics instead of cryptic parse errors.
- Adds Troubleshooting section to `EPHEMERAL-PR-ENVIRONMENTS.md` with PostgREST schema cache reload guidance.

Closes vibeacademy/agile-flow-meta#64

## Changes

| File | Change |
|------|--------|
| `docs/EPHEMERAL-PR-ENVIRONMENTS.md` | Clarified SUPABASE_PROJECT_REF in secrets table; added Troubleshooting section |
| `docs/CI-CD-GUIDE.md` | Clarified SUPABASE_PROJECT_REF description |
| `docs/PLATFORM-GUIDE.md` | Clarified SUPABASE_PROJECT_REF description |
| `.github/workflows/preview-deploy.yml` | Added 7 JSON validation guards before jq calls |

## Test plan

- [ ] Verify `grep -n 'jq' .github/workflows/preview-deploy.yml` shows every `jq` call is preceded by a type-check guard or is inside a guarded block
- [ ] Verify all `SUPABASE_PROJECT_REF` references include "typically production, NOT staging" clarification
- [ ] `npm run lint` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)