### PR TITLE
fix(telemetry): restore instrumentation.ts deleted in #122

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,24 @@
+import * as Sentry from "@sentry/nextjs";
+
+export function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    let dsn = process.env.SENTRY_DSN;
+
+    if (!dsn) {
+      // Self-DSN: point Sentry back at our own error-events endpoint
+      const baseUrl =
+        process.env.RENDER_EXTERNAL_URL || process.env.APP_URL || "";
+      if (baseUrl) {
+        const host = baseUrl.replace(/^https?:\/\//, "");
+        dsn = `https://self@${host}/api/error-events/0`;
+      }
+    }
+
+    if (dsn) {
+      Sentry.init({
+        dsn,
+        tracesSampleRate: 0,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Restores `instrumentation.ts` which was accidentally deleted in #122 (public cleanup)
- Without this file, the Sentry SDK is never initialized, so the zero-config error receiver (`/api/error-events`) never receives events
- This broke the full error → GitHub issue pipeline on deployed instances

## Test plan

- [ ] Deploy to Render
- [ ] Hit `/api/error` and confirm a `bug:auto` issue is created via `gh issue list --label bug:auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)