### PR TITLE
[#27] feat(ci): add template cleanliness gate for cloud-provider terms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,15 @@ jobs:
       - name: Validate agent files
         run: ./scripts/validation/validate-agents.sh
 
+  template-cleanliness:
+    name: template-cleanliness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for forbidden cloud-provider terms
+        run: ./scripts/check-template-cleanliness.sh
+
   lint-agent-policies:
     name: lint-agent-policies
     runs-on: ubuntu-latest

--- a/scripts/check-template-cleanliness.sh
+++ b/scripts/check-template-cleanliness.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fails if GCP/AWS/enterprise-specific terms are found in core agile-flow files.
+# Self-excluded from the scan to avoid false positives on the pattern strings.
+set -euo pipefail
+
+SELF="$(basename "$0")"
+FORBIDDEN='\bgcp\b|google-cloud|\bgcloud\b|cloud-run|\baws\b|\bamazon\b|\bec2\b|\bs3\b|\blambda\b'
+
+SCAN_DIRS=(scripts .claude/commands .github/workflows)
+SCAN_INCLUDE=(--include='*.sh' --include='*.md' --include='*.yml')
+
+violations=0
+for dir in "${SCAN_DIRS[@]}"; do
+  [ -d "$dir" ] || continue
+  while IFS= read -r match; do
+    echo "VIOLATION: $match"
+    violations=$((violations + 1))
+  done < <(grep -rinP "$FORBIDDEN" "${SCAN_INCLUDE[@]}" --exclude="$SELF" "$dir" 2>/dev/null || true)
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "Template cleanliness check FAILED ($violations violation(s))."
+  echo "Forbidden terms: gcp, google-cloud, gcloud, cloud-run, aws, amazon, ec2, s3, lambda"
+  exit 1
+fi
+
+echo "Template cleanliness check PASSED."


### PR DESCRIPTION
## Ticket

Closes VIB-27 — [Add CI template cleanliness gate to agile-flow](https://paperclip-thco.onrender.com/VIB/issues/VIB-27)

Reimplementation of closed PR #186 on a fresh branch off `main`, per Staff Engineer reassignment. PR #186 was closed as part of a cross-PR architectural review (VIB-41), not for issues with the gate code itself — the Staff Engineer's prior review explicitly approved the script and CI job. This branch starts clean off `main` to avoid the VIB-22 bundling problem that affected the first round.

## Summary

- Adds `scripts/check-template-cleanliness.sh` — greps `scripts/`, `.claude/commands/`, and `.github/workflows/` for forbidden enterprise cloud-provider terms (gcp, google-cloud, gcloud, cloud-run, aws, amazon, ec2, s3, lambda) using PCRE word boundaries and case-insensitive matching
- Script self-excludes (`--exclude=$SELF`) so it does not flag its own pattern strings
- Adds `template-cleanliness` job to `ci.yml` that runs the check on every push and PR to `main`

## Changes Made

- `scripts/check-template-cleanliness.sh` (new, executable) — bash script with `set -euo pipefail`, exits non-zero on any violation
- `.github/workflows/ci.yml` — adds `template-cleanliness` job between `test` and `lint-agent-policies`

## Testing

### Automated Tests

- [x] `./scripts/validation/validate-scripts.sh` passes (includes shellcheck where available; new script reports PASS)
- [x] Bash syntax check (`bash -n`) passes
- [x] The script itself runs clean on this branch (no violations)
- [x] Verified that planting a forbidden term causes the script to exit 1 with a VIOLATION line

### Manual Testing

```
$ ./scripts/check-template-cleanliness.sh
Template cleanliness check PASSED.
$ echo "# cloud-run example" > .claude/commands/__test.md && ./scripts/check-template-cleanliness.sh; echo exit=$?
VIOLATION: .claude/commands/__test.md:1:# cloud-run example
Template cleanliness check FAILED (1 violation(s)).
Forbidden terms: gcp, google-cloud, gcloud, cloud-run, aws, amazon, ec2, s3, lambda
exit=1
```

## Acceptance Criteria

- [x] Audit passes with zero violations on `main` (run locally against this branch which is even with main)
- [x] CI check added and runs on every push/PR to `main`
- [x] CI check fails if a future commit introduces a forbidden term

## Checklist

- [x] All tests pass locally
- [x] Code follows project standards (`set -euo pipefail`, quoted variables, conventional commit)
- [x] No linting warnings (`validate-scripts.sh` reports PASS)
- [x] Branched off `main` (no bleed from other in-flight branches)