### PR TITLE
[#129] Fix template-sync runtime self-overwrite guard

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -32,11 +32,25 @@ RUNTIME_PROTECTED_PATHS=(
   "scripts/lib/overrides.sh"
 )
 
+normalize_rel_path() {
+  local path="$1"
+  while [[ "$path" == ./* ]]; do
+    path="${path#./}"
+  done
+  while [[ "$path" == *"//"* ]]; do
+    path="${path//\/\//\/}"
+  done
+  path="${path%/}"
+  printf '%s\n' "$path"
+}
+
 is_runtime_protected() {
   local path="$1"
+  local normalized_path
+  normalized_path="$(normalize_rel_path "$path")"
   local protected
   for protected in "${RUNTIME_PROTECTED_PATHS[@]}"; do
-    if [ "$path" = "$protected" ]; then
+    if [ "$normalized_path" = "$(normalize_rel_path "$protected")" ]; then
       return 0
     fi
   done
@@ -175,11 +189,12 @@ while IFS= read -r sync_path; do
     while IFS= read -r file; do
       rel_file="${file#"$upstream_path"/}"
       local_file="$sync_path/$rel_file"
+      normalized_local_file="$(normalize_rel_path "$local_file")"
       upstream_file="$file"
 
-      if is_runtime_protected "$local_file"; then
-        echo "SKIP (runtime-protected): $local_file"
-        FILES_SKIPPED_RUNTIME+=("$local_file")
+      if is_runtime_protected "$normalized_local_file"; then
+        echo "SKIP (runtime-protected): $normalized_local_file"
+        FILES_SKIPPED_RUNTIME+=("$normalized_local_file")
         continue
       fi
 
@@ -212,9 +227,10 @@ while IFS= read -r sync_path; do
     done < <(find "$upstream_path" -type f)
   else
     # Single file sync
-    if is_runtime_protected "$sync_path"; then
-      echo "SKIP (runtime-protected): $sync_path"
-      FILES_SKIPPED_RUNTIME+=("$sync_path")
+    normalized_sync_path="$(normalize_rel_path "$sync_path")"
+    if is_runtime_protected "$normalized_sync_path"; then
+      echo "SKIP (runtime-protected): $normalized_sync_path"
+      FILES_SKIPPED_RUNTIME+=("$normalized_sync_path")
       continue
     fi
 

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -25,6 +25,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/overrides.sh
 source "$SCRIPT_DIR/lib/overrides.sh"
 
+# Runtime-critical files must never be overwritten while this script is running.
+# The overrides file is user-configurable, so we enforce these guards in code.
+RUNTIME_PROTECTED_PATHS=(
+  "scripts/template-sync.sh"
+  "scripts/lib/overrides.sh"
+)
+
+is_runtime_protected() {
+  local path="$1"
+  local protected
+  for protected in "${RUNTIME_PROTECTED_PATHS[@]}"; do
+    if [ "$path" = "$protected" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 ###############################################################################
 # 1. Read local version and syncDirectories
 ###############################################################################
@@ -140,6 +158,7 @@ echo "Created rollback tag: $ROLLBACK_TAG (local-only)"
 ###############################################################################
 FILES_CHANGED=()
 FILES_SKIPPED_OVERRIDE=()
+FILES_SKIPPED_RUNTIME=()
 
 while IFS= read -r sync_path; do
   [ -z "$sync_path" ] && continue
@@ -157,6 +176,12 @@ while IFS= read -r sync_path; do
       rel_file="${file#"$upstream_path"/}"
       local_file="$sync_path/$rel_file"
       upstream_file="$file"
+
+      if is_runtime_protected "$local_file"; then
+        echo "SKIP (runtime-protected): $local_file"
+        FILES_SKIPPED_RUNTIME+=("$local_file")
+        continue
+      fi
 
       if is_override "$local_file"; then
         echo "SKIP (override): $local_file"
@@ -187,6 +212,12 @@ while IFS= read -r sync_path; do
     done < <(find "$upstream_path" -type f)
   else
     # Single file sync
+    if is_runtime_protected "$sync_path"; then
+      echo "SKIP (runtime-protected): $sync_path"
+      FILES_SKIPPED_RUNTIME+=("$sync_path")
+      continue
+    fi
+
     if is_override "$sync_path"; then
       echo "SKIP (override): $sync_path"
       FILES_SKIPPED_OVERRIDE+=("$sync_path")
@@ -216,6 +247,10 @@ done <<< "$SYNC_DIRS"
 
 if [ "${#FILES_SKIPPED_OVERRIDE[@]}" -gt 0 ]; then
   echo "Skipped ${#FILES_SKIPPED_OVERRIDE[@]} override(s) — kept local versions."
+fi
+
+if [ "${#FILES_SKIPPED_RUNTIME[@]}" -gt 0 ]; then
+  echo "Skipped ${#FILES_SKIPPED_RUNTIME[@]} runtime-protected file(s)."
 fi
 
 ###############################################################################

--- a/scripts/template-sync.test.sh
+++ b/scripts/template-sync.test.sh
@@ -33,7 +33,7 @@ cat > "$REPO_DIR/.agile-flow-version" <<'JSON'
 {
   "version": "0.1.0",
   "syncDirectories": [
-    "scripts"
+    "./scripts"
   ]
 }
 JSON

--- a/scripts/template-sync.test.sh
+++ b/scripts/template-sync.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Regression test: template-sync must never overwrite itself at runtime.
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+  echo -e "  ${GREEN}PASS${NC}: $1"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+fail() {
+  echo -e "  ${RED}FAIL${NC}: $1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+REPO_DIR="$WORK_DIR/repo"
+mkdir -p "$REPO_DIR/scripts/lib"
+cp scripts/template-sync.sh "$REPO_DIR/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$REPO_DIR/scripts/lib/overrides.sh"
+chmod +x "$REPO_DIR/scripts/template-sync.sh"
+
+cat > "$REPO_DIR/.agile-flow-version" <<'JSON'
+{
+  "version": "0.1.0",
+  "syncDirectories": [
+    "scripts"
+  ]
+}
+JSON
+
+: > "$REPO_DIR/.agile-flow-overrides"
+
+mkdir -p "$WORK_DIR/upstream/vibeacademy-agile-flow-release/scripts/lib"
+cp scripts/template-sync.sh "$WORK_DIR/upstream/vibeacademy-agile-flow-release/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$WORK_DIR/upstream/vibeacademy-agile-flow-release/scripts/lib/overrides.sh"
+echo "# upstream mutation" >> "$WORK_DIR/upstream/vibeacademy-agile-flow-release/scripts/template-sync.sh"
+
+tar -czf "$WORK_DIR/upstream.tar.gz" -C "$WORK_DIR/upstream" vibeacademy-agile-flow-release
+
+mkdir -p "$WORK_DIR/bin"
+cat > "$WORK_DIR/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"/releases/latest"* ]]; then
+  printf '{"tag_name":"v1.0.0","html_url":"https://example.invalid/release","tarball_url":"https://example.invalid/upstream.tar.gz"}'
+  exit 0
+fi
+if [[ "$*" == *"upstream.tar.gz"* ]]; then
+  out=''
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+      out="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  cp "$TEST_UPSTREAM_TARBALL" "$out"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$WORK_DIR/bin/curl"
+
+pushd "$REPO_DIR" >/dev/null
+git init >/dev/null
+git add .
+git commit -m "init" >/dev/null
+git init --bare "$WORK_DIR/origin.git" >/dev/null
+git remote add origin "$WORK_DIR/origin.git"
+git push -u origin HEAD >/dev/null
+
+SCRIPT_BEFORE_SUM=$(sha256sum scripts/template-sync.sh | awk '{print $1}')
+
+if TEST_UPSTREAM_TARBALL="$WORK_DIR/upstream.tar.gz" PATH="$WORK_DIR/bin:$PATH" bash scripts/template-sync.sh > "$WORK_DIR/run.log" 2>&1; then
+  SCRIPT_AFTER_SUM=$(sha256sum scripts/template-sync.sh | awk '{print $1}')
+  if [ "$SCRIPT_BEFORE_SUM" = "$SCRIPT_AFTER_SUM" ]; then
+    pass "runtime-protected template-sync.sh is not overwritten"
+  else
+    fail "template-sync.sh changed despite runtime protection"
+  fi
+
+  if grep -q "SKIP (runtime-protected): scripts/template-sync.sh" "$WORK_DIR/run.log"; then
+    pass "runtime-protected skip is reported"
+  else
+    fail "expected runtime-protected skip log entry"
+  fi
+else
+  cat "$WORK_DIR/run.log"
+  fail "template-sync.sh execution failed"
+fi
+
+popd >/dev/null
+
+echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+if [ "$TESTS_FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Ticket
Paperclip: VIB-129 (DEF-EXEC-003)
Quick fix — no linked GitHub ticket.

## Summary
Fixes the template sync runtime regression where `scripts/template-sync.sh` could still be overwritten mid-run, causing the self-sync crash path to reappear.
Adds an explicit runtime protection gate for the currently executing sync script and its sourced override helper.

## Changes Made
- Added runtime-protected path checks in `scripts/template-sync.sh`
- Tracked and reported runtime-protected skips separately from override skips
- Added `scripts/template-sync.test.sh` regression test that simulates upstream tarball mutation and verifies runtime guard behavior

## Testing
### Automated Tests
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Coverage meets threshold

### Manual Testing
- Ran `bash scripts/template-sync.test.sh`
- Ran `bash scripts/lib/overrides.test.sh`

## Screenshots/Demo
N/A (script/runtime fix)

## Checklist
- [x] All tests pass
- [x] Code follows project standards
- [x] No linting warnings
- [x] Built successfully
