### PR TITLE
feat(cmd): add /upgrade command and UPGRADING.md document

### DIFF
--- a/.claude/commands/upgrade.md
+++ b/.claude/commands/upgrade.md
@@ -1,0 +1,81 @@
+---
+description: "Upgrade Agile Flow framework files to the latest release"
+---
+
+# /upgrade — Agile Flow Framework Upgrade
+
+Check for a newer version of Agile Flow and sync framework files from the
+latest upstream release. User content is never modified.
+
+## Instructions
+
+1. **Verify clean working tree** — run `git status --porcelain`. If there are
+   uncommitted changes, STOP and report:
+
+   ```
+   Your working tree has uncommitted changes. Please commit or stash them
+   before upgrading:
+     git stash
+     /upgrade
+   ```
+
+2. **Verify GitHub CLI authentication** — run `gh auth status`. If not
+   authenticated, STOP and report:
+
+   ```
+   GitHub CLI is not authenticated. Run:
+     gh auth login
+   ```
+
+3. **Run the sync script**:
+
+   ```bash
+   bash scripts/template-sync.sh
+   ```
+
+4. **Parse the output** and report what happened. The script will print one of:
+
+   - **Already up to date** — no action needed.
+   - **Update available: X -> Y** followed by file-level ADDED/UPDATED/SKIP
+     lines and a PR URL.
+   - **ERROR** — report the error message to the user.
+
+5. **If a PR was created**, remind the user:
+
+   ```
+   A sync PR has been created. Review the changes, then merge when ready:
+     gh pr view <PR_NUMBER> --web
+   ```
+
+## Important
+
+- This command calls `scripts/template-sync.sh` as-is. Do not modify the script.
+- The sync only updates framework-controlled files. User content (app code,
+  config customizations, product docs) is never touched. See
+  [DISTRIBUTION.md](../../docs/DISTRIBUTION.md) for the full classification.
+- The created PR requires human review and merge. Do not auto-merge.
+- For details on what gets synced and troubleshooting, see
+  [UPGRADING.md](../../docs/UPGRADING.md).
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Upgrade complete
+From: v0.9.0
+To: v1.0.0
+PR: #42 — chore(sync): update Agile Flow framework to v1.0.0
+Action: Review and merge the PR to finalize the upgrade
+```
+
+Or if already up to date:
+
+```
+---
+
+**Result:** Already up to date
+Version: v0.9.0
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,4 +214,5 @@ approved, tests passing, no lint errors, PR merged to main.
 | `/architect-review` | Architectural guidance |
 | `/lock-scope` | Lock MVP scope |
 | `/doctor` | Environment health check (local + remote) |
+| `/upgrade` | Upgrade framework files to latest release |
 <!-- FRAMEWORK:END -->

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -118,6 +118,7 @@ Content **outside** markers in hybrid files is user-owned. Content
 | `docs/EPHEMERAL-PR-ENVIRONMENTS.md` | framework | Preview env docs | Overwrite |
 | `docs/FAQ.md` | framework | Common questions | Overwrite |
 | `docs/GETTING-STARTED.md` | framework | Onboarding guide | Overwrite |
+| `docs/UPGRADING.md` | framework | Upgrade guide for participants | Overwrite |
 | `docs/testing/agent-restriction-tests.md` | framework | Test documentation | Overwrite |
 | `docs/PRODUCT-REQUIREMENTS.md` | user-content | Bootstrap-generated, user-owned | Never touch |
 | `docs/PRODUCT-ROADMAP.md` | user-content | Bootstrap-generated, user-owned | Never touch |

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -252,6 +252,17 @@ makes the final call.
 
 ---
 
+## "How do I upgrade to a newer version of Agile Flow?"
+
+Run `/upgrade` from Claude Code. This checks for a newer release, syncs
+framework files into your project, and opens a pull request for you to review.
+Your application code and configuration are never touched.
+
+For the full upgrade guide, alternative methods, and troubleshooting, see
+[UPGRADING.md](UPGRADING.md).
+
+---
+
 ## "Why did the agent create a branch?"
 
 When you run `/work-ticket`, the AI agent picks up the next task and starts

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -368,6 +368,9 @@ To see if a newer version is available, visit the
 The `/doctor` command also checks for updates automatically and will warn
 you if a newer version is available.
 
+To upgrade, run `/upgrade` from Claude Code. See [UPGRADING.md](UPGRADING.md)
+for the full upgrade guide, alternative methods, and troubleshooting.
+
 ---
 
 ## Next Steps

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,167 @@
+# Upgrading Agile Flow
+
+This guide explains how to update your project to a newer version of the
+Agile Flow framework. Upgrades only touch framework-controlled files (agents,
+commands, hooks, skills, scripts). Your application code, product docs, and
+configuration customizations are never modified.
+
+For the full list of what is and is not touched during an upgrade, see
+[DISTRIBUTION.md](DISTRIBUTION.md).
+
+---
+
+## Check Your Current Version
+
+```bash
+jq .version .agile-flow-version
+```
+
+The `/doctor` command also checks for updates automatically and warns you if
+a newer version is available.
+
+To see all available releases, visit the
+[Agile Flow releases page](https://github.com/vibeacademy/agile-flow/releases).
+
+---
+
+## Upgrade Methods
+
+### Option 1: `/upgrade` Command (Recommended)
+
+From Claude Code, run:
+
+```
+/upgrade
+```
+
+This checks for a newer release, syncs framework files, and opens a pull
+request for you to review. You must commit or stash any uncommitted changes
+before running the command.
+
+### Option 2: GitHub Actions
+
+1. Go to your repository on GitHub.
+2. Click the **Actions** tab.
+3. Select the **Template Sync** workflow in the left sidebar.
+4. Click **Run workflow** and confirm.
+
+The workflow runs the same sync script and opens a pull request.
+
+---
+
+## What Happens During an Upgrade
+
+1. The sync script fetches the latest release from `vibeacademy/agile-flow`.
+2. It compares your local version (from `.agile-flow-version`) to the latest.
+3. If an update is available, it downloads the release and copies only the
+   directories listed in `syncDirectories` (inside `.agile-flow-version`):
+   - `.claude/agents`
+   - `.claude/commands`
+   - `.claude/hooks`
+   - `.claude/skills`
+   - `scripts`
+   - `starters`
+4. It creates a branch (`agile-flow-sync/v{VERSION}`), commits the changes,
+   and opens a pull request.
+5. Your `.agile-flow-version` file is updated with the new version number.
+
+**Your code is safe.** Application code (`app/`, `__tests__/`), product docs
+(`PRODUCT-REQUIREMENTS.md`, `PRODUCT-ROADMAP.md`), deployment config
+(`render.yaml`), and other user-content files are never touched.
+
+---
+
+## Reviewing and Merging the Sync PR
+
+1. Open the pull request on GitHub (or run `gh pr view --web`).
+2. Review the changed files. The PR body lists every file that was added or
+   updated.
+3. If everything looks good, click **Squash and merge**.
+4. After merging, your project is running the new version.
+
+---
+
+## Troubleshooting
+
+### "Your working tree has uncommitted changes"
+
+Commit or stash your changes before running `/upgrade`:
+
+```bash
+git stash
+/upgrade
+# After the upgrade PR is merged:
+git stash pop
+```
+
+### "GitHub CLI is not authenticated"
+
+Log in to the GitHub CLI:
+
+```bash
+gh auth login
+```
+
+### "Could not fetch latest release"
+
+The sync script uses the public GitHub API. This can fail if:
+
+- You have no internet connection.
+- The GitHub API is temporarily unavailable.
+- You have hit the unauthenticated API rate limit (60 requests/hour).
+
+Wait a few minutes and try again.
+
+### "Branch already exists on remote"
+
+A sync PR for this version was already created. Check your open pull requests:
+
+```bash
+gh pr list
+```
+
+If the PR is still open, review and merge it. If it was closed without
+merging and you want to retry, delete the remote branch first:
+
+```bash
+git push origin --delete agile-flow-sync/v{VERSION}
+```
+
+### Merge Conflicts
+
+If the sync PR has merge conflicts, it usually means a framework file was
+edited locally. To resolve:
+
+1. Check out the sync branch locally:
+
+   ```bash
+   gh pr checkout <PR_NUMBER>
+   ```
+
+2. Merge main into it and resolve conflicts:
+
+   ```bash
+   git merge main
+   # Resolve conflicts, keeping the upstream version for framework files
+   git add .
+   git commit -m "fix: resolve sync merge conflicts"
+   git push
+   ```
+
+3. Review the PR again and merge.
+
+---
+
+## Manual Upgrade
+
+If the automated sync does not work for your setup, you can upgrade manually:
+
+1. Download the latest release from the
+   [releases page](https://github.com/vibeacademy/agile-flow/releases).
+2. Extract the archive.
+3. Copy the framework directories (`.claude/agents`, `.claude/commands`,
+   `.claude/hooks`, `.claude/skills`, `scripts`, `starters`) into your
+   project, overwriting existing files.
+4. Update the `version` field in `.agile-flow-version` to match the release
+   tag.
+5. Commit the changes and open a pull request for review.


### PR DESCRIPTION
## Summary

- Add `/upgrade` slash command that calls existing `template-sync.sh` with pre-flight checks (clean working tree, gh auth)
- Add `docs/UPGRADING.md` — participant-facing guide covering both upgrade methods, what gets synced, and troubleshooting
- Add cross-references from GETTING-STARTED.md, FAQ.md, and DISTRIBUTION.md
- Add `/upgrade` to CLAUDE.md Slash Commands table

Closes vibeacademy/agile-flow-meta#71

## Test plan

- [ ] `.claude/commands/upgrade.md` exists and follows command file pattern (frontmatter, instructions, result block)
- [ ] `docs/UPGRADING.md` covers: version check, `/upgrade` command, Actions alternative, sync details, troubleshooting
- [ ] GETTING-STARTED.md "Checking for Updates" links to UPGRADING.md
- [ ] FAQ.md has "How do I upgrade?" entry linking to UPGRADING.md
- [ ] DISTRIBUTION.md docs table includes UPGRADING.md row
- [ ] CLAUDE.md Slash Commands table includes `/upgrade`
- [ ] All cross-references resolve (no broken links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)