### PR TITLE
fix(telemetry): coerce Sentry envelope fields to strings

### DIFF
--- a/app/api/error-events/parse.ts
+++ b/app/api/error-events/parse.ts
@@ -54,9 +54,9 @@ export function parseSentryEnvelope(body: string): ErrorInfo | null {
             type: exc.type ?? "UnknownError",
             value: exc.value ?? "No message",
             stacktrace: formatStacktrace(exc.stacktrace),
-            timestamp: data.timestamp ?? "",
-            environment: data.environment ?? "unknown",
-            serverName: data.server_name ?? "",
+            timestamp: String(data.timestamp ?? ""),
+            environment: String(data.environment ?? "unknown"),
+            serverName: String(data.server_name ?? ""),
           };
         }
       }


### PR DESCRIPTION
## Summary

- Sentry sends `timestamp` as a number (Unix epoch), not a string
- The error receiver's `sanitize()` calls `.replace()` on it, causing `TypeError: a.replace is not a function`
- Wraps `timestamp`, `environment`, and `server_name` with `String()` in the parser

## Test plan

- [ ] Deploy to Render
- [ ] Hit `/api/error`
- [ ] Confirm no "Error processing event" in logs
- [ ] Confirm `bug:auto` issue is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)