### PR TITLE
feat(commands): add memory validation to /log-session and /validate-memory

### DIFF
--- a/.claude/commands/log-session.md
+++ b/.claude/commands/log-session.md
@@ -75,7 +75,7 @@ Use the template structure from existing journals in `reports/session-journals/`
    - Report results using standard vocabulary:
      `→ Memory OK: CompletedTicket-{issue} exists for #{issue}`
      `✗ Missing memory: CompletedTicket-{issue} — no entity found for #{issue}`
-     `  → Run /validate-memory to create missing entities`
+     `→ Run /validate-memory to create missing entities`
    - Summary: `→ Memory validation: {found}/{total} completed tickets have CompletedTicket entities`
 4. Present a brief summary to the user
 

--- a/.claude/commands/log-session.md
+++ b/.claude/commands/log-session.md
@@ -66,10 +66,22 @@ Use the template structure from existing journals in `reports/session-journals/`
 
 1. Read the journal back to verify completeness
 2. Cross-reference against the git log and board state to catch anything missed
-3. Present a brief summary to the user
+3. **Validate memory writes** — check that completed tickets have corresponding
+   `CompletedTicket` entities in Memory MCP:
+   - For each ticket listed in "Tickets Delivered", query Memory MCP:
+     `mcp__memory__search_nodes({ "query": "CompletedTicket-{issue-number}" })`
+   - If Memory MCP is not configured, skip validation:
+     `→ Memory validation skipped — Memory MCP server not available`
+   - Report results using standard vocabulary:
+     `→ Memory OK: CompletedTicket-{issue} exists for #{issue}`
+     `✗ Missing memory: CompletedTicket-{issue} — no entity found for #{issue}`
+     `  → Run /validate-memory to create missing entities`
+   - Summary: `→ Memory validation: {found}/{total} completed tickets have CompletedTicket entities`
+4. Present a brief summary to the user
 
 ## Related Commands
 
+- `/validate-memory` — Standalone memory validation and entity creation
 - `/sprint-status` — Current board health overview
 - `/groom-backlog` — Prioritize and populate Ready column
 - `/work-ticket` — Pick up next ticket

--- a/.claude/commands/validate-memory.md
+++ b/.claude/commands/validate-memory.md
@@ -1,0 +1,110 @@
+---
+description: Validate that completed tickets have corresponding Memory MCP entities
+---
+
+Check whether completed tickets from the current session have corresponding
+`CompletedTicket` entities in the Memory MCP knowledge graph. Optionally
+create missing entities.
+
+## Workflow
+
+### Step 1: Check Memory MCP Availability
+
+Attempt a `mcp__memory__search_nodes` call with a simple query (e.g.,
+`"CompletedTicket"`). If the Memory MCP server is not configured or
+unreachable:
+
+```
+→ Memory validation skipped — Memory MCP server not available
+```
+
+Stop here. Do not treat this as an error.
+
+### Step 2: Identify Completed Tickets
+
+Query GitHub for tickets completed during the current session. Use the
+project board to find items in "Done" that have linked PRs merged today,
+or check recent `git log --merges` on main for PR merge commits.
+
+Collect: issue number, issue title, PR number, key files changed.
+
+### Step 3: Check for Existing Entities
+
+For each completed ticket, query Memory MCP:
+
+```
+mcp__memory__search_nodes({ "query": "CompletedTicket-{issue-number}" })
+```
+
+### Step 4: Report Results
+
+For each ticket, report one of:
+
+```
+→ Memory OK: CompletedTicket-{issue} exists for #{issue} — {title}
+✗ Missing memory: CompletedTicket-{issue} — no entity found for #{issue} ({title})
+  → Create this entity? Reading PR diff to generate observations...
+```
+
+Summary line:
+
+```
+→ Memory validation: {found}/{total} completed tickets have CompletedTicket entities
+```
+
+### Step 5: Create Missing Entities (Interactive)
+
+For each missing entity, read the PR diff and generate a `CompletedTicket`
+entity with observations:
+
+- Issue number and title
+- PR number and branch name
+- Summary of what was implemented
+- Key files changed
+- Patterns or conventions established (if any)
+- Gotchas encountered (if any)
+
+Use `mcp__memory__create_entities` to create the entity:
+
+```json
+{
+  "entities": [
+    {
+      "name": "CompletedTicket-{issue}",
+      "entityType": "CompletedTicket",
+      "observations": [
+        "Issue #{issue}: {title}",
+        "PR #{pr} merged to main",
+        "{summary of implementation}",
+        "Key files: {files}",
+        "{patterns or gotchas, if any}"
+      ]
+    }
+  ]
+}
+```
+
+After creating each entity, confirm:
+
+```
+→ Created CompletedTicket-{issue} with {N} observations
+```
+
+## Output Format
+
+End with a Result Block:
+
+```
+---
+
+**Result:** Memory validation complete
+Checked: {total} completed tickets
+Found: {found} existing entities
+Created: {created} new entities
+Missing: {still-missing} (if any were skipped)
+```
+
+## Related Commands
+
+- `/log-session` — Session journal (includes memory validation)
+- `/work-ticket` — Pick up next ticket


### PR DESCRIPTION
## Summary

- Adds memory validation step to `/log-session` that checks for missing `CompletedTicket` entities after listing delivered tickets
- Creates `/validate-memory` standalone command that checks and interactively creates missing Memory MCP entities
- Gracefully skips validation when Memory MCP server is not configured (info message, not error)
- Uses standard output vocabulary (`→` success, `✗` missing)

Closes #142

## Test plan

- [ ] Run `/log-session` after completing a ticket WITH memory write — validation should show all green
- [ ] Run `/log-session` after completing a ticket WITHOUT memory write — validation should flag the missing entity
- [ ] Run `/validate-memory` standalone — should identify and offer to create missing entities
- [ ] Test with Memory MCP not configured — should skip with info message
- [ ] Verify `/log-session` still produces complete journals (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)