### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --title "${{ steps.version.outputs.tag }}" \
-            --notes-file /tmp/release-notes.md
+          if gh release view "${{ steps.version.outputs.tag }}" &>/dev/null; then
+            echo "Release ${{ steps.version.outputs.tag }} already exists — skipping creation."
+          else
+            gh release create "${{ steps.version.outputs.tag }}" \
+              --title "${{ steps.version.outputs.tag }}" \
+              --notes-file /tmp/release-notes.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-08
+
+First stable public release. This batch solidifies the framework's versioning story, expands the slash-command surface, introduces the Agent Output Format standard, and cleans up public-facing documentation.
+
+### Added
+
+- `/upgrade` command with `UPGRADING.md` migration guide for downstream fork upgrades
+- `/prune-memory` command with time-decay scoring for agent memory hygiene
+- `/research`, `/jtbd`, and `/positioning` slash commands for strategic discovery
+- Transcript-based insight extraction added to `/log-session`
+- Memory validation added to `/log-session` and `/validate-memory`
+- Ticket-aware context paging added to `/work-ticket`
+- Optional URI input added to `/research` command
+- Agent Output Format standard (Result Block + Progress Lines) to `CLAUDE.md`
+- Result Block templates across all 6 agent definitions
+- Result Block and Progress Lines across high-traffic slash commands
+- `MEMORY-ARCHITECTURE.md` documenting the full agent memory system
+- Entity naming conventions for keyword search documented
+- Pattern library and deployment bug fixes
+- `.agile-flow-version` manifest file for downstream version tracking
+- Version awareness in `/doctor` command
+- Version parity CI check between `.agile-flow-version` and `package.json`
+- Template-sync GitHub Action (`template-sync.yml`) for downstream forks to pull upstream updates
+- BSL 1.1 license with Apache 2.0 change date (2029)
+- Attribution badges and branding to README
+- YouTube video embed in README
+
+### Fixed
+
+- Multiple Sentry/telemetry transport fixes (custom transport, envelope coercion, preview detection, `onRequestError` hook, `withSentryConfig`)
+- Static asset copy for Next.js standalone on Render
+- Preview workflows correctly skipped on template repo
+- `doctor.sh` false positives in restricted PATH environments
+- Agent commands hardened against protocol violations
+- Quick fix protocol and linked-ticket board guard added
+
+### Changed
+
+- Removed GitHub MCP server dependency
+- Workshop curriculum replaced with stubs; framework/user-content boundary documented
+- Public-facing documentation reduced redundancy and improved quality for external audience
+
+### Security
+
+- BSL 1.1 license enforces non-production-service use; Apache 2.0 grant triggers 2029-01-01
+
 ## [0.9.0] - 2025-12-07
 
 Pre-upgrade baseline — the first tagged release of Agile Flow.
@@ -30,5 +76,6 @@ Pre-upgrade baseline — the first tagged release of Agile Flow.
 - Product documentation templates (PRD, Roadmap)
 - Getting Started guide
 
-[Unreleased]: https://github.com/vibeacademy/agile-flow/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/vibeacademy/agile-flow/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/vibeacademy/agile-flow/compare/v0.9.0...v1.0.0
 [0.9.0]: https://github.com/vibeacademy/agile-flow/releases/tag/v0.9.0


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` CHANGELOG section to v1.0.0 — the first stable public release of Agile Flow.

### What's in v1.0.0

**New slash commands:** `/upgrade`, `/prune-memory`, `/research`, `/jtbd`, `/positioning`, plus major extensions to `/log-session`, `/work-ticket`, `/validate-memory`, `/doctor`

**Agent Output Format standard:** Result Block + Progress Lines across all 6 agents and high-traffic commands

**Infrastructure:** `.agile-flow-version` manifest, template-sync GitHub Action, version parity CI check

**Docs & license:** BSL 1.1 license, public-facing doc cleanup, MEMORY-ARCHITECTURE.md, pattern library

**Fixes:** Telemetry transport stack, Next.js static asset copy on Render, doctor.sh false positives, agent protocol hardening

### After merge
Push `v1.0.0` tag → triggers `release.yml` → GitHub Release auto-created from this CHANGELOG section.

Tracked in [VIB-6](/VIB/issues/VIB-6).