### PR TITLE
[VIB-120] fix: prevent template-sync.sh runtime crash when invoked via sh

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -13,6 +13,7 @@ if [ -z "${BASH_VERSION:-}" ]; then
   exec bash "$0" "$@"
 fi
 
+main() {
 set -euo pipefail
 
 UPSTREAM_REPO="vibeacademy/agile-flow"
@@ -281,3 +282,6 @@ echo "===================== Summary ====================="
 echo "PR created successfully for v${LATEST_VERSION}."
 echo "Rollback: git reset --hard $ROLLBACK_TAG"
 echo "==================================================="
+}
+
+main "$@"

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -7,6 +7,12 @@
 #   - Does NOT auto-merge; PR requires human review
 #   - Uses unauthenticated GitHub API to fetch release metadata
 
+# If invoked via `sh scripts/template-sync.sh`, re-exec with bash so bash-only
+# features below (arrays/process substitution) do not crash at runtime.
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+
 set -euo pipefail
 
 UPSTREAM_REPO="vibeacademy/agile-flow"


### PR DESCRIPTION
## Ticket
Quick fix — no linked ticket
Internal: VIB-120 (DEF-EXEC-002)

## Summary
Prevents `scripts/template-sync.sh` from crashing when invoked through `sh` by re-executing under Bash before any Bash-only syntax is parsed. This preserves existing behavior for normal Bash execution while making invocation mode robust for downstream Node template automation.

## Changes Made
- Added an early Bash re-exec guard in `scripts/template-sync.sh`
- Documented why the guard is required (arrays and process substitution in the script body)

## Testing
### Automated Tests
- [x] Unit tests pass (`bash scripts/lib/overrides.test.sh`)
- [ ] Integration tests pass (not run)
- [ ] Coverage meets threshold (not applicable)

### Manual Testing
- Ran `sh scripts/template-sync.sh` to verify invocation via `sh` no longer fails with shell syntax/control-flow errors and reaches normal runtime checks.

## Screenshots/Demo
N/A

## Checklist
- [x] All tests pass (for touched area)
- [x] Code follows project standards
- [x] No linting warnings (shell script change only)
- [x] Built successfully (not applicable)
