### PR TITLE
[#55] docs: rewrite /upgrade user docs against actual template-sync mechanism

### DIFF
--- a/docs/DOWNSTREAM-GUIDE.md
+++ b/docs/DOWNSTREAM-GUIDE.md
@@ -1,0 +1,233 @@
+# Downstream Fork Guide
+
+You are running a fork of `vibeacademy/agile-flow`. This guide explains how
+to pull updates to the framework files (agents, commands, hooks, skills,
+scripts, starters) without disturbing your own application code, product
+docs, or configuration.
+
+For the framework/user-content classification of every file in the template,
+see [DISTRIBUTION.md](DISTRIBUTION.md). For deeper troubleshooting, see
+[UPGRADING.md](UPGRADING.md).
+
+---
+
+## How the Upgrade Works (One-Minute Version)
+
+`/upgrade` is a thin Claude Code wrapper around `scripts/template-sync.sh`.
+The script:
+
+1. Reads the local version from `.agile-flow-version`.
+2. Calls the public GitHub API (`api.github.com/repos/vibeacademy/agile-flow/releases/latest`)
+   to find the latest release tag — no authentication required.
+3. If the local version already matches the latest tag, it exits with
+   `Already up to date`.
+4. Otherwise, it downloads the release tarball, extracts it, and **copies**
+   every file in each path listed under `syncDirectories` in
+   `.agile-flow-version`. If a copied file differs from the local file, the
+   local file is overwritten. If a file does not exist locally, it is added.
+5. It bumps `version` inside `.agile-flow-version`, creates a branch
+   named `agile-flow-sync/v{LATEST_VERSION}`, commits as
+   `github-actions[bot]`, pushes the branch, and runs
+   `gh pr create` to open a pull request against `main`.
+6. The script exits. The upgrade is **not** applied to `main` at this point.
+   A human still needs to review and merge the sync PR.
+
+The script takes no flags and offers no interactive prompts. There is no
+git merge step and no three-way conflict resolution. The whole interaction
+with your repo is "copy files, commit, push, open PR."
+
+---
+
+## Pre-Flight Checks
+
+`/upgrade` will stop and ask you to fix the environment before running the
+sync script if either of these is wrong:
+
+1. **Working tree must be clean.** `git status --porcelain` must produce no
+   output. If you have uncommitted changes:
+
+   ```bash
+   git stash
+   /upgrade
+   # After the sync PR is merged:
+   git stash pop
+   ```
+
+2. **GitHub CLI must be authenticated.** `gh auth status` must report a
+   logged-in account that can push branches and open PRs on your fork:
+
+   ```bash
+   gh auth login
+   ```
+
+The script itself uses `gh pr create` at the end, so missing auth means no
+PR.
+
+---
+
+## Running an Upgrade
+
+### Option 1: `/upgrade` from Claude Code (recommended)
+
+From your fork's checkout (Codespace or local), open Claude Code and run:
+
+```
+/upgrade
+```
+
+Claude verifies the pre-flight checks, runs `bash scripts/template-sync.sh`,
+and reports the result. Possible outcomes:
+
+| Output | Meaning |
+|--------|---------|
+| `Already up to date` | Local version matches the latest release. Nothing to do. |
+| `Update available: X -> Y` followed by `ADDED` / `UPDATED` / `SKIP` lines and a PR URL | A sync PR was opened on your fork. Review and merge it to finish the upgrade. |
+| `ERROR: ...` | The script aborted. Read the message and fix the underlying issue (e.g. network, auth, missing `.agile-flow-version`). |
+
+When a PR is created, open it:
+
+```bash
+gh pr view <PR_NUMBER> --web
+```
+
+### Option 2: `Template Sync` workflow from the GitHub UI
+
+If you cannot use Claude Code, the same script runs from a GitHub Actions
+workflow:
+
+1. Go to your fork on GitHub.
+2. **Actions → Template Sync → Run workflow → Run workflow**.
+3. The workflow checks out your repo and runs `bash scripts/template-sync.sh`
+   with `GH_TOKEN=${{ secrets.GITHUB_TOKEN }}`. If an update is available,
+   it opens the same sync PR you would get from `/upgrade`.
+
+The workflow is triggered by `workflow_dispatch` only — it does not run on
+a schedule, so you get an upgrade only when you ask for one.
+
+---
+
+## Reviewing and Merging the Sync PR
+
+Each sync PR is named `chore(sync): update Agile Flow framework to v{VERSION}`
+on a branch `agile-flow-sync/v{VERSION}`. The PR body lists every file the
+script touched plus a link to the upstream release notes.
+
+1. Open the PR (`gh pr view <PR_NUMBER> --web`).
+2. Read the diff. Pay attention to any file you have hand-edited locally —
+   the sync script copies the upstream version directly over it.
+3. If anything looks wrong, close the PR. Your fork is unaffected because
+   the changes only live on the sync branch.
+4. If everything looks right, **Squash and merge**. After the merge, your
+   fork is running the new version.
+
+Your local `main` does not have the new version until you `git pull` after
+the merge.
+
+---
+
+## What Gets Touched (and What Doesn't)
+
+Only paths listed under `syncDirectories` in your `.agile-flow-version`
+file are eligible to be modified. With the shipped template, that is:
+
+- `.claude/agents`
+- `.claude/commands`
+- `.claude/hooks`
+- `.claude/skills`
+- `scripts`
+- `starters`
+
+Anything outside those paths is never read, never compared, and never
+written. That includes `app/`, `__tests__/`, `docs/PRODUCT-REQUIREMENTS.md`,
+`docs/PRODUCT-ROADMAP.md`, `render.yaml`, `eslint.config.mjs`,
+`tsconfig.json`, `next.config.ts`, your migrations, and `.env*`.
+
+The full file-by-file classification lives in
+[DISTRIBUTION.md](DISTRIBUTION.md).
+
+### Hand-Edited Framework Files
+
+`template-sync.sh` does not consult a per-file override list. If you
+hand-edit a file under one of the `syncDirectories` paths (for example,
+you customise `.claude/agents/github-ticket-worker.md`), the next
+`/upgrade` PR will contain a diff that overwrites your edit. The
+protection model is:
+
+- **Review the sync PR.** It will show your edit being reverted, so you
+  can decide whether to merge.
+- **Keep custom files outside `syncDirectories`** so they are never
+  considered for sync. For example, add a new agent under a path the
+  framework does not own, or split your customisation into a separate
+  file.
+
+If your sync PR diff looks wrong, close it. Your fork is unaffected
+because the changes only live on the sync branch.
+
+---
+
+## Quick Reference
+
+### Check your current version
+
+```bash
+jq .version .agile-flow-version
+```
+
+### Check the latest upstream version
+
+```bash
+gh api repos/vibeacademy/agile-flow/releases/latest --jq .tag_name
+```
+
+Or visit the
+[releases page](https://github.com/vibeacademy/agile-flow/releases).
+
+### Trigger an upgrade
+
+| Method | Command |
+|--------|---------|
+| Claude Code | `/upgrade` |
+| GitHub UI | Actions → Template Sync → Run workflow |
+| Shell directly | `bash scripts/template-sync.sh` |
+
+### Inspect or close the sync PR
+
+```bash
+gh pr list --head "agile-flow-sync/v*"
+gh pr view <PR_NUMBER> --web
+gh pr close <PR_NUMBER>
+```
+
+### Re-run after closing an unmerged sync PR
+
+If you closed the sync PR without merging and want a fresh one for the
+same version, delete the remote branch first — `template-sync.sh` skips
+PR creation when the branch already exists on remote:
+
+```bash
+git push origin --delete agile-flow-sync/v{VERSION}
+/upgrade
+```
+
+---
+
+## Files That Drive the Upgrade
+
+| Path | Role |
+|------|------|
+| `.agile-flow-version` | Local version + `syncDirectories` whitelist. Source of truth for "what version am I on?" |
+| `scripts/template-sync.sh` | The actual sync script. Always invoked as-is; takes no flags. |
+| `.claude/commands/upgrade.md` | The `/upgrade` Claude Code wrapper. Adds the pre-flight checks. |
+| `.github/workflows/template-sync.yml` | The `workflow_dispatch` alternative path. |
+| `docs/UPGRADING.md` | Reference guide with troubleshooting; same mechanism, more detail. |
+| `docs/DISTRIBUTION.md` | Per-file classification of framework vs. user-content. |
+
+---
+
+## Troubleshooting
+
+For environment errors (clean tree, `gh auth`, GitHub API rate limit,
+existing sync branch, manual upgrade fallback) see the
+**Troubleshooting** section of [UPGRADING.md](UPGRADING.md). The behaviour
+is identical for downstream forks — there is nothing fork-specific to
+configure.

--- a/docs/FACILITATOR-RUNBOOK.md
+++ b/docs/FACILITATOR-RUNBOOK.md
@@ -1,0 +1,220 @@
+# Workshop Facilitator Runbook
+
+Operational procedures for facilitators running Agile Flow workshops on
+the upstream `vibeacademy/agile-flow` template.
+
+This runbook covers the framework-upgrade story for cohort participants
+who have forked the template into their own GitHub accounts. The same
+mechanism that powers individual `/upgrade` calls is what cohorts use to
+stay in sync with the upstream release line during a workshop.
+
+For full reference detail on the upgrade machinery, see
+[UPGRADING.md](UPGRADING.md). For the participant-facing walkthrough that
+you can hand to a fork owner, see [DOWNSTREAM-GUIDE.md](DOWNSTREAM-GUIDE.md).
+
+---
+
+## Mental Model
+
+Each participant has their own fork of `vibeacademy/agile-flow`. When a
+new release ships, every participant pulls it **independently** by running
+`/upgrade` in their own fork. The script in their fork:
+
+1. Reads their local `.agile-flow-version`.
+2. Calls the public GitHub API to find the latest `vibeacademy/agile-flow`
+   release tag.
+3. Downloads the release tarball.
+4. Copies files from each path listed in `syncDirectories` into their
+   working tree, overwriting any local file that differs.
+5. Creates a branch `agile-flow-sync/v{VERSION}`, commits, pushes, and
+   opens a pull request on their fork.
+
+The participant then reviews and merges the PR on their own. Nothing about
+this flow requires the facilitator to push commits to the participants'
+forks. The facilitator's job during an upgrade is shepherding, not
+pushing.
+
+---
+
+## Mid-Workshop Upgrade Playbook
+
+Use this when you need every participant on a newer framework version
+during an active session.
+
+### 1. Cut the upstream release
+
+Releases are cut on `vibeacademy/agile-flow`. Until a release exists with
+the desired tag, participants' `/upgrade` calls will return
+`Already up to date` for the unreleased changes — `template-sync.sh` only
+sees published releases, not `main`. Confirm the release exists:
+
+```bash
+gh api repos/vibeacademy/agile-flow/releases/latest --jq .tag_name
+```
+
+### 2. Announce the upgrade
+
+Tell the cohort:
+
+> Run `/upgrade` in your fork's Codespace. It will open a sync PR on your
+> fork called `chore(sync): update Agile Flow framework to v{VERSION}`.
+> Review the diff, merge it, and pull on your local clone.
+
+### 3. Walk participants through the pre-flight checks
+
+`/upgrade` will refuse to proceed if either check fails:
+
+- **Clean working tree.** `git status --porcelain` must be empty. If a
+  participant has uncommitted in-progress work, have them
+  `git stash` first.
+- **Authenticated `gh`.** `gh auth status` must show a logged-in account
+  with permission to push branches and create PRs on the participant's
+  fork. If it does not, have them run `gh auth login` and re-run.
+
+### 4. Walk participants through the result
+
+The script prints one of:
+
+| Output | What the participant should do |
+|--------|--------------------------------|
+| `Already up to date` | Nothing. Their fork is on the latest release. |
+| `Update available: X -> Y` followed by `ADDED` / `UPDATED` / `SKIP` lines and a PR URL | Open the PR, review the diff, squash-and-merge. Then `git pull` locally. |
+| `ERROR: ...` | Read the message. Most failures are network or `gh auth`. |
+
+### 5. Confirm the cohort has converged
+
+After the cohort has merged their sync PRs:
+
+```bash
+# Spot-check a few participant forks
+gh api repos/{user}/agile-flow/contents/.agile-flow-version --jq '.content' | base64 -d | jq .version
+```
+
+Every fork should now report the new release tag.
+
+---
+
+## Alternative Path: GitHub Actions
+
+A participant who is not in a Claude Code session can run the same script
+from the GitHub UI:
+
+1. Their fork → **Actions → Template Sync → Run workflow → Run workflow**.
+2. The workflow runs `bash scripts/template-sync.sh` with the
+   workflow-scoped `GITHUB_TOKEN`.
+3. The outcome is identical: a sync PR opened on the participant's fork.
+
+The workflow is `workflow_dispatch` only — there is no schedule, no auto
+trigger, no daily run. The participant always initiates.
+
+---
+
+## What Is and Is Not Touched
+
+The sync script only reads and writes files inside paths listed in
+`syncDirectories` of `.agile-flow-version`. For the shipped template,
+that is:
+
+- `.claude/agents`
+- `.claude/commands`
+- `.claude/hooks`
+- `.claude/skills`
+- `scripts`
+- `starters`
+
+Application code, product docs, deployment config, lint config, lockfiles
+and migrations are never touched. The per-file classification is in
+[DISTRIBUTION.md](DISTRIBUTION.md).
+
+### Hand-Edited Framework Files
+
+`template-sync.sh` does not consult a per-file override list. If a
+participant hand-edits a file inside `syncDirectories`, the next sync PR
+will overwrite their edit. Their protection is the PR review — the diff
+will show the revert and they can choose not to merge.
+
+If a participant wants permanent local customisations, coach them to add
+**new** files outside `syncDirectories` rather than editing framework
+files in place.
+
+---
+
+## Common Participant Issues
+
+### "Working tree has uncommitted changes"
+
+```bash
+git stash
+/upgrade
+# After the sync PR is merged and pulled:
+git stash pop
+```
+
+### "GitHub CLI is not authenticated"
+
+```bash
+gh auth login
+```
+
+Make sure the authenticated account is the one that owns the fork.
+
+### "Could not fetch latest release"
+
+The script hits the public GitHub API unauthenticated, which has a
+60-requests-per-hour limit per IP. In a cohort sharing the same
+Codespace egress IP, a busy session can hit the limit.
+
+Workarounds:
+
+- Wait for the rate-limit window to reset.
+- Use the `Template Sync` workflow path (runs from GitHub-side
+  infrastructure, separate rate limit).
+
+### "Branch agile-flow-sync/v{VERSION} already exists on remote"
+
+A previous sync attempt left the branch on the fork's `origin`. Two
+options:
+
+1. The PR is still open — review and merge that one.
+2. The PR was closed without merging — delete the remote branch first,
+   then re-run:
+
+   ```bash
+   git push origin --delete agile-flow-sync/v{VERSION}
+   /upgrade
+   ```
+
+### "The PR opened but the changes look wrong"
+
+Have the participant close the PR. The fork's `main` is unaffected — the
+copy only lives on the sync branch. Then debug.
+
+---
+
+## What This Runbook Does **Not** Cover
+
+- **Pushing framework changes from a facilitator-controlled repo into
+  participant forks.** The upstream → fork direction is participant-driven
+  (`/upgrade`), not facilitator-pushed. There is no facilitator-side
+  "push update to all forks" command for the `vibeacademy/agile-flow`
+  template.
+- **GCP-track workshops.** The `agile-flow-gcp` edition adds a second
+  hop and a separate maintainer tool (`/pull-upstream`). For that flow,
+  see the runbook in the `agile-flow-gcp` repo.
+- **Manual upgrades.** If the script genuinely cannot run (e.g., a
+  participant has an air-gapped fork), see the "Manual Upgrade" section
+  in [UPGRADING.md](UPGRADING.md).
+
+---
+
+## Reference
+
+| Path | Role |
+|------|------|
+| `.agile-flow-version` | Local version + `syncDirectories` whitelist. |
+| `scripts/template-sync.sh` | The sync script — release-tarball based, no flags. |
+| `.claude/commands/upgrade.md` | The `/upgrade` Claude Code wrapper. |
+| `.github/workflows/template-sync.yml` | The `workflow_dispatch` alternative. |
+| `docs/UPGRADING.md` | Reference + troubleshooting. |
+| `docs/DOWNSTREAM-GUIDE.md` | Participant-facing walkthrough. |
+| `docs/DISTRIBUTION.md` | Framework/user-content classification. |


### PR DESCRIPTION
## Ticket

Closes VIB-55. Follow-up to VIB-54 (verification result: FAIL — docs described cancelled VIB-22/VIB-23 design).

## Summary

The VIB-28 drafts of `docs/DOWNSTREAM-GUIDE.md` and `docs/FACILITATOR-RUNBOOK.md` were sitting **untracked** in the working tree and described the cancelled `.agile-flow-meta/` + git-merge architecture rather than the on-main release-tarball mechanism. Rewriting cleanly against the actual machinery before anything ships to downstream forks.

Both files now describe the same flow that `docs/UPGRADING.md` already documents:

`.agile-flow-version` → `scripts/template-sync.sh` → release tarball → file-copy of each `syncDirectories` path → sync PR (`agile-flow-sync/v{VERSION}`) → human review and merge.

## Changes Made

- **`docs/DOWNSTREAM-GUIDE.md`** (new file) — Fork owner walkthrough. Pre-flight checks (clean tree, `gh auth`), Claude `/upgrade` vs `Actions → Template Sync` paths, what's in `syncDirectories`, PR review behaviour, troubleshooting cross-references to `UPGRADING.md`.
- **`docs/FACILITATOR-RUNBOOK.md`** (new file) — Cohort/workshop facing. Mental model (participant-driven, not facilitator-pushed), mid-workshop playbook, GitHub Actions fallback, common participant issues (rate limits, stale sync branch, hand-edited framework files).

## Guardrails Satisfied (per VIB-55)

- [x] No references to `.agile-flow-meta/`
- [x] No references to `scripts/upgrade.sh`
- [x] No `--accept-upstream` / `--abort-on-conflict` / `--continue` flags
- [x] No `pre-upgrade-{timestamp}` rollback tags
- [x] No `git merge --abort` recovery
- [x] No `--no-commit --no-ff` merge model
- [x] PR-based outcome explicit: `/upgrade` opens a sync PR; nothing is applied to `main` by the script itself
- [x] Both pre-flight checks documented (clean tree + `gh auth status`)
- [x] Both upgrade paths documented (`/upgrade` + `Actions → Template Sync`)
- [x] Quick Reference references only paths that exist on main
- [x] `.agile-flow-overrides` not mentioned (GCP-runbook scope only)

## How To Verify

Cross-check every claim in either file against:
- `scripts/template-sync.sh` (the only sync implementation)
- `.claude/commands/upgrade.md` (pre-flight checks + wrapper behaviour)
- `.github/workflows/template-sync.yml` (workflow_dispatch alternative)
- `docs/UPGRADING.md` (canonical reference; new docs intentionally point to it for troubleshooting)

## Out of Scope

- `/report-issue` sections of any DOWNSTREAM-GUIDE.md — the same `.agile-flow-meta/reports/` fictions live there and need a separate verification ticket.
- The hard-coded `UPSTREAM_REPO` in `agile-flow-gcp/scripts/template-sync.sh` (real bug; participant-`/upgrade` in a GCP fork pulls from `agile-flow`, not `agile-flow-gcp`). The companion GCP runbook PR documents the current behaviour honestly; the script fix is a separate ticket.

## Testing

### Manual
- [x] Read each rewritten claim against `scripts/template-sync.sh` line-by-line.
- [x] Confirmed every path mentioned in Quick Reference exists on `main`.
- [x] Confirmed `docs/UPGRADING.md` and `docs/DISTRIBUTION.md` cross-references resolve.
- [x] Grep for forbidden tokens (`agile-flow-meta`, `scripts/upgrade.sh`, conflict flags, `pre-upgrade-`, `merge --abort`, `--no-commit --no-ff`, `.agile-flow-overrides`) — zero matches in both files.

### Automated
- [ ] No automated test layer for docs. CI markdown linting (if any) will run on push.

## Checklist
- [x] Follows project documentation conventions
- [x] No linting warnings expected (plain Markdown, no broken cross-references)
- [x] Guardrail compliance verified by grep