### PR TITLE
feat(docs): add Agent Output Format standard to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,39 @@ permissions.
 - Code blocks with language specifiers
 - Tables for structured data
 
+### Agent Output Format
+
+Every agent output MUST follow these patterns. Full spec: `docs/AGENT-OUTPUT-STANDARD.md`
+
+**Result Block** — every completed action ends with:
+
+```
+---
+
+**Result:** <one-line outcome>
+<key-value pairs, one per line>
+```
+
+**Progress Lines** — multi-step workflows report each step:
+
+```
+→ Step completed
+✗ Step failed — see output above
+```
+
+**Standard Vocabulary** — use these terms only, no synonyms:
+
+| Category | Terms |
+|----------|-------|
+| Decisions | GO / NO-GO / CONDITIONAL |
+| Status | On Track / At Risk / Blocked |
+| Findings | Required change (blocking) / Suggestion (non-blocking) |
+| Effort | S (1-4h) / M (0.5-2d) / L (2-5d) / XL (5+d) |
+
+**GitHub References** — first mention: `#N — title`. Subsequent: bare `#N`.
+
+**Section Order** (multi-section reports): Context → Findings → Recommendations → Result Block
+
 <!-- FRAMEWORK:END -->
 
 ---


### PR DESCRIPTION
## Summary
- Adds concise "Agent Output Format" section to CLAUDE.md inside `<!-- FRAMEWORK:START -->` markers
- Covers Result Block template, Progress Lines, standard vocabulary, GitHub reference format, and section ordering
- 33 lines added (under the 40-line ticket limit), references `docs/AGENT-OUTPUT-STANDARD.md` for full spec

Closes vibeacademy/agile-flow-meta#67

## Test plan
- [x] Verify the new section appears after "Formatting Standards" and before `<!-- FRAMEWORK:END -->`
- [x] Confirm section is under 40 lines
- [x] Confirm `docs/AGENT-OUTPUT-STANDARD.md` is referenced
- [x] Verify Result Block template, Progress Line format, vocabulary table, and GitHub reference format are all present
- [x] Run markdownlint — no new errors introduced (pre-existing MD060 on all tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)