### PR TITLE
ci(version): add version parity check for .agile-flow-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Validate JSON files
         run: ./scripts/validation/validate-json.sh
 
+      - name: Validate version parity
+        run: ./scripts/validation/validate-version-parity.sh
+
   build:
     name: build
     runs-on: ubuntu-latest

--- a/scripts/validation/validate-version-parity.sh
+++ b/scripts/validation/validate-version-parity.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Validates that .agile-flow-version and package.json agree on the version field.
+# Runs in CI to prevent version drift between the two files.
+
+set -euo pipefail
+
+MANIFEST=".agile-flow-version"
+PACKAGE="package.json"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "SKIP: $MANIFEST not found (not yet bootstrapped)"
+  exit 0
+fi
+
+if [ ! -f "$PACKAGE" ]; then
+  echo "SKIP: $PACKAGE not found (non-Node project)"
+  exit 0
+fi
+
+MANIFEST_VERSION=$(jq -r '.version // empty' "$MANIFEST")
+PACKAGE_VERSION=$(jq -r '.version // empty' "$PACKAGE")
+
+if [ -z "$MANIFEST_VERSION" ]; then
+  echo "FAIL: $MANIFEST has no version field"
+  exit 1
+fi
+
+if [ -z "$PACKAGE_VERSION" ]; then
+  echo "FAIL: $PACKAGE has no version field"
+  exit 1
+fi
+
+if [ "$MANIFEST_VERSION" != "$PACKAGE_VERSION" ]; then
+  echo "FAIL: Version mismatch"
+  echo "  $MANIFEST: $MANIFEST_VERSION"
+  echo "  $PACKAGE:  $PACKAGE_VERSION"
+  echo ""
+  echo "Update both files to the same version before merging."
+  exit 1
+fi
+
+echo "PASS: Version $MANIFEST_VERSION matches across $MANIFEST and $PACKAGE"


### PR DESCRIPTION
## Summary

- Adds `scripts/validation/validate-version-parity.sh` that fails CI when `.agile-flow-version` and `package.json` have different version values
- Adds the check to the `typecheck` job in `ci.yml`
- Gracefully skips if either file is missing (non-bootstrapped or non-Node projects)

This was the missing DoD item from ticket #58 (version manifest). Caught during full audit of all session tickets.

## Test plan

- [ ] `./scripts/validation/validate-version-parity.sh` passes locally (both files at 0.1.0)
- [ ] Manually change version in `.agile-flow-version` to `0.2.0`, re-run script — should FAIL
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)