### PR TITLE
feat(commands): add ticket-aware context paging to /work-ticket

### DIFF
--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -48,12 +48,23 @@ the user if any check fails — do not continue with partial tooling.
         **do not proceed until the user explicitly approves**
      5. Update the GitHub issue with the user-approved version
    - If all 4 sections are present → proceed normally (no delay)
-3. **Setup** — Create branch, move to In Progress
-4. **Implement** — Follow CLAUDE.md standards, write clean code, follow existing patterns
-5. **Test Locally** — Run lint and tests. Do NOT push if any fail.
-6. **Push** — If pre-push hook fails, fix and retry (see Reference below)
-7. **Create PR** — Detailed description, link to issue
-8. **Monitor CI** — Watch checks, auto-fix failures, move to In Review when green
+3. **Load Context from Past Sessions** — Query Memory MCP for relevant
+   institutional knowledge (silently skip if Memory MCP is not configured
+   or returns no results):
+   - Extract domain keywords from the ticket title and labels
+   - `search_nodes` for `Pattern-` matching those keywords (cap: 3 results)
+   - `search_nodes` for `Lesson-` matching those keywords (cap: 3 results)
+   - If the ticket has a parent epic, `search_nodes` for `CompletedTicket-`
+     in that epic (cap: 4 results, most recent first)
+   - Total cap: 10 entities. Summarize findings in a brief
+     "Context from past sessions" note before proceeding.
+   - If no relevant entities found, produce no output — proceed silently.
+4. **Setup** — Create branch, move to In Progress
+5. **Implement** — Follow CLAUDE.md standards, write clean code, follow existing patterns
+6. **Test Locally** — Run lint and tests. Do NOT push if any fail.
+7. **Push** — If pre-push hook fails, fix and retry (see Reference below)
+8. **Create PR** — Detailed description, link to issue
+9. **Monitor CI** — Watch checks, auto-fix failures, move to In Review when green
 
 ## Quick Fix Protocol
 


### PR DESCRIPTION
## Summary

- Adds step 3 "Load Context from Past Sessions" to `/work-ticket` workflow between ticket validation and branch setup
- Queries Memory MCP for `Pattern-*`, `Lesson-*`, and `CompletedTicket-*` entities matching the ticket's domain keywords
- Results capped at 10 entities total (3 patterns + 3 lessons + 4 completed tickets)
- Silently skips when Memory MCP is unavailable or returns no results
- Renumbers subsequent workflow steps (4-9)

Closes #143

## Test plan

- [ ] Create a `LessonLearned` entity in Memory MCP, run `/work-ticket` on a related ticket — lesson should appear in context
- [ ] Run `/work-ticket` with Memory MCP not configured — step should be silently skipped
- [ ] Run `/work-ticket` on a ticket with no related entities — no output from step 3
- [ ] Verify step numbering is sequential (1-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)