### PR TITLE
[VIB-60] fix(template-sync): idempotent re-run + scoped commit identity (DEF-004, DEF-005)

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -54,6 +54,22 @@ fi
 echo "Update available: $LOCAL_VERSION -> $LATEST_VERSION"
 
 ###############################################################################
+# 3a. Skip cleanly if the sync branch is already pushed (idempotent re-run)
+###############################################################################
+SYNC_BRANCH="agile-flow-sync/v${LATEST_VERSION}"
+
+if git ls-remote --exit-code --heads origin "$SYNC_BRANCH" >/dev/null 2>&1; then
+  echo "Sync branch '$SYNC_BRANCH' already exists on remote — nothing to do."
+  if command -v gh >/dev/null 2>&1; then
+    EXISTING_PR_URL=$(gh pr list --head "$SYNC_BRANCH" --state open --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    if [ -n "${EXISTING_PR_URL:-}" ]; then
+      echo "Existing PR: $EXISTING_PR_URL"
+    fi
+  fi
+  exit 0
+fi
+
+###############################################################################
 # 4. Download and extract release tarball
 ###############################################################################
 WORK_DIR=$(mktemp -d)
@@ -146,13 +162,7 @@ fi
 ###############################################################################
 # 8. Create branch, commit, and open PR
 ###############################################################################
-SYNC_BRANCH="agile-flow-sync/v${LATEST_VERSION}"
-
-# Check if a branch or PR already exists for this version
-if git ls-remote --heads origin "$SYNC_BRANCH" | grep -q "$SYNC_BRANCH"; then
-  echo "Branch $SYNC_BRANCH already exists on remote. Skipping PR creation."
-  exit 0
-fi
+# SYNC_BRANCH was computed and verified absent on remote in step 3a above.
 
 git checkout -b "$SYNC_BRANCH"
 
@@ -168,11 +178,12 @@ with open('$VERSION_FILE', 'w') as f:
 "
 git add "$VERSION_FILE"
 
-git config user.name "github-actions[bot]"
-git config user.email "github-actions[bot]@users.noreply.github.com"
-
 COMMIT_MSG="chore(sync): update Agile Flow framework to v${LATEST_VERSION}"
-git commit -m "$COMMIT_MSG"
+# Scope the bot identity to this single commit using -c so running locally
+# does NOT overwrite the user's per-repo git author config.
+git -c user.name="github-actions[bot]" \
+    -c user.email="github-actions[bot]@users.noreply.github.com" \
+    commit -m "$COMMIT_MSG"
 git push origin "$SYNC_BRANCH"
 
 # Build file list for PR body


### PR DESCRIPTION
## Ticket

Paperclip: VIB-60 — *template-sync.sh polish: idempotent re-run + scoped commit identity (DEF-004 + DEF-005)*

Source defects from the VIB-53 end-to-end /upgrade test.

## Summary

Two follow-up polish defects in `scripts/template-sync.sh`:

- **DEF-004 (MAJOR)** — Re-running the script after the sync branch was already pushed used to leave the working tree dirty with staged framework-file changes on `main` while the script exited 0 with `Branch ... already exists on remote. Skipping PR creation.` That made it easy to accidentally commit those staged changes to `main`.
- **DEF-005 (MINOR)** — `scripts/template-sync.sh` called `git config user.name "github-actions[bot]"` without `--local --temporary` scoping. When run by a human on a developer machine, this overrode their per-repo author identity persistently.

Combined into one PR because both are small and both touch `template-sync.sh`.

## Changes Made

- `scripts/template-sync.sh`:
  - New section 3a runs `git ls-remote --exit-code --heads origin "$SYNC_BRANCH"` immediately after the version comparison, BEFORE the tarball download, rollback-tag step, or any `cp` invocation. If the branch already exists, the script prints a clear message (including the existing PR URL when `gh` is available) and exits 0 cleanly — no working-tree changes, no staged files.
  - The duplicate branch-existence check that used to live mid-script (after files had already been staged) is removed.
  - The `git config user.name/email "github-actions[bot]"` pair is replaced with inline `git -c user.name=... -c user.email=... commit` so the bot identity is scoped to the single sync commit. Local repo config is never mutated, but CI commits remain authored by `github-actions[bot]`.

## Testing

### Manual Testing

Built a sandbox repo with a bare "remote" containing `agile-flow-sync/v1.0.0` to exercise both DEF paths.

**DEF-004** — re-run with sync branch already on remote:

```
Update available: 0.1.0 -> 1.0.0
Sync branch 'agile-flow-sync/v1.0.0' already exists on remote — nothing to do.
Existing PR: https://example.com/fake/pull/42
```

- Exit code: `0`
- `git status`: clean
- Staged file count: `0`

**DEF-005** — fresh run that performs the actual commit:

- Pre-run local config: `user.name = "Pre-existing User"`, `user.email = "preexisting@example.com"`
- Post-run local config: **unchanged** (`Pre-existing User` / `preexisting@example.com`)
- Resulting commit author: `github-actions[bot] <github-actions[bot]@users.noreply.github.com>`

### Automated Tests

- Pre-push hook (Node project): eslint passed, vitest passed (6/6)
- `bash -n` syntax check: clean

## Companion PR

Same patch applied to the GCP fork (also has `scripts/template-sync.sh`):

- `vibeacademy/agile-flow-gcp` PR: *will link from comment after creation*

## Acceptance Criteria

- [x] When the target sync branch already exists on remote, the script exits cleanly with no `cp` calls, no staged changes, and no working-tree modifications
- [x] Script prints a clear message identifying the existing branch and pointing the user at the existing PR (when `gh` is available)
- [x] Running the script locally does not persistently change `git config --local user.name` or `user.email`
- [x] CI cron run (`template-sync.yml`) still produces commits authored by the bot identity (`-c user.name=... -c user.email=...` is passed at commit time)
- [x] Change applied to both `agile-flow` and `agile-flow-gcp`

## Checklist

- [x] All tests pass
- [x] Code follows project standards
- [x] No linting warnings
- [x] Manually verified both DEF paths against a sandbox