### PR TITLE
docs(memory): document entity naming conventions for keyword search

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -102,6 +102,10 @@ You are an expert Product Owner and Agile Coach specializing in agile digital pr
 - `search_nodes` - Query stored knowledge about past prioritization decisions
 - `open_nodes` - Retrieve specific knowledge items
 
+**Entity naming conventions** (see `docs/MEMORY-ARCHITECTURE.md` for full table):
+- `Prioritization-{epic-name}` for sequencing logic
+- `Decision-{feature-name}` for feature decisions
+
 **Use Memory MCP to:**
 - Remember which features are prerequisites for others
 - Store sequencing logic across sessions

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -294,9 +294,12 @@ so institutional knowledge persists across sessions.
 
 | Entity Type | Naming Convention | When Created |
 |-------------|-------------------|--------------|
-| CompletedTicket | CompletedTicket-{issue} | After PR merge confirmed |
-| PatternDiscovered | Pattern-{short-name} | When a reusable pattern emerges |
-| LessonLearned | Lesson-{short-name} | When a gotcha or workaround is found |
+| CompletedTicket | `CompletedTicket-{issue-number}` | After PR merge confirmed |
+| PatternDiscovered | `Pattern-{domain}-{short-name}` | When a reusable pattern emerges |
+| LessonLearned | `Lesson-{domain}-{short-name}` | When a gotcha or workaround is found |
+
+See `docs/MEMORY-ARCHITECTURE.md` for full naming conventions and the
+`{domain}` field definition.
 
 ## Framework-Specific Testing Patterns
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -567,8 +567,10 @@ patterns and quality trends persist across sessions.
 
 | Entity Type | Naming Convention | When Created |
 |-------------|-------------------|--------------|
-| ReviewObservation | Review-PR-{number} | After posting review comment |
-| QualityTrend | Trend-{topic} | When a recurring quality pattern emerges |
+| ReviewObservation | `Review-PR-{pr-number}` | After posting review comment |
+| QualityTrend | `Trend-{topic}` | When a recurring quality pattern emerges |
+
+See `docs/MEMORY-ARCHITECTURE.md` for full naming conventions.
 
 Your role is to be a guardian of quality while enabling velocity. Provide confident GO recommendations when standards are met, but never compromise on the fundamentals. The human reviewer will perform the final approval and merge after reading your detailed assessment.
 

--- a/docs/MEMORY-ARCHITECTURE.md
+++ b/docs/MEMORY-ARCHITECTURE.md
@@ -85,13 +85,24 @@ structured facts that any agent can query.
 
 **Entity types and naming conventions:**
 
-| Entity Type | Naming Convention | Created By | When Created |
-|-------------|-------------------|------------|--------------|
-| CompletedTicket | `CompletedTicket-{issue}` | Ticket Worker | After PR merge confirmed |
-| PatternDiscovered | `Pattern-{short-name}` | Ticket Worker | When a reusable pattern emerges |
-| LessonLearned | `Lesson-{short-name}` | Ticket Worker | When a gotcha or workaround is found |
-| ReviewObservation | `Review-PR-{number}` | PR Reviewer | After posting review comment |
-| QualityTrend | `Trend-{topic}` | PR Reviewer | When a recurring quality pattern emerges |
+All agents must follow these conventions when creating Memory MCP entities.
+Consistent naming is critical because Memory MCP uses keyword search, not
+embeddings — retrieval quality depends entirely on predictable entity names.
+
+| Entity Type | Convention | Example | Created By |
+|-------------|-----------|---------|------------|
+| CompletedTicket | `CompletedTicket-{issue-number}` | `CompletedTicket-142` | Ticket Worker |
+| ReviewObservation | `Review-PR-{pr-number}` | `Review-PR-150` | PR Reviewer |
+| PatternDiscovered | `Pattern-{domain}-{short-name}` | `Pattern-auth-jwt-refresh` | Ticket Worker |
+| LessonLearned | `Lesson-{domain}-{short-name}` | `Lesson-db-n-plus-one-fix` | Ticket Worker |
+| FeatureDecision | `Decision-{feature-name}` | `Decision-social-login` | Product Manager |
+| PrioritizationLogic | `Prioritization-{epic-name}` | `Prioritization-onboarding-flow` | Backlog Prioritizer |
+| QualityTrend | `Trend-{topic}` | `Trend-test-coverage-gaps` | PR Reviewer |
+
+**The `{domain}` field** should match the ticket's epic label or primary
+domain area (e.g., `auth`, `db`, `ui`, `api`, `infra`, `ci`, `docs`).
+Use lowercase, hyphen-separated words. Keep names short — they are search
+keys, not descriptions. Put descriptive detail in observations instead.
 
 **Relation types:**
 


### PR DESCRIPTION
## Summary

- Expands MEMORY-ARCHITECTURE.md naming conventions table to 7 entity types with domain-prefixed patterns
- Adds `FeatureDecision` (`Decision-{feature-name}`) and `PrioritizationLogic` (`Prioritization-{epic-name}`) types
- Adds `{domain}` field guidance (lowercase, hyphen-separated, matches epic label)
- Updates ticket worker, PR reviewer, and backlog prioritizer agents to reference canonical table
- Agents now point to `docs/MEMORY-ARCHITECTURE.md` for full conventions instead of inline rules

Closes #147

## Test plan

- [ ] Verify naming convention table in MEMORY-ARCHITECTURE.md covers all 7 entity types
- [ ] Verify each entity type has convention pattern and example
- [ ] Verify agent policy files reference the doc for naming conventions
- [ ] Verify no existing entities renamed (conventions apply to new entities only)
- [ ] Verify `{domain}` field guidance is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)