### PR TITLE
feat(commands): add optional URI input to /research command

### DIFF
--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -72,6 +72,16 @@ What geographic focus, if any?
 Enter a number (1-5) or describe:
 ```
 
+**Question 6 (Optional)**
+```
+Do you have any specific URLs you'd like included in the research?
+(articles, competitor pages, market reports, pricing pages, etc.)
+
+Paste up to 5 URLs, one per line.
+
+Type "skip" to continue without.
+```
+
 ---
 
 ## After Collecting All Responses
@@ -96,11 +106,19 @@ Attempt to use `WebSearch` to gather real market data. Run searches in parallel 
 
 For each search result, note the source URL for the Sources section.
 
-**If `WebSearch` is unavailable:** Skip web research entirely. Instead, conduct a structured interview — ask 3-5 follow-up questions to extract what the user already knows about the market, competitors, and audience. Note all findings as "User-reported (not web-validated)" in the confidence labels.
+**User-provided URLs (from Q6):**
+
+If the user provided URLs in Q6, fetch each one using `WebFetch` after the `WebSearch` queries complete. Run fetches in parallel where possible:
+
+- Extract key findings from each URL (market data, competitor info, pricing, audience insights)
+- Categorize findings by the section they inform (Market Overview, Competitor Analysis, Target Audience)
+- Use the original URL as the source attribution in the Sources section
+
+**If `WebSearch` is unavailable:** Skip web search entirely. Instead, conduct a structured interview — ask 3-5 follow-up questions to extract what the user already knows about the market, competitors, and audience. Note all findings as "User-reported (not web-validated)" in the confidence labels. However, if the user provided URLs in Q6, still fetch those using `WebFetch` — URL fetching does not depend on `WebSearch` availability.
 
 ### Phase 2: Synthesize
 
-Combine user answers with web research findings. For each section, assign a confidence label:
+Combine user answers, web research findings, and any content fetched from user-provided URLs. For each section, assign a confidence label:
 
 | Label | Meaning |
 |-------|---------|


### PR DESCRIPTION
## Summary

- Adds optional Question 6 to the `/research` questionnaire for user-provided URLs (up to 5)
- URLs are fetched via `WebFetch` during Phase 1, after existing `WebSearch` queries complete
- Fetched content is incorporated into Phase 2 synthesis with source attribution
- `WebSearch`-unavailable fallback updated to still fetch user-provided URLs independently

Closes #129

## Test plan

- [ ] Run `/research` and verify Q6 appears after Q5 as optional
- [ ] Provide URLs at Q6 and verify they are fetched and incorporated into the output
- [ ] Type "skip" at Q6 and verify the command proceeds without fetching
- [ ] Test with `WebSearch` unavailable — verify user URLs are still fetched via `WebFetch`
- [ ] Verify output template is unchanged (no structural modifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)