### PR TITLE
feat(commands): add Result Block to remaining slash commands

### DIFF
--- a/.claude/commands/architect-review.md
+++ b/.claude/commands/architect-review.md
@@ -119,3 +119,17 @@ Proposed
 ```
 /architect-review "How to scale the search service to 10x traffic"
 ```
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Architecture review complete
+Topic: Authentication service design
+Recommendation: OAuth2 with PKCE flow
+Options evaluated: 3
+Risks: 1 (token refresh complexity)
+```

--- a/.claude/commands/bootstrap-agents.md
+++ b/.claude/commands/bootstrap-agents.md
@@ -164,3 +164,21 @@ If you need to reset agents to template state:
 # Re-copy from template (loses customizations)
 git checkout -- .claude/agents/
 ```
+
+### Output Format
+
+Report each phase with a Progress Line, then end with a Result Block:
+
+```
+→ Read PRD and architecture docs
+→ Updated quality-engineer with project context
+→ Updated system-architect with platform details
+→ Updated 4 remaining agents
+
+---
+
+**Result:** Agent specialization complete
+Agents updated: 6
+Source: docs/PRODUCT-REQUIREMENTS.md, docs/TECHNICAL-ARCHITECTURE.md
+Next: /bootstrap-workflow
+```

--- a/.claude/commands/bootstrap-architecture.md
+++ b/.claude/commands/bootstrap-architecture.md
@@ -393,3 +393,22 @@ export default [
 ```
 
 This prevents ESLint from attempting to parse Python virtualenv files.
+
+### Output Format
+
+Report each phase with a Progress Line, then end with a Result Block:
+
+```
+→ Read PRODUCT-REQUIREMENTS.md
+→ Selected platform: Render
+→ Defined tech stack and data models
+→ Generated TECHNICAL-ARCHITECTURE.md
+
+---
+
+**Result:** Architecture definition complete
+Document: docs/TECHNICAL-ARCHITECTURE.md
+Platform: Render
+Stack: Next.js, Supabase, TypeScript
+Next: /bootstrap-agents
+```

--- a/.claude/commands/bootstrap-product.md
+++ b/.claude/commands/bootstrap-product.md
@@ -380,3 +380,21 @@ After completing this questionnaire:
 1. Review the generated PRD and Roadmap
 2. Run `/bootstrap-architecture` for Phase 2 (Technical Architecture)
 3. The System Architect will reference your PRD for technical decisions
+
+### Output Format
+
+Report each phase with a Progress Line, then end with a Result Block:
+
+```
+→ Loaded 2 research artifacts
+→ Completed questionnaire (25 questions)
+→ Generated PRODUCT-REQUIREMENTS.md
+→ Generated PRODUCT-ROADMAP.md
+
+---
+
+**Result:** Product definition complete
+Documents: docs/PRODUCT-REQUIREMENTS.md, docs/PRODUCT-ROADMAP.md
+Features defined: 8 (3 MVP, 5 future)
+Next: /bootstrap-architecture
+```

--- a/.claude/commands/bootstrap-workflow.md
+++ b/.claude/commands/bootstrap-workflow.md
@@ -286,3 +286,22 @@ After bootstrap:
 3. **Invite team members** - Share repo access
 4. **Set up CI/CD** - Configure GitHub Actions
 5. **Schedule standups** - Daily `/sprint-status`
+
+### Output Format
+
+Report each phase with a Progress Line, then end with a Result Block:
+
+```
+→ Configured GitHub project board
+→ Set up branch protection rules
+→ Generated backlog from PRD (12 issues)
+→ Populated Ready column (4 tickets)
+
+---
+
+**Result:** Workflow setup complete
+Project board: configured
+Issues created: 12
+Ready column: 4 tickets
+Status: ready for development
+```

--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -81,3 +81,16 @@ configuration. Surfaces every issue that could block a workshop participant.
   404 or 403 for users without admin access. Map these responses to
   WARN or SKIP rather than FAIL — the checks are informational and do
   not indicate a broken setup.
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Health check complete
+Local: 8 pass, 1 warn, 0 fail
+Remote: 3 pass, 1 warn, 0 fail
+Ready for workshop: YES
+```

--- a/.claude/commands/evaluate-feature.md
+++ b/.claude/commands/evaluate-feature.md
@@ -91,3 +91,17 @@ The **Product Manager** (agile-product-manager) owns this decision.
 After evaluation:
 - If BUILD: Product Owner (agile-backlog-prioritizer) handles execution planning
 - If DEFER/DECLINE: Product Manager communicates decision
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Feature evaluation — BUILD
+Feature: Bulk export for enterprise users
+Strategic fit: Strong
+Revenue impact: High
+Handoff: Product Owner for execution planning
+```

--- a/.claude/commands/jtbd.md
+++ b/.claude/commands/jtbd.md
@@ -222,3 +222,17 @@ Write the output to **`docs/JOBS-TO-BE-DONE.md`** using the template below.
 After completing JTBD analysis:
 1. Run `/positioning` to define product positioning (uses both market research and JTBD as input)
 2. Run `/bootstrap-product` to create the PRD (reads all three artifacts and pre-populates questions)
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** JTBD analysis complete
+Core job: Manage class schedules and fill open slots
+Pain points identified: 4
+Underserved needs: 3
+Document: docs/JOBS-TO-BE-DONE.md
+```

--- a/.claude/commands/lock-scope.md
+++ b/.claude/commands/lock-scope.md
@@ -262,3 +262,18 @@ Scope is now locked. Next steps:
 
 Remember: Adding scope now requires a formal trade-off discussion.
 ```
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Scope locked
+Status: LOCKED
+Target launch: Q2 2025
+Features in scope: 12
+Open items: 0
+Document: docs/SCOPE-LOCK.md
+```

--- a/.claude/commands/positioning.md
+++ b/.claude/commands/positioning.md
@@ -231,3 +231,17 @@ Write the output to **`docs/POSITIONING-ANALYSIS.md`** using the template below.
 After completing positioning analysis:
 1. Run `/bootstrap-product` to create the PRD — it will read all three research artifacts (market research, JTBD, positioning) and pre-populate 10 of 25 questions automatically
 2. Your positioning statement will appear directly in the PRD's value proposition
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Positioning analysis complete
+Category: Boutique fitness management
+Strategy: Win subsegment
+Alternatives evaluated: 4
+Document: docs/POSITIONING-ANALYSIS.md
+```

--- a/.claude/commands/release-decision.md
+++ b/.claude/commands/release-decision.md
@@ -102,3 +102,17 @@ The Product Owner provides input on:
 - Delivery completeness
 - Technical quality
 - Team readiness
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Release decision — GO
+Release: v2.0
+Risks: 1 medium (monitoring coverage)
+Conditions: none
+Recommended date: March 15
+```

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -186,3 +186,17 @@ After completing market research:
 1. Run `/jtbd` to analyze user jobs and pain points (uses this research as input)
 2. Run `/positioning` to define product positioning (uses both prior artifacts)
 3. Run `/bootstrap-product` to create the PRD (reads all three artifacts and pre-populates questions)
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Market research complete
+Industry: SaaS / Developer Tools
+Competitors analyzed: 5
+Confidence: Partially validated
+Document: docs/MARKET-RESEARCH.md
+```

--- a/.claude/commands/test-feature.md
+++ b/.claude/commands/test-feature.md
@@ -116,3 +116,17 @@ Launch the quality-engineer agent to create a comprehensive test plan and/or exe
 - After completing implementation
 - Before release to validate critical paths
 - When investigating reported bugs
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Test report — GO
+Feature: user authentication flow
+Tests: 8 passed, 0 failed
+Coverage: 91%
+Required changes: 0
+```


### PR DESCRIPTION
## Summary
- Adds output format instructions with Result Block templates to all 13 remaining slash commands
- Bootstrap commands (4) include Progress Lines (`→` prefix) for multi-step workflows
- `release-decision.md` uses GO/NO-GO/CONDITIONAL vocabulary
- `evaluate-feature.md` uses BUILD/DEFER/DECLINE vocabulary (domain-specific, intentional)
- All 19 slash commands now have standardized output — 100% coverage of the Agent Output Standard

Closes vibeacademy/agile-flow-meta#70

## Test plan
- [ ] All command files contain `**Result:**` (`grep "Result:" .claude/commands/*.md` — expect 19 matches across 19 files)
- [ ] Bootstrap commands include Progress Line examples with `→` prefix
- [ ] `release-decision.md` uses GO/NO-GO/CONDITIONAL
- [ ] `evaluate-feature.md` uses BUILD/DEFER/DECLINE
- [ ] No command logic was modified (only output format additions appended)
- [ ] No new markdownlint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)