### PR TITLE
fix(telemetry): add onRequestError hook and withSentryConfig

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -38,3 +38,7 @@ export function register() {
     }
   }
 }
+
+// Next.js 15+ hook: captures unhandled errors from API routes,
+// Server Components, and Server Actions.
+export const onRequestError = Sentry.captureRequestError;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
+import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   output: "standalone",
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, {
+  // Disable source map uploads — no auth token in zero-config mode
+  sourcemaps: { disable: true },
+  // Disable telemetry to Sentry's servers
+  telemetry: false,
+  // Suppress build logs about missing SENTRY_AUTH_TOKEN
+  silent: true,
+});


### PR DESCRIPTION
## Summary

- `Sentry.init()` alone doesn't capture API route errors — two pieces were missing
- Adds `onRequestError = Sentry.captureRequestError` to `instrumentation.ts` — this is the Next.js 15+ hook that wires unhandled errors from route handlers to the Sentry SDK
- Wraps `next.config.ts` with `withSentryConfig` for build-time instrumentation (source maps and telemetry disabled for zero-config mode)

## Test plan

- [ ] Deploy to Render
- [ ] Hit `/api/error`
- [ ] Check Render logs for a POST to `/api/error-events`
- [ ] Confirm `bug:auto` issue is created via `gh issue list --label bug:auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)