### PR TITLE
Add YouTube video embed to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A Claude Code project template that bootstraps a complete agile development workflow with specialized AI agents.
 
+[![Watch the video](https://img.youtube.com/vi/rkHxmnsyTiM/maxresdefault.jpg)](https://youtu.be/rkHxmnsyTiM)
+
 ## Why This Exists
 
 In lean manufacturing, a **gemba walk** is when a manager goes to the


### PR DESCRIPTION
## Summary
- Adds a clickable YouTube thumbnail linking to https://youtu.be/rkHxmnsyTiM at the top of the README, below the badges

## Test plan
- [ ] Verify thumbnail renders on GitHub
- [ ] Verify clicking the image opens the YouTube video

🤖 Generated with [Claude Code](https://claude.com/claude-code)