### PR TITLE
fix(scripts): template-sync honors .agile-flow-overrides

### DIFF
--- a/scripts/lib/overrides.sh
+++ b/scripts/lib/overrides.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# overrides.sh -- Shared loader for .agile-flow-overrides.
+#
+# Sourced by template-sync.sh (and downstream pull-upstream.sh) so both flows
+# agree on which framework files are intentionally fork-customised and must
+# never be overwritten by an upstream sync.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/overrides.sh"
+#   load_override_patterns ".agile-flow-overrides"   # populates OVERRIDE_PATTERNS
+#   if is_override "scripts/doctor.sh"; then ... ; fi
+#
+# File format (.agile-flow-overrides):
+#   - One path per line, relative to the repo root
+#   - Lines starting with `#` are comments
+#   - Blank lines are ignored
+#   - Bash glob characters (`*`, `?`, `[...]`) match any portion of the path.
+#     Note: bash pattern matching is greedy — `*` will cross `/`, so
+#     `scripts/*.sh` also matches `scripts/lib/overrides.sh`. Use a more
+#     specific path if you need a narrower match.
+
+# Indexed array of patterns loaded from the overrides file.
+OVERRIDE_PATTERNS=()
+
+# load_override_patterns <overrides-file>
+#
+# Populates OVERRIDE_PATTERNS from the given file. If the file does not exist
+# (the common case on a fresh fork), OVERRIDE_PATTERNS is left empty and
+# is_override always returns 1. This preserves first-run behavior.
+load_override_patterns() {
+  local overrides_file="${1:-.agile-flow-overrides}"
+  OVERRIDE_PATTERNS=()
+
+  [ -f "$overrides_file" ] || return 0
+
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    # Trim leading/trailing whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -z "$line" ] && continue
+    [[ "$line" == \#* ]] && continue
+    OVERRIDE_PATTERNS+=("$line")
+  done < "$overrides_file"
+}
+
+# is_override <relative-path>
+#
+# Returns 0 if the given path matches any loaded override pattern, 1 otherwise.
+# Patterns use bash glob semantics (e.g. `scripts/doctor.sh`, `scripts/*.sh`).
+is_override() {
+  local path="$1"
+  local pattern
+  for pattern in "${OVERRIDE_PATTERNS[@]}"; do
+    # shellcheck disable=SC2053
+    if [[ "$path" == $pattern ]]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/scripts/lib/overrides.test.sh
+++ b/scripts/lib/overrides.test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Tests for scripts/lib/overrides.sh
+# Usage: ./scripts/lib/overrides.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/overrides.sh
+source "$SCRIPT_DIR/overrides.sh"
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+assert_eq() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_match() {
+  local name="$1"
+  local path="$2"
+  if is_override "$path"; then
+    echo -e "  ${GREEN}PASS${NC}: $name ('$path' matches)"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $name ('$path' should match)"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_no_match() {
+  local name="$1"
+  local path="$2"
+  if is_override "$path"; then
+    echo -e "  ${RED}FAIL${NC}: $name ('$path' should NOT match)"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  else
+    echo -e "  ${GREEN}PASS${NC}: $name ('$path' does not match)"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  fi
+}
+
+echo "Running overrides.sh tests"
+echo "=========================="
+
+echo
+echo "Test 1: Missing overrides file leaves OVERRIDE_PATTERNS empty"
+load_override_patterns "$WORK_DIR/does-not-exist"
+assert_eq "OVERRIDE_PATTERNS length is 0" "0" "${#OVERRIDE_PATTERNS[@]}"
+assert_no_match "first-run behavior unchanged" "scripts/doctor.sh"
+
+echo
+echo "Test 2: Empty overrides file leaves OVERRIDE_PATTERNS empty"
+: > "$WORK_DIR/empty"
+load_override_patterns "$WORK_DIR/empty"
+assert_eq "empty file -> 0 patterns" "0" "${#OVERRIDE_PATTERNS[@]}"
+
+echo
+echo "Test 3: Exact path match"
+cat > "$WORK_DIR/exact" <<'EOF'
+scripts/doctor.sh
+.claude/agents/system-architect.md
+EOF
+load_override_patterns "$WORK_DIR/exact"
+assert_eq "loaded 2 patterns" "2" "${#OVERRIDE_PATTERNS[@]}"
+assert_match "doctor.sh listed -> match" "scripts/doctor.sh"
+assert_match "agent file listed -> match" ".claude/agents/system-architect.md"
+assert_no_match "unrelated file -> no match" "scripts/template-sync.sh"
+
+echo
+echo "Test 4: Comments and blank lines are ignored"
+cat > "$WORK_DIR/comments" <<'EOF'
+# This is a comment
+
+   # Indented comment
+
+scripts/doctor.sh
+
+# Another comment
+scripts/extra.sh
+EOF
+load_override_patterns "$WORK_DIR/comments"
+assert_eq "loaded 2 patterns (comments stripped)" "2" "${#OVERRIDE_PATTERNS[@]}"
+assert_match "doctor.sh still matches" "scripts/doctor.sh"
+assert_match "extra.sh still matches" "scripts/extra.sh"
+
+echo
+echo "Test 5: Leading/trailing whitespace is trimmed"
+cat > "$WORK_DIR/whitespace" <<'EOF'
+   scripts/doctor.sh
+scripts/extra.sh
+EOF
+load_override_patterns "$WORK_DIR/whitespace"
+assert_match "leading whitespace trimmed" "scripts/doctor.sh"
+assert_match "trailing whitespace trimmed" "scripts/extra.sh"
+
+echo
+echo "Test 6: Glob patterns"
+cat > "$WORK_DIR/globs" <<'EOF'
+scripts/*.sh
+.claude/agents/gcp-*.md
+docs/**
+EOF
+load_override_patterns "$WORK_DIR/globs"
+assert_match "scripts/*.sh matches scripts/doctor.sh" "scripts/doctor.sh"
+assert_match "scripts/*.sh matches scripts/workshop-setup.sh" "scripts/workshop-setup.sh"
+# Bash pattern matching: `*` is greedy and crosses `/`, so a glob anchored to
+# a directory prefix matches nested files too. Documented in overrides.sh.
+assert_match "scripts/*.sh also matches nested file (bash glob is greedy)" "scripts/lib/overrides.sh"
+assert_match "gcp-*.md matches gcp-engineer" ".claude/agents/gcp-engineer.md"
+assert_no_match "gcp-*.md does NOT match other agents" ".claude/agents/system-architect.md"
+
+echo
+echo "Test 7: Reloading replaces previous patterns"
+cat > "$WORK_DIR/first" <<'EOF'
+scripts/doctor.sh
+EOF
+cat > "$WORK_DIR/second" <<'EOF'
+docs/PATTERN-LIBRARY.md
+EOF
+load_override_patterns "$WORK_DIR/first"
+assert_match "first load: doctor.sh matches" "scripts/doctor.sh"
+load_override_patterns "$WORK_DIR/second"
+assert_no_match "after reload: doctor.sh no longer matches" "scripts/doctor.sh"
+assert_match "after reload: PATTERN-LIBRARY matches" "docs/PATTERN-LIBRARY.md"
+
+echo
+echo "Test 8: File without trailing newline still reads last line"
+printf 'scripts/doctor.sh' > "$WORK_DIR/no-newline"
+load_override_patterns "$WORK_DIR/no-newline"
+assert_eq "1 pattern loaded (no trailing newline)" "1" "${#OVERRIDE_PATTERNS[@]}"
+assert_match "last line still matched" "scripts/doctor.sh"
+
+echo
+echo "=========================="
+echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+
+if [ "$TESTS_FAILED" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/lib/overrides.test.sh
+++ b/scripts/lib/overrides.test.sh
@@ -115,7 +115,7 @@ echo
 echo "Test 6: Glob patterns"
 cat > "$WORK_DIR/globs" <<'EOF'
 scripts/*.sh
-.claude/agents/gcp-*.md
+.claude/agents/worker-*.md
 docs/**
 EOF
 load_override_patterns "$WORK_DIR/globs"
@@ -124,8 +124,8 @@ assert_match "scripts/*.sh matches scripts/workshop-setup.sh" "scripts/workshop-
 # Bash pattern matching: `*` is greedy and crosses `/`, so a glob anchored to
 # a directory prefix matches nested files too. Documented in overrides.sh.
 assert_match "scripts/*.sh also matches nested file (bash glob is greedy)" "scripts/lib/overrides.sh"
-assert_match "gcp-*.md matches gcp-engineer" ".claude/agents/gcp-engineer.md"
-assert_no_match "gcp-*.md does NOT match other agents" ".claude/agents/system-architect.md"
+assert_match "worker-*.md matches worker-engineer" ".claude/agents/worker-engineer.md"
+assert_no_match "worker-*.md does NOT match other agents" ".claude/agents/system-architect.md"
 
 echo
 echo "Test 7: Reloading replaces previous patterns"

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -3,6 +3,7 @@
 # Called by .github/workflows/template-sync.yml (workflow_dispatch only).
 # Guardrails:
 #   - Only syncs directories/files listed in syncDirectories (.agile-flow-version)
+#   - Respects .agile-flow-overrides — fork-local paths/globs are never touched
 #   - Does NOT auto-merge; PR requires human review
 #   - Uses unauthenticated GitHub API to fetch release metadata
 
@@ -10,6 +11,11 @@ set -euo pipefail
 
 UPSTREAM_REPO="vibeacademy/agile-flow"
 VERSION_FILE=".agile-flow-version"
+OVERRIDES_FILE=".agile-flow-overrides"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/overrides.sh
+source "$SCRIPT_DIR/lib/overrides.sh"
 
 ###############################################################################
 # 1. Read local version and syncDirectories
@@ -28,6 +34,9 @@ print('\n'.join(dirs))
 
 echo "Local version : $LOCAL_VERSION"
 echo "Sync targets  : $SYNC_DIRS"
+
+load_override_patterns "$OVERRIDES_FILE"
+echo "Protected overrides: ${#OVERRIDE_PATTERNS[@]} pattern(s)"
 
 ###############################################################################
 # 2. Fetch latest release from GitHub (unauthenticated)
@@ -76,6 +85,7 @@ fi
 # 5. Sync each directory/file from syncDirectories
 ###############################################################################
 FILES_CHANGED=()
+FILES_SKIPPED_OVERRIDE=()
 
 while IFS= read -r sync_path; do
   [ -z "$sync_path" ] && continue
@@ -93,6 +103,12 @@ while IFS= read -r sync_path; do
       rel_file="${file#"$upstream_path"/}"
       local_file="$sync_path/$rel_file"
       upstream_file="$file"
+
+      if is_override "$local_file"; then
+        echo "SKIP (override): $local_file"
+        FILES_SKIPPED_OVERRIDE+=("$local_file")
+        continue
+      fi
 
       # Create parent directory if needed
       mkdir -p "$(dirname "$local_file")"
@@ -113,6 +129,12 @@ while IFS= read -r sync_path; do
     done < <(find "$upstream_path" -type f)
   else
     # Single file sync
+    if is_override "$sync_path"; then
+      echo "SKIP (override): $sync_path"
+      FILES_SKIPPED_OVERRIDE+=("$sync_path")
+      continue
+    fi
+
     if [ -f "$sync_path" ]; then
       if ! diff -q "$upstream_path" "$sync_path" >/dev/null 2>&1; then
         cp "$upstream_path" "$sync_path"
@@ -129,6 +151,10 @@ while IFS= read -r sync_path; do
     fi
   fi
 done <<< "$SYNC_DIRS"
+
+if [ "${#FILES_SKIPPED_OVERRIDE[@]}" -gt 0 ]; then
+  echo "Skipped ${#FILES_SKIPPED_OVERRIDE[@]} override(s) — kept local versions."
+fi
 
 ###############################################################################
 # 6. Clean up


### PR DESCRIPTION
## Ticket

Paperclip: [VIB-57 — DEF-001: template-sync.sh must honor .agile-flow-overrides](/VIB/issues/VIB-57)

(No corresponding GitHub issue. Tracking lives in Paperclip.)

## Summary

`scripts/template-sync.sh` silently overwrote locally-customised framework files even when they were listed in `.agile-flow-overrides`, a hard regression vs. `scripts/pull-upstream.sh` (downstream). This PR teaches `template-sync.sh` to read `.agile-flow-overrides` and skip matching paths, with the same semantics as `pull-upstream.sh` plus bash-glob support.

## Changes Made

- New `scripts/lib/overrides.sh` — sourceable helper exposing `load_override_patterns` and `is_override`. Comments and blank lines stripped, leading/trailing whitespace trimmed, missing file yields zero patterns (first-run behaviour unchanged).
- `scripts/template-sync.sh` — sources the helper, loads patterns from `.agile-flow-overrides`, and skips overridden paths in both the directory-sync and single-file-sync branches. Skipped files report as `SKIP (override): <path>` and roll up into a `Skipped N override(s) — kept local versions.` summary line.
- New `scripts/lib/overrides.test.sh` — 22 unit tests covering exact match, comments, blank lines, whitespace trimming, globs, reloading, missing file, and a file without a trailing newline.

## Testing

### Automated tests

- [x] `bash scripts/lib/overrides.test.sh` — 22/22 pass
- [x] `bash scripts/validation/validate-scripts.sh` — all scripts pass syntax check
- [x] `bash -n scripts/template-sync.sh` — no syntax errors

### Manual end-to-end repro

Followed the VIB-53 S3 scenario locally with a synthetic upstream tarball and a fixture fork:

- Override file lists `scripts/doctor.sh`; local copy customised — after sync, md5 unchanged, output emits `SKIP (override): scripts/doctor.sh`. ✓
- Non-overridden file `.claude/agents/old-agent.md` — updated as expected. ✓
- New file `scripts/new-script.sh` — added as expected. ✓
- No `.agile-flow-overrides` present — `doctor.sh` updates as before (first-run path unchanged). ✓

## Acceptance Criteria Mapping

- [x] `scripts/template-sync.sh` reads `.agile-flow-overrides` if present in repo root → via `load_override_patterns "$OVERRIDES_FILE"`
- [x] Each path in the sync loop is checked against the override list before `cp` → `is_override` guard in both branches
- [x] Matching paths are skipped and reported as `SKIP (override): <path>` → see new `echo` lines
- [x] First-run behaviour (no `.agile-flow-overrides`) is unchanged → helper returns 0 early, `OVERRIDE_PATTERNS=()`, `is_override` always returns 1
- [x] Exit codes are unchanged → no early-exit paths added
- [x] Manual repro from VIB-53 S3 now preserves `scripts/doctor.sh` → verified above

## Guardrails Honored

- Reused override-loader logic in spirit of `scripts/pull-upstream.sh` (which lives in `agile-flow-gcp`); extracted into `scripts/lib/overrides.sh` so future agile-flow scripts can share it.
- No changes to branch/PR-creation logic in `template-sync.sh`.
- No `.agile-flow-overrides` example committed to this framework repo.

## Follow-up

After merge, `agile-flow-gcp` should pull this version via its existing `template-sync` flow (script is byte-identical between repos). DEF-002 / DEF-003 in VIB-52 remain separate.

## Checklist

- [x] All tests pass (lint + vitest passed in pre-push)
- [x] Code follows project conventions (matches existing script style)
- [x] No new linter warnings
- [x] Manual repro confirms acceptance criteria