### PR TITLE
feat(commands): add Result Block to high-traffic slash commands

### DIFF
--- a/.claude/commands/check-milestone.md
+++ b/.claude/commands/check-milestone.md
@@ -49,7 +49,7 @@ Launch the agile-backlog-prioritizer agent to assess progress toward a specific 
 ## Milestone: <Name>
 **Target Date**: <Date from roadmap>
 **Projected Date**: <Based on velocity>
-**Status**: On Track | At Risk | Behind Schedule
+**Status**: On Track | At Risk | Blocked
 
 ### Progress Summary
 - Completed: X tasks (Y%)
@@ -97,3 +97,17 @@ Define milestones in `docs/PRODUCT-ROADMAP.md`:
 - Update PRODUCT-ROADMAP.md if dates need adjustment
 - Create new issues if gaps are identified
 - Defer scope to next milestone rather than compromise quality
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Milestone check — On Track
+Milestone: MVP Release (target: March 15)
+Progress: 12/18 tasks (67%)
+Blockers: 1 (#34 — API dependency)
+Projected: March 13 (-2 days)
+```

--- a/.claude/commands/create-ticket.md
+++ b/.claude/commands/create-ticket.md
@@ -70,3 +70,17 @@ Before showing the draft to the user, verify:
 /create-ticket
 /create-ticket Add health check endpoint to the API
 ```
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Ticket created
+Issue: #45 — feat: add health check endpoint
+Priority: P1
+Size: S
+Column: Backlog
+```

--- a/.claude/commands/groom-backlog.md
+++ b/.claude/commands/groom-backlog.md
@@ -66,3 +66,17 @@ The agent will report:
 - Recommendations for next grooming session
 
 See `docs/TICKET-FORMAT.md` for the canonical ticket format specification.
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Backlog groomed
+Moved to Ready: 4 tickets (#21, #22, #23, #24)
+Backlog remaining: 8 tickets
+Flags: 2 tickets need refinement (#30, #31)
+Next grooming: after current sprint completes
+```

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -105,3 +105,16 @@ Escalate to the human reviewer with a detailed comment when:
 - **Disagreement with approach** — The implementation works but a fundamentally different approach would be better
 
 **Escalation format**: Start the comment with `⚠️ ESCALATION` and explain the concern, the options, and a recommendation.
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Review posted — GO
+PR: #108 — feat: add health check endpoint
+Required changes: 0
+Suggestions: 2 (non-blocking)
+```

--- a/.claude/commands/sprint-status.md
+++ b/.claude/commands/sprint-status.md
@@ -90,3 +90,16 @@ Launch the agile-backlog-prioritizer agent to provide a quick status overview of
 - `/check-milestone` - Progress toward specific milestone
 - `/work-ticket` - Pick up next ticket from Ready
 - `/review-pr` - Review pending pull requests
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Sprint status — On Track
+Ready: 3 | In Progress: 2 | In Review: 1 | Done: 8
+Blockers: 0
+Action items: 2
+```

--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -144,3 +144,25 @@ what's failing, and recommended next steps.
 - Only work on tickets from the Ready column
 - One ticket at a time (no parallel work)
 - Agent is responsible for delivering a clean, CI-passing PR
+
+### Output Format
+
+Report each step with a Progress Line, then end your output with a Result Block:
+
+```
+→ Moved #21 to In Progress
+→ Created branch: feature/issue-21-health-check
+→ Implemented health check endpoint
+→ Tests passing (3/3)
+→ Pushed to origin
+→ Created PR #108
+→ Moved #21 to In Review
+
+---
+
+**Result:** PR created
+PR: #108 — feat: add health check endpoint
+Branch: feature/issue-21-health-check
+Ticket: #21 — moved to In Review
+Status: CI pending
+```


### PR DESCRIPTION
## Summary
- Adds output format instructions with Result Block templates to 6 high-traffic slash commands
- `work-ticket.md` includes Progress Lines (`→` prefix) + Result Block
- `review-pr.md` Result Block includes GO/NO-GO on the Result line
- `check-milestone.md` vocabulary aligned: "Behind Schedule" → "Blocked"
- `groom-backlog.md`, `sprint-status.md`, `create-ticket.md` get Result Blocks
- Additions are 5-15 lines per file per guardrails

Closes vibeacademy/agile-flow-meta#69

## Test plan
- [ ] All 6 command files contain `**Result:**` (`grep "Result:" .claude/commands/{work-ticket,review-pr,groom-backlog,sprint-status,check-milestone,create-ticket}.md`)
- [ ] `work-ticket.md` includes Progress Line examples with `→` prefix
- [ ] `check-milestone.md` uses On Track/At Risk/Blocked (not Behind Schedule)
- [ ] `review-pr.md` Result Block includes GO/NO-GO
- [ ] No command logic was modified (only output format additions)
- [ ] No new markdownlint errors (pre-existing MD060 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)