### PR TITLE
fix(telemetry): use Sentry tunnel instead of self-DSN

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,21 +2,18 @@ import * as Sentry from "@sentry/nextjs";
 
 export function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    let dsn = process.env.SENTRY_DSN;
-
-    if (!dsn) {
-      // Self-DSN: point Sentry back at our own error-events endpoint
-      const baseUrl =
-        process.env.RENDER_EXTERNAL_URL || process.env.APP_URL || "";
-      if (baseUrl) {
-        const host = baseUrl.replace(/^https?:\/\//, "");
-        dsn = `https://self@${host}/api/error-events/0`;
-      }
-    }
+    const dsn = process.env.SENTRY_DSN;
 
     if (dsn) {
+      // External Sentry/GlitchTip — use the DSN directly
+      Sentry.init({ dsn, tracesSampleRate: 0 });
+    } else {
+      // Zero-config: tunnel events to our own error-events endpoint.
+      // A dummy DSN is required for the SDK to initialize; the tunnel
+      // option overrides where envelopes are actually sent.
       Sentry.init({
-        dsn,
+        dsn: "https://self@localhost/0",
+        tunnel: "/api/error-events",
         tracesSampleRate: 0,
       });
     }


### PR DESCRIPTION
## Summary

- The self-DSN approach caused Sentry to mangle the request path (`/api/error-events/api/0/envelope/` instead of `/api/error-events`)
- Switches to Sentry's `tunnel` option which POSTs envelopes directly to `/api/error-events` with no path construction
- Also removes dependency on `RENDER_EXTERNAL_URL` / `APP_URL` for the zero-config flow

## Test plan

- [ ] Deploy to Render
- [ ] Hit `/api/error` and confirm a `bug:auto` issue is created
- [ ] Verify Render logs show a POST to `/api/error-events` (not the mangled path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)