### PR TITLE
feat: add triage-downstream-reports GitHub Action (VIB-25)

### DIFF
--- a/.github/workflows/triage-downstream-reports.yml
+++ b/.github/workflows/triage-downstream-reports.yml
@@ -1,0 +1,164 @@
+name: Triage downstream reports
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  triage:
+    if: contains(github.event.issue.labels.*.name, 'downstream-report') && !contains(github.event.issue.labels.*.name, 'paperclip-created')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Parse report and create Paperclip issue
+        env:
+          PAPERCLIP_API_URL: ${{ secrets.PAPERCLIP_API_URL }}
+          PAPERCLIP_API_KEY: ${{ secrets.PAPERCLIP_API_KEY }}
+          PAPERCLIP_COMPANY_ID: ${{ secrets.PAPERCLIP_COMPANY_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          REPO: ${{ github.repository }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+
+          # ── Parse YAML front-matter, output JSON ──────────────────────────
+          PARSED=$(python3 - <<'PYEOF'
+          import os, re, sys, json
+
+          body = os.environ.get("ISSUE_BODY", "")
+
+          match = re.match(r'^---\s*\n(.*?)\n---', body, re.DOTALL)
+          if not match:
+              print(json.dumps({"skip": True}))
+              sys.exit(0)
+
+          fm_text = match.group(1)
+
+          def parse_value(v):
+              v = re.sub(r'\s*#.*$', '', v).strip()
+              if (v.startswith('"') and v.endswith('"')) or \
+                 (v.startswith("'") and v.endswith("'")):
+                  v = v[1:-1]
+              return v
+
+          data = {}
+          for line in fm_text.splitlines():
+              kv = re.match(r'^(\w+)\s*:\s*(.*)$', line)
+              if kv:
+                  data[kv.group(1)] = parse_value(kv.group(2))
+
+          if data.get("agile_flow_report") not in ("true", "True", "1"):
+              print(json.dumps({"skip": True}))
+              sys.exit(0)
+
+          print(json.dumps({
+              "skip":      False,
+              "severity":  data.get("severity",  "p3").lower(),
+              "component": data.get("component", "other").lower(),
+              "title":     data.get("title",     "").strip(),
+          }))
+          PYEOF
+          )
+
+          SKIP=$(echo "$PARSED" | jq -r '.skip')
+          if [ "$SKIP" = "true" ]; then
+            echo "Issue has no valid agile_flow_report front-matter — skipping."
+            exit 0
+          fi
+
+          SEVERITY=$(echo  "$PARSED" | jq -r '.severity')
+          COMPONENT=$(echo "$PARSED" | jq -r '.component')
+          FM_TITLE=$(echo  "$PARSED" | jq -r '.title')
+
+          REPORT_TITLE="${FM_TITLE:-}"
+          if [ -z "$REPORT_TITLE" ]; then
+            REPORT_TITLE="$ISSUE_TITLE"
+          fi
+
+          # ── Map severity → Paperclip priority ──────────────────────────────
+          case "$SEVERITY" in
+            p1) PRIORITY="critical" ;;
+            p2) PRIORITY="high"     ;;
+            p3) PRIORITY="medium"   ;;
+            *)  PRIORITY="medium"   ;;
+          esac
+
+          # ── Route by component ──────────────────────────────────────────────
+          # provisioning, ci, claude-commands, docs, other → Engineer
+          # patterns → System Architect
+          case "$COMPONENT" in
+            patterns) ASSIGNEE_ID="68591f61-5d49-413b-939a-c767999514b2" ;;
+            *)        ASSIGNEE_ID="9be8d6b0-1d87-4613-be28-e4b749969f60" ;;
+          esac
+
+          GOAL_ID="a310fdff-eb5c-4240-8927-4e32f7e095a2"
+          PAPERCLIP_TITLE="[Downstream/${REPO_NAME}] ${REPORT_TITLE}"
+
+          DESCRIPTION=$(jq -rn \
+            --arg repo "$REPO_NAME" \
+            --arg num  "$ISSUE_NUMBER" \
+            --arg url  "$ISSUE_URL" \
+            --arg sev  "$SEVERITY" \
+            --arg pri  "$PRIORITY" \
+            --arg comp "$COMPONENT" \
+            --arg body "$ISSUE_BODY" \
+            '"Downstream report from GitHub issue [#\($num)](\($url)) in `\($repo)`.\n\n**Severity:** \($sev) → \($pri)\n**Component:** \($comp)\n**Source issue:** \($url)\n\n---\n\n\($body)"')
+
+          # ── Create Paperclip issue ──────────────────────────────────────────
+          PAYLOAD=$(jq -n \
+            --arg title    "$PAPERCLIP_TITLE" \
+            --arg desc     "$DESCRIPTION" \
+            --arg priority "$PRIORITY" \
+            --arg goalId   "$GOAL_ID" \
+            --arg assignee "$ASSIGNEE_ID" \
+            '{
+              title:           $title,
+              description:     $desc,
+              priority:        $priority,
+              goalId:          $goalId,
+              assigneeAgentId: $assignee
+            }')
+
+          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Authorization: Bearer ${PAPERCLIP_API_KEY}" \
+            -H "Content-Type: application/json" \
+            "${PAPERCLIP_API_URL}/api/companies/${PAPERCLIP_COMPANY_ID}/issues" \
+            -d "$PAYLOAD")
+
+          HTTP_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+          HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n 1)
+
+          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
+            echo "ERROR: Paperclip API returned HTTP ${HTTP_CODE}"
+            echo "$HTTP_BODY"
+            exit 1
+          fi
+
+          PAPERCLIP_ID=$(echo "$HTTP_BODY" | jq -r '.identifier // .id')
+          echo "Created Paperclip issue: ${PAPERCLIP_ID}"
+
+          # ── Ensure paperclip-created label exists ───────────────────────────
+          gh label create "paperclip-created" \
+            --repo "$REPO" \
+            --color "0075ca" \
+            --description "Downstream report has been triaged into Paperclip" \
+            2>/dev/null || true
+
+          # ── Label GitHub issue as processed ────────────────────────────────
+          gh issue edit "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --add-label "paperclip-created"
+
+          # ── Comment on GitHub issue with Paperclip link ─────────────────────
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --body "Paperclip triage issue created: **${PAPERCLIP_ID}**
+
+          The upstream team has been notified and will review this report.
+
+          > Routed as: component \`${COMPONENT}\` · priority \`${PRIORITY}\`"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/triage-downstream-reports.yml` per [VIB-16](https://paperclip-thco.onrender.com/VIB/issues/VIB-16) architecture plan §7.1–7.2.

- Triggers on `issues: [opened, labeled]`
- Skips if `downstream-report` label is absent or `paperclip-created` is already present (idempotent)
- Parses YAML front-matter from issue body (requires `agile_flow_report: true`)
- Maps severity: `p1`→`critical`, `p2`→`high`, `p3`→`medium`
- Routes by component: `patterns`→System Architect, all others→Engineer
- Creates a Paperclip issue via API with title prefix `[Downstream/agile-flow]`
- Labels GitHub issue `paperclip-created` (auto-creates label if missing)
- Comments on GitHub issue with Paperclip issue ID

## Secrets required

Configure in repo settings before the workflow is live:
- `PAPERCLIP_API_URL`
- `PAPERCLIP_API_KEY` (scoped triage service account)
- `PAPERCLIP_COMPANY_ID`

## Dependencies

Requires the `downstream-report` label to exist in this repo (created by [VIB-24](https://paperclip-thco.onrender.com/VIB/issues/VIB-24) PR #184).

## Test plan

- [ ] File a test issue with `downstream-report` label and valid YAML front-matter
- [ ] Verify Paperclip issue created with correct title prefix, priority, and assignee
- [ ] Verify `paperclip-created` label added to GitHub issue
- [ ] Verify comment posted on GitHub issue with Paperclip ID
- [ ] File a second identical issue — confirm it is skipped (idempotent)
- [ ] File issue without `agile_flow_report: true` — confirm it is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)