### PR TITLE
feat(cmd): add /pull-upstream slash command

### DIFF
--- a/.claude/commands/pull-upstream.md
+++ b/.claude/commands/pull-upstream.md
@@ -1,0 +1,82 @@
+---
+description: "Pull framework updates from the upstream agile-flow repo into this fork"
+---
+
+# /pull-upstream — Sync from Upstream
+
+Pull the latest framework changes from
+[vibeacademy/agile-flow](https://github.com/vibeacademy/agile-flow) into this
+downstream fork. Only touches files listed in syncDirectories in
+.agile-flow-version; excludes stack-specific customizations automatically.
+
+## Instructions
+
+1. **Verify the environment** -- confirm the working tree is clean and gh is
+   authenticated. If either check fails, STOP and tell the user what to fix.
+
+   git status --porcelain
+   gh auth status
+
+2. **Run the sync script**:
+
+   bash scripts/pull-upstream.sh
+
+3. **Parse the output** between === PULL_UPSTREAM_SUMMARY === and
+   === END_SUMMARY === to extract STATUS, UPSTREAM_HEAD, APPLIED,
+   SKIPPED, and PR_URL (if present).
+
+4. **Report results** to the facilitator based on status:
+
+   - already_up_to_date: nothing to do; report the current upstream SHA
+   - pr_created: surface the PR URL; remind them to review before merging
+   - applied: direct apply; remind them to run the test suite
+
+5. **If errors occur** -- surface the full error output. Common issues:
+
+   - Uncommitted changes: git stash, then re-run
+   - gh not authenticated: gh auth login
+   - Network failure: check connectivity and retry
+
+## Mid-Workshop Fast Path
+
+When running during a live workshop and you need an upstream fix applied
+immediately without waiting for a PR review:
+
+   bash scripts/pull-upstream.sh --direct
+
+This applies changes to the current branch directly. Confirm the test suite
+still passes after:
+
+   uv sync --extra dev && uv run pytest
+
+## Dry Run
+
+To preview what would change without touching anything:
+
+   bash scripts/pull-upstream.sh --dry-run
+
+## Output Format
+
+End your response with a Result Block:
+
+If a PR was created:
+
+  **Result:** Sync PR created
+  Upstream: abc1234 -> def5678 (N new commits)
+  Applied: 3 files
+  Skipped: 2 files (excluded)
+  PR: #47 -- chore(upstream): sync framework from agile-flow@def5678
+  Action: Review and merge the PR to finalize the sync
+
+If already up to date:
+
+  **Result:** Already up to date
+  Upstream HEAD: abc1234
+
+If applied directly:
+
+  **Result:** Applied directly to current branch
+  Upstream: abc1234 -> def5678
+  Applied: 3 files
+  Skipped: 2 files (excluded)
+  Action: Run uv sync --extra dev && uv run pytest to verify

--- a/.github/workflows/pull-upstream.yml
+++ b/.github/workflows/pull-upstream.yml
@@ -1,0 +1,73 @@
+name: Pull Upstream
+
+on:
+  workflow_dispatch:
+    inputs:
+      push_changes:
+        description: "Push changes directly to main (true) or open a PR (false)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pull-upstream:
+    name: Apply upstream agile-flow framework changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run pull-upstream script
+        id: sync
+        run: bash scripts/pull-upstream.sh
+        continue-on-error: true
+
+      - name: Check for changes
+        id: changes
+        run: |
+          # Script commits if it applied updates; check log vs HEAD~1
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          if echo "$COMMIT_MSG" | grep -q "^chore(upstream): sync framework files"; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push directly to main
+        if: >
+          steps.changes.outputs.has_changes == 'true' &&
+          inputs.push_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git push origin HEAD:main
+
+      - name: Open pull request
+        if: >
+          steps.changes.outputs.has_changes == 'true' &&
+          inputs.push_changes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          UPSTREAM_SHA=$(git rev-parse upstream/main 2>/dev/null || echo "unknown")
+          BRANCH="upstream-sync/$(date -u +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+          PR_TITLE="chore(upstream): sync framework files from agile-flow@${UPSTREAM_SHA:0:7}"
+          PR_BODY="Upstream sync from agile-flow@${UPSTREAM_SHA:0:7}. GCP-specific overrides in .agile-flow-overrides were preserved. Triggered via the Pull Upstream workflow (workflow_dispatch). Review and merge when ready."
+          gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base main --head "$BRANCH"
+
+      - name: Report no changes
+        if: steps.changes.outputs.has_changes == 'false'
+        run: echo "Already up to date with upstream. No changes applied."

--- a/.github/workflows/pull-upstream.yml
+++ b/.github/workflows/pull-upstream.yml
@@ -28,15 +28,24 @@ jobs:
 
       - name: Run pull-upstream script
         id: sync
-        run: bash scripts/pull-upstream.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [[ "${{ inputs.push_changes }}" == "true" ]]; then
+            bash scripts/pull-upstream.sh --direct
+          else
+            bash scripts/pull-upstream.sh
+          fi
         continue-on-error: true
 
       - name: Check for changes
         id: changes
         run: |
-          # Script commits if it applied updates; check log vs HEAD~1
+          # Script commits if it applied updates; check last commit message
           COMMIT_MSG=$(git log -1 --pretty=%s)
-          if echo "$COMMIT_MSG" | grep -q "^chore(upstream): sync framework files"; then
+          if echo "$COMMIT_MSG" | grep -q "^chore(upstream): sync framework from agile-flow@"; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -48,25 +57,7 @@ jobs:
           inputs.push_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git push origin HEAD:main
-
-      - name: Open pull request
-        if: >
-          steps.changes.outputs.has_changes == 'true' &&
-          inputs.push_changes == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          UPSTREAM_SHA=$(git rev-parse upstream/main 2>/dev/null || echo "unknown")
-          BRANCH="upstream-sync/$(date -u +%Y%m%d-%H%M%S)"
-          git checkout -b "$BRANCH"
-          git push origin "$BRANCH"
-          PR_TITLE="chore(upstream): sync framework files from agile-flow@${UPSTREAM_SHA:0:7}"
-          PR_BODY="Upstream sync from agile-flow@${UPSTREAM_SHA:0:7}. GCP-specific overrides in .agile-flow-overrides were preserved. Triggered via the Pull Upstream workflow (workflow_dispatch). Review and merge when ready."
-          gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base main --head "$BRANCH"
+        run: git push origin HEAD:main
 
       - name: Report no changes
         if: steps.changes.outputs.has_changes == 'false'

--- a/scripts/pull-upstream.sh
+++ b/scripts/pull-upstream.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# pull-upstream.sh — Pull framework updates from vibeacademy/agile-flow.
+#
+# Safe to run mid-workshop. Only updates files listed in syncDirectories
+# in .agile-flow-version; respects the excludeFromSync exclusion list.
+#
+# Usage:
+#   bash scripts/pull-upstream.sh [--dry-run] [--direct]
+#
+# Options:
+#   --dry-run   Show what would change; make no modifications
+#   --direct    Apply changes directly to the current branch (no PR)
+
+set -euo pipefail
+
+###############################################################################
+# Config
+###############################################################################
+
+UPSTREAM_REMOTE="upstream"
+UPSTREAM_URL="https://github.com/vibeacademy/agile-flow.git"
+UPSTREAM_BRANCH="main"
+VERSION_FILE=".agile-flow-version"
+
+DRY_RUN=false
+DIRECT=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --direct)  DIRECT=true;  shift ;;
+    *) echo "ERROR: Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+###############################################################################
+# 1. Read config from .agile-flow-version
+###############################################################################
+
+if [[ ! -f "$VERSION_FILE" ]]; then
+  echo "ERROR: $VERSION_FILE not found. Is this an Agile Flow repo?"
+  exit 1
+fi
+
+UPSTREAM_COMMIT=$(python3 -c "
+import json
+data = json.load(open('$VERSION_FILE'))
+print(data.get('upstreamCommit', ''))
+")
+
+if [[ -z "$UPSTREAM_COMMIT" ]]; then
+  echo "ERROR: 'upstreamCommit' not set in $VERSION_FILE."
+  echo "Add the SHA of the upstream commit you forked from, e.g.:"
+  echo '  { "upstreamCommit": "b9bd5e3830a9fd3d2cfd64fccbd82876695493c6", ... }'
+  exit 1
+fi
+
+readarray -t SYNC_DIRS < <(python3 -c "
+import json
+data = json.load(open('$VERSION_FILE'))
+print('\n'.join(data.get('syncDirectories', [])))
+" | grep -v '^$')
+
+readarray -t EXCLUDE_PATHS < <(python3 -c "
+import json
+data = json.load(open('$VERSION_FILE'))
+print('\n'.join(data.get('excludeFromSync', [])))
+" | grep -v '^$')
+
+###############################################################################
+# 2. Verify clean working tree
+###############################################################################
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "ERROR: Working tree has uncommitted changes."
+  echo "Commit or stash before syncing:"
+  echo "  git stash && bash scripts/pull-upstream.sh"
+  exit 1
+fi
+
+###############################################################################
+# 3. Add upstream remote if missing
+###############################################################################
+
+if ! git remote get-url "$UPSTREAM_REMOTE" &>/dev/null; then
+  echo "Adding upstream remote: $UPSTREAM_URL"
+  git remote add "$UPSTREAM_REMOTE" "$UPSTREAM_URL"
+fi
+
+###############################################################################
+# 4. Fetch upstream
+###############################################################################
+
+echo "Fetching $UPSTREAM_REMOTE/$UPSTREAM_BRANCH..."
+git fetch "$UPSTREAM_REMOTE" "$UPSTREAM_BRANCH" --quiet
+
+UPSTREAM_HEAD=$(git rev-parse "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH")
+
+if [[ "$UPSTREAM_HEAD" == "$UPSTREAM_COMMIT" ]]; then
+  echo "Already up to date. (upstream head: ${UPSTREAM_COMMIT:0:8})"
+  echo ""
+  echo "=== PULL_UPSTREAM_SUMMARY ==="
+  echo "STATUS=already_up_to_date"
+  echo "UPSTREAM_HEAD=${UPSTREAM_HEAD:0:8}"
+  echo "=== END_SUMMARY ==="
+  exit 0
+fi
+
+###############################################################################
+# 5. Show new upstream commits
+###############################################################################
+
+echo ""
+echo "New upstream commits since ${UPSTREAM_COMMIT:0:8}:"
+git log --oneline "$UPSTREAM_COMMIT..$UPSTREAM_REMOTE/$UPSTREAM_BRANCH"
+echo ""
+
+###############################################################################
+# 6. Classify changed files: APPLY vs SKIP
+###############################################################################
+
+CHANGED_FILES=$(git diff --name-only "$UPSTREAM_COMMIT" "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH")
+
+APPLY_FILES=()
+SKIP_FILES=()
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  # Check if file falls under a sync directory
+  in_sync_dir=false
+  for dir in "${SYNC_DIRS[@]}"; do
+    if [[ "$file" == "$dir/"* || "$file" == "$dir" ]]; then
+      in_sync_dir=true
+      break
+    fi
+  done
+
+  if ! $in_sync_dir; then
+    SKIP_FILES+=("$file  (not in syncDirectories)")
+    continue
+  fi
+
+  # Check if file is explicitly excluded
+  is_excluded=false
+  for exc in "${EXCLUDE_PATHS[@]}"; do
+    if [[ "$file" == "$exc" ]]; then
+      is_excluded=true
+      break
+    fi
+  done
+
+  if $is_excluded; then
+    SKIP_FILES+=("$file  (excluded — local customization preserved)")
+    continue
+  fi
+
+  APPLY_FILES+=("$file")
+done <<< "$CHANGED_FILES"
+
+###############################################################################
+# 7. Report plan
+###############################################################################
+
+echo "Files to apply  (${#APPLY_FILES[@]}):"
+for f in "${APPLY_FILES[@]}"; do
+  echo "  APPLY  $f"
+done
+
+if [[ ${#SKIP_FILES[@]} -gt 0 ]]; then
+  echo ""
+  echo "Files to skip   (${#SKIP_FILES[@]}):"
+  for f in "${SKIP_FILES[@]}"; do
+    echo "  SKIP   $f"
+  done
+fi
+
+if [[ ${#APPLY_FILES[@]} -eq 0 ]]; then
+  echo ""
+  echo "No tracked files changed in upstream. Advancing upstreamCommit."
+  if ! $DRY_RUN; then
+    python3 - "$UPSTREAM_HEAD" "$VERSION_FILE" <<'PYEOF'
+import json, sys
+sha, path = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data['upstreamCommit'] = sha
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+PYEOF
+    git add "$VERSION_FILE"
+    git commit -m "chore(upstream): advance to agile-flow@${UPSTREAM_HEAD:0:8}
+
+No tracked framework files changed between ${UPSTREAM_COMMIT:0:8} and ${UPSTREAM_HEAD:0:8}.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+  fi
+  exit 0
+fi
+
+if $DRY_RUN; then
+  echo ""
+  echo "Dry run — no changes made."
+  exit 0
+fi
+
+###############################################################################
+# 8. Apply changes
+###############################################################################
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+SYNC_BRANCH="agile-flow-sync/upstream-${TIMESTAMP}"
+
+if ! $DIRECT; then
+  git checkout -b "$SYNC_BRANCH"
+fi
+
+APPLIED=()
+REMOVED=()
+
+for file in "${APPLY_FILES[@]}"; do
+  # Check if file still exists in upstream (may have been deleted)
+  if git ls-tree "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH" -- "$file" | grep -q .; then
+    mkdir -p "$(dirname "$file")"
+    git checkout "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH" -- "$file"
+    APPLIED+=("$file")
+    echo "APPLIED: $file"
+  elif [[ -f "$file" ]]; then
+    git rm "$file"
+    REMOVED+=("$file")
+    echo "REMOVED: $file"
+  fi
+done
+
+# Advance upstreamCommit
+python3 - "$UPSTREAM_HEAD" "$VERSION_FILE" <<'PYEOF'
+import json, sys
+sha, path = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data['upstreamCommit'] = sha
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+PYEOF
+git add "$VERSION_FILE"
+
+###############################################################################
+# 9. Commit and (optionally) create PR
+###############################################################################
+
+COMMIT_MSG="chore(upstream): sync framework from agile-flow@${UPSTREAM_HEAD:0:8}
+
+Applied ${#APPLIED[@]} file(s); skipped ${#SKIP_FILES[@]} stack-specific file(s).
+Previous upstreamCommit: ${UPSTREAM_COMMIT:0:8}
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+
+git commit -m "$COMMIT_MSG"
+
+if $DIRECT; then
+  echo ""
+  echo "Applied directly to current branch."
+  echo "Run your test suite to verify:"
+  echo "  uv sync --extra dev && uv run pytest"
+  echo ""
+  echo "=== PULL_UPSTREAM_SUMMARY ==="
+  echo "STATUS=applied"
+  echo "UPSTREAM_HEAD=${UPSTREAM_HEAD:0:8}"
+  echo "APPLIED=${#APPLIED[@]}"
+  echo "SKIPPED=${#SKIP_FILES[@]}"
+  echo "=== END_SUMMARY ==="
+  exit 0
+fi
+
+# Push and open PR
+git push origin "$SYNC_BRANCH"
+
+# Build PR body
+APPLIED_LIST=""
+for f in "${APPLIED[@]}"; do APPLIED_LIST="${APPLIED_LIST}- \`${f}\`"$'\n'; done
+
+SKIP_LIST_BODY=""
+for f in "${SKIP_FILES[@]}"; do SKIP_LIST_BODY="${SKIP_LIST_BODY}- ${f}"$'\n'; done
+
+PR_BODY="## Upstream Sync
+
+Pulls framework updates from [vibeacademy/agile-flow](https://github.com/vibeacademy/agile-flow).
+
+| Field | Value |
+|---|---|
+| Previous sync | \`${UPSTREAM_COMMIT:0:8}\` |
+| Upstream HEAD | \`${UPSTREAM_HEAD:0:8}\` |
+
+### Applied (${#APPLIED[@]} files)
+
+${APPLIED_LIST}
+$(if [[ ${#SKIP_FILES[@]} -gt 0 ]]; then echo "### Skipped — stack-specific or excluded (${#SKIP_FILES[@]} files)"; echo ""; echo "${SKIP_LIST_BODY}"; fi)
+---
+*Generated by \`scripts/pull-upstream.sh\`. Review changes before merging.*"
+
+PR_URL=$(gh pr create \
+  --title "chore(upstream): sync framework from agile-flow@${UPSTREAM_HEAD:0:8}" \
+  --body "$PR_BODY" \
+  --base main \
+  --head "$SYNC_BRANCH")
+
+echo ""
+echo "PR created: $PR_URL"
+echo "Review and merge when ready."
+echo ""
+echo "=== PULL_UPSTREAM_SUMMARY ==="
+echo "STATUS=pr_created"
+echo "UPSTREAM_HEAD=${UPSTREAM_HEAD:0:8}"
+echo "APPLIED=${#APPLIED[@]}"
+echo "SKIPPED=${#SKIP_FILES[@]}"
+echo "PR_URL=$PR_URL"
+echo "=== END_SUMMARY ==="


### PR DESCRIPTION
## Summary

Adds the `/pull-upstream` slash command and backing script to the core agile-flow framework. Downstream forks (agile-flow-gcp, agile-flow-aws) receive this via the existing `template-sync` workflow.

This was previously submitted as PR #181 (closed without merge). This is a clean re-submission rebased on current `main`.

## What ships

- **`scripts/pull-upstream.sh`** — safe mid-workshop sync script
  - Fetches `upstream/main`, diffs blob hashes for every `syncDirectories` file
  - Applies upstream files; skips anything in `excludeFromSync`
  - Creates a PR by default; `--direct` applies to current branch immediately
  - `--dry-run` mode for preview
  - Advances `upstreamCommit` in `.agile-flow-version` after each sync
- **`.claude/commands/pull-upstream.md`** — Claude Code slash command
  - Step-by-step instructions for the facilitator
  - Mid-workshop fast path documented
  - Structured output format for result reporting
- **`.github/workflows/pull-upstream.yml`** — `workflow_dispatch` alternative
  - Can push directly to main or open a PR (input toggle)

## Acceptance criteria (VIB-2)

1. Facilitator can run `/pull-upstream` from a participant Codespace mid-workshop
2. Command pulls upstream changes without breaking participant working state
3. Merge conflicts surfaced clearly (clean tree required before running)
4. `--dry-run` preview available

## Related

- Closes VIB-2 in Paperclip
- agile-flow-gcp already has the equivalent merged (PR #172)
- Original PR: #181 (closed without merge)