### PR TITLE
fix(telemetry): use real host in DSN and add transport error logging

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -15,17 +15,23 @@ export function register() {
       const baseUrl =
         process.env.RENDER_EXTERNAL_URL || process.env.APP_URL || "";
       if (baseUrl) {
+        const host = baseUrl.replace(/^https?:\/\//, "");
         const endpoint = `${baseUrl}/api/error-events`;
         Sentry.init({
-          dsn: "https://self@localhost/0",
+          dsn: `https://self@${host}/0`,
           tracesSampleRate: 0,
           transport: (options: Parameters<typeof createTransport>[0]) =>
             createTransport(options, async (request) => {
-              const res = await fetch(endpoint, {
-                method: "POST",
-                body: request.body as string,
-              });
-              return { statusCode: res.status };
+              try {
+                const res = await fetch(endpoint, {
+                  method: "POST",
+                  body: request.body as string,
+                });
+                return { statusCode: res.status };
+              } catch (e) {
+                console.error("Self-transport failed:", e);
+                return { statusCode: 500 };
+              }
             }),
         });
       }


### PR DESCRIPTION
## Summary

- The dummy DSN `self@localhost/0` may cause Sentry to silently reject initialization — use the app's actual host instead
- Adds try/catch with `console.error` to the custom transport so failures show up in Render logs
- Follow-up to #135 which still wasn't producing `bug:auto` issues

## Test plan

- [ ] Deploy to Render
- [ ] Hit `/api/error`
- [ ] Check Render logs for either a POST to `/api/error-events` or a "Self-transport failed" error
- [ ] Confirm `bug:auto` issue is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)