### PR TITLE
feat(agents): require issue comments on backward ticket moves

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -104,15 +104,19 @@ See .claude/README.md for bot account setup instructions.
 
 **YOUR Workflow Steps:**
 1. **Read Ticket**: Fully understand requirements from the Ready column
-2. **Create Feature Branch**: `git checkout -b feature/issue-{number}-description`
-3. **Move to In Progress**: Update project board status to "In Progress"
-4. **Implement**: Follow project standards (see Architecture section below)
-5. **Test**: Ensure all tests pass and demo works
-6. **Commit**: Make atomic, well-described commits
-7. **Push Branch**: `git push origin feature/issue-{number}-description`
-8. **Create PR**: Link to issue, provide detailed description
-9. **Move to In Review**: Update project board status to "In Review"
-10. **Your work is done**: pr-reviewer agent will review, then human will merge
+2. **Check Prior Review History**: If the ticket has linked PRs, read the most
+   recent PR's review comments before starting. If a NO-GO review exists,
+   incorporate the required changes into your implementation plan. Look for
+   issue comments matching `**Review result: NO-GO**` for a quick summary.
+3. **Create Feature Branch**: `git checkout -b feature/issue-{number}-description`
+4. **Move to In Progress**: Update project board status to "In Progress"
+5. **Implement**: Follow project standards (see Architecture section below)
+6. **Test**: Ensure all tests pass and demo works
+7. **Commit**: Make atomic, well-described commits
+8. **Push Branch**: `git push origin feature/issue-{number}-description`
+9. **Create PR**: Link to issue, provide detailed description
+10. **Move to In Review**: Update project board status to "In Review"
+11. **Your work is done**: pr-reviewer agent will review, then human will merge
 
 **YOU CANNOT:**
 - Merge pull requests (only human does this)

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -204,6 +204,11 @@ After completing your review:
 1. **Post a detailed PR review comment** listing all required changes
 2. **Clearly state: "NO-GO - Changes required before merge"**
 3. **Be specific and actionable** - provide file paths, line numbers, and examples
+4. **Post a summary comment on the linked issue** so the audit trail is visible
+   on the ticket (not just the PR). Use this format:
+   `**Review result: NO-GO** (PR #N)`
+   `Required changes: [1-2 sentence summary of blocking issues]`
+   `See full review: #N (review comment)`
 
 **YOU DO NOT:**
 - Click "Approve" button on GitHub (human does this)


### PR DESCRIPTION
## Summary

- Adds step 2 "Check Prior Review History" to ticket worker workflow — reads linked PR review comments before starting implementation on previously-reviewed tickets
- Adds step 4 to PR reviewer's NO-GO flow — posts a summary comment on the linked GitHub issue with format `**Review result: NO-GO** (PR #N)` so the audit trail is visible on the ticket
- Worker looks for `**Review result: NO-GO**` issue comments for quick context on why a ticket regressed

Closes #144

## Test plan

- [ ] Verify ticket worker step numbering is sequential (1-11)
- [ ] Verify PR reviewer NO-GO flow has 4 steps
- [ ] Verify issue comment format matches: `**Review result: NO-GO** (PR #N)` + summary + link
- [ ] Verify no changes to forward-move flows (Ready -> In Progress, etc.)
- [ ] Verify added lines are within 5-10 line guardrail per agent file

🤖 Generated with [Claude Code](https://claude.com/claude-code)