### PR TITLE
fix(telemetry): use correct Render env var for preview detection

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,8 +2,8 @@ import * as Sentry from "@sentry/nextjs";
 import { createTransport } from "@sentry/core";
 
 function detectEnvironment(): string {
-  // Render sets IS_PULL_REQUEST_PREVIEW=true for PR preview deploys
-  if (process.env.IS_PULL_REQUEST_PREVIEW === "true") return "preview";
+  // Render sets IS_PULL_REQUEST=true for PR preview deploys
+  if (process.env.IS_PULL_REQUEST === "true") return "preview";
   if (process.env.NODE_ENV === "production") return "production";
   return process.env.NODE_ENV || "development";
 }


### PR DESCRIPTION
## Summary

- Render sets `IS_PULL_REQUEST` on preview deploys, not `IS_PULL_REQUEST_PREVIEW`
- This one-character fix makes preview environments correctly report as `"preview"` in Sentry error issues instead of `"production"`

## Test plan

- [ ] Deploy to a Render PR preview and hit `/error` — verify the GitHub issue shows `Environment: preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)