### PR TITLE
fix(deploy): copy static assets for Next.js standalone on Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: agile-flow-starter
     runtime: node
     plan: free
-    buildCommand: npm install && npm run build
+    buildCommand: npm install && npm run build && cp -r .next/static .next/standalone/.next/static
     startCommand: node .next/standalone/server.js
     healthCheckPath: /api/health
     previewsEnabled: true


### PR DESCRIPTION
## Summary

- Fixes 404 on page routes when deploying Next.js standalone to Render
- Copies `.next/static/` into `.next/standalone/.next/static/` after build
- API routes were unaffected; only page routes (e.g., `/`) returned 404

Quick fix — no linked ticket.

## Test plan

- [ ] Deploy to Render and verify `GET /` returns the Agile Flow landing page (not 404)
- [ ] Verify `GET /api/health` still returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)