### PR TITLE
feat(ci): add template cleanliness gate for GCP/AWS terms (VIB-27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,15 @@ jobs:
       - name: Validate agent files
         run: ./scripts/validation/validate-agents.sh
 
+  template-cleanliness:
+    name: template-cleanliness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for forbidden cloud-provider terms
+        run: ./scripts/check-template-cleanliness.sh
+
   lint-agent-policies:
     name: lint-agent-policies
     runs-on: ubuntu-latest

--- a/scripts/check-template-cleanliness.sh
+++ b/scripts/check-template-cleanliness.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fails if GCP/AWS/enterprise-specific terms are found in core agile-flow files.
+# Self-excluded from the scan to avoid false positives on the pattern strings.
+set -euo pipefail
+
+SELF="$(basename "$0")"
+FORBIDDEN='\bgcp\b|google-cloud|\bgcloud\b|cloud-run|\baws\b|\bamazon\b|\bec2\b|\bs3\b|\blambda\b'
+
+SCAN_DIRS=(scripts .claude/commands .github/workflows)
+SCAN_INCLUDE=(--include='*.sh' --include='*.md' --include='*.yml')
+
+violations=0
+for dir in "${SCAN_DIRS[@]}"; do
+  [ -d "$dir" ] || continue
+  while IFS= read -r match; do
+    echo "VIOLATION: $match"
+    violations=$((violations + 1))
+  done < <(grep -rinP "$FORBIDDEN" "${SCAN_INCLUDE[@]}" --exclude="$SELF" "$dir" 2>/dev/null || true)
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "Template cleanliness check FAILED ($violations violation(s))."
+  echo "Forbidden terms: gcp, google-cloud, gcloud, cloud-run, aws, amazon, ec2, s3, lambda"
+  exit 1
+fi
+
+echo "Template cleanliness check PASSED."


### PR DESCRIPTION
## Summary

- Adds `scripts/check-template-cleanliness.sh` — greps `scripts/`, `.claude/commands/`, and `.github/workflows/` for forbidden GCP/AWS/enterprise cloud-provider terms (gcp, google-cloud, gcloud, cloud-run, aws, amazon, ec2, s3, lambda)
- Script self-excludes to avoid false positives on its own pattern strings
- Adds `template-cleanliness` job to `ci.yml` that runs the check on every push and PR

## Audit result

Audit of `main` returned zero violations. The check passes clean.

**Note:** `feature/vib-24-report-issue` (not yet merged) introduces `.claude/commands/report-issue.md` which contains `GCP/AWS` as workshop track names — this CI gate will block that branch from merging until cleaned up.

## Acceptance criteria

- [x] Audit passes with zero violations on `main`
- [x] CI check added and runs on every push/PR
- [x] CI check fails if a future commit introduces a forbidden term

Closes VIB-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)