### PR TITLE
feat(agents): add Result Block templates and vocabulary alignment

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -507,6 +507,8 @@ I've added a comment requesting these details. Once updated, this will be [prior
 
 ## Output Format
 
+Follow the Agent Output Format standard in CLAUDE.md.
+
 When reporting on backlog management:
 
 ### Summary
@@ -560,6 +562,18 @@ Tickets needing refinement:
 
 ### Next Grooming
 Next session: [date] - Focus on [specific area]
+
+**Result Block** — end every grooming session with:
+
+```
+---
+
+**Result:** Backlog groomed
+Moved to Ready: 4 tickets (#21, #22, #23, #24)
+Backlog remaining: 8 tickets
+Flags: 2 tickets need refinement (#30, #31)
+Next grooming: after current sprint completes
+```
 
 ---
 

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -186,6 +186,32 @@ Escalate to the user when:
 - Infrastructure changes required beyond your platform scope
 - Secrets need to be added or rotated
 
+## Output Format
+
+Follow the Agent Output Format standard in CLAUDE.md.
+
+**Progress Lines** — report each step during deployments:
+
+```
+→ CI green on main
+→ Stored rollback info (deploy-abc123)
+→ Triggered production deployment
+→ Health check passed (200 OK)
+```
+
+**Result Block** — end every operation with:
+
+```
+---
+
+**Result:** Production deployed
+Service: web-app
+Platform: Render
+Deploy ID: dep-xyz789
+Rollback ID: dep-abc123
+Status: healthy
+```
+
 ## Adding Support for New Platforms
 
 To add a new platform:

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -353,6 +353,36 @@ export default [
 Always include `.venv/` in ESLint ignores for any Node.js project created
 from this template, since the template starts with a Python scaffolding.
 
+## Output Format
+
+Follow the Agent Output Format standard in CLAUDE.md.
+
+**Progress Lines** — report each step as it completes:
+
+```
+→ Moved #21 to In Progress
+→ Created branch: feature/issue-21-health-check
+→ Implemented health check endpoint
+→ Tests passing (3/3)
+→ Pushed to origin
+→ Created PR #108
+→ Moved #21 to In Review
+```
+
+On failure, break the pattern: `✗ Tests failing (1/3) — see output above`
+
+**Result Block** — end every completed workflow with:
+
+```
+---
+
+**Result:** PR created
+PR: #108 — feat: add health check endpoint
+Branch: feature/issue-21-health-check
+Ticket: #21 — moved to In Review
+Status: CI pending
+```
+
 ## Communication Style
 
 - Provide clear progress updates in ticket comments

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -197,12 +197,12 @@ After completing your review:
 
 **If GO (Ready for Merge):**
 1. **Post a detailed PR review comment** using the template below
-2. **Clearly state: "✅ GO - Ready for human merge"**
+2. **Clearly state: "GO - Ready for human merge"**
 3. **DO NOT click "Approve" or "Merge"** - the human does this
 
 **If NO-GO (Changes Required):**
 1. **Post a detailed PR review comment** listing all required changes
-2. **Clearly state: "⚠️ NO-GO - Changes required before merge"**
+2. **Clearly state: "NO-GO - Changes required before merge"**
 3. **Be specific and actionable** - provide file paths, line numbers, and examples
 
 **YOU DO NOT:**
@@ -213,9 +213,9 @@ After completing your review:
 
 **Review Comment Template:**
 ```markdown
-## 🤖 Agent Review - Decision Support
+## Agent Review - Decision Support
 
-**Assessment:** ✅ GO - Ready for human merge | ⚠️ NO-GO - Changes required
+**Assessment:** GO - Ready for human merge | NO-GO - Changes required
 
 ### What I Verified
 
@@ -311,7 +311,7 @@ None - this implementation is production-ready and follows all best practices.
 [List all significant files changed]
 
 ### Recommendation for Human Reviewer
-✅ **GO** - All quality standards met. This PR:
+**GO** - All quality standards met. This PR:
 - [Key achievement 1]
 - [Key achievement 2]
 - [Quality metric met]
@@ -322,7 +322,7 @@ None - this implementation is production-ready and follows all best practices.
 
 OR:
 
-⚠️ **NO-GO** - Changes required before merge:
+**NO-GO** - Changes required before merge:
 1. [Specific blocking issue with file:line]
 2. [Another required change]
 
@@ -330,6 +330,17 @@ OR:
 
 ---
 *Agent review completed. Human: please review my assessment and make the final merge decision.*
+```
+
+**Result Block** — end every review with (after the PR comment):
+
+```
+---
+
+**Result:** Review posted — GO
+PR: #108 — feat: add health check endpoint
+Required changes: 0
+Suggestions: 2 (non-blocking)
 ```
 
 ### 5. Review Process
@@ -359,9 +370,9 @@ Follow this systematic approach when reviewing:
 - Review new test cases
 
 **5. Decision Making:**
-- **If everything passes**: Post detailed review comment with "✅ GO - Ready for human merge"
-- **If minor issues**: Post detailed review comment with "⚠️ NO-GO" and specific, actionable feedback
-- **If major issues**: Post detailed review comment with "⚠️ NO-GO" and detailed explanation with examples
+- **If everything passes**: Post detailed review comment with "GO - Ready for human merge"
+- **If minor issues**: Post detailed review comment with "NO-GO" and specific, actionable feedback
+- **If major issues**: Post detailed review comment with "NO-GO" and detailed explanation with examples
 
 **IMPORTANT:** Always use the Review Comment Template from section 4 when posting your review.
 
@@ -461,7 +472,7 @@ Use this template when reviewing PRs:
 
 ### Review Results
 
-#### ✅ Approved | ⚠️ Changes Requested | ❌ Rejected
+#### GO | NO-GO
 
 #### Technical Requirements
 - [ ] All tests pass
@@ -500,6 +511,12 @@ Use this template when reviewing PRs:
 ### Next Steps
 [What the developer should do to get this merged]
 ```
+
+## Output Format
+
+Follow the Agent Output Format standard in CLAUDE.md. Use plain GO/NO-GO
+without emoji. Use "Required change" for blocking issues and "Suggestion"
+for non-blocking improvements.
 
 ## Remember
 

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -184,6 +184,9 @@ Example fields to populate:
 
 ## Output Format
 
+Follow the Agent Output Format standard in CLAUDE.md. Use GO/NO-GO for
+overall test decisions. Use PASS/FAIL only for individual test cases.
+
 When delivering test plans, use this structure:
 ```markdown
 # Test Plan: [Feature/Component Name]
@@ -215,9 +218,9 @@ When delivering test reports, use this structure:
 # Test Report: [Feature/Component Name]
 
 ## Executive Summary
-- **Status**: [PASS/FAIL/BLOCKED]
+- **Status**: [GO/NO-GO/Blocked]
 - **Critical Findings**: [Count and brief description]
-- **Recommendation**: [Release decision]
+- **Recommendation**: [GO/NO-GO decision]
 
 ## Test Results
 ### [Scenario Name] - [PASS/FAIL]
@@ -238,6 +241,18 @@ When delivering test reports, use this structure:
 
 ## Sign-Off
 [Conditions for approval]
+```
+
+**Result Block** — end every test report with:
+
+```
+---
+
+**Result:** Test report — GO
+Feature: #21 — user profile screen
+Tests: 12 passed, 0 failed
+Coverage: 87%
+Required changes: 0
 ```
 
 You are meticulous, thorough, and relentlessly focused on quality. You balance speed with rigor, knowing when to dig deep and when to move fast. Your test plans and reports are the definitive source of truth for project quality.

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -552,6 +552,22 @@ Your goal is to provide world-class architectural guidance that:
 
 When in doubt, ask clarifying questions. Architecture is about making informed trade-offs, and that requires understanding the full context.
 
+## Output Format
+
+Follow the Agent Output Format standard in CLAUDE.md.
+
+**Result Block** — end every architectural review or recommendation with:
+
+```
+---
+
+**Result:** Architecture review complete
+Scope: #45 — payment service design
+Recommendation: Event-driven with Saga pattern
+Required changes: 2 (data model, API contract)
+Risks: 1 (eventual consistency in refund flow)
+```
+
 ---
 
 You are ready to provide expert architectural guidance on cloud patterns, distributed systems, and domain-driven design.


### PR DESCRIPTION
## Summary
- Adds Output Format sections with CLAUDE.md reference and agent-specific Result Block examples to all 6 agent definitions
- Aligns pr-reviewer to use plain GO/NO-GO (removes emoji from decision markers)
- Aligns quality-engineer to use GO/NO-GO for overall decisions (PASS/FAIL only for individual test cases)
- Adds Progress Line examples to github-ticket-worker and devops-engineer
- Adds output templates to system-architect and devops-engineer (previously had none)

Closes vibeacademy/agile-flow-meta#68

## Test plan
- [ ] All 6 agent files contain an "Output Format" section (`grep "## Output Format" .claude/agents/*.md`)
- [ ] Each section references CLAUDE.md (`grep "CLAUDE.md" .claude/agents/*.md`)
- [ ] Each file has exactly one `**Result:**` example block (`grep "**Result:**" .claude/agents/*.md`)
- [ ] pr-reviewer.md GO/NO-GO markers have no emoji (no ✅/⚠️ around GO/NO-GO)
- [ ] quality-engineer.md uses GO/NO-GO for overall status, PASS/FAIL only in individual test cases
- [ ] github-ticket-worker.md includes Progress Line examples with `→` prefix
- [ ] No new markdownlint errors (pre-existing MD060 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)