### PR TITLE
[VIB-139] fix(sync): bootstrap re-entry dirty-tree guard + regression

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -57,6 +57,53 @@ is_runtime_protected() {
   return 1
 }
 
+path_allowed_for_bootstrap_reentry() {
+  local path="$1"
+  local normalized_path
+  local protected
+  local sync_path
+
+  normalized_path="$(normalize_rel_path "$path")"
+
+  if [ "$normalized_path" = "$(normalize_rel_path "$VERSION_FILE")" ]; then
+    return 0
+  fi
+
+  for protected in "${RUNTIME_PROTECTED_PATHS[@]}"; do
+    if [ "$normalized_path" = "$(normalize_rel_path "$protected")" ] || [[ "$normalized_path" == "$(normalize_rel_path "$protected")/"* ]]; then
+      return 0
+    fi
+  done
+
+  while IFS= read -r sync_path; do
+    [ -z "$sync_path" ] && continue
+    sync_path="$(normalize_rel_path "$sync_path")"
+    if [ "$normalized_path" = "$sync_path" ] || [[ "$normalized_path" == "$sync_path/"* ]]; then
+      return 0
+    fi
+  done <<< "$SYNC_DIRS"
+
+  return 1
+}
+
+bootstrap_reentry_dirty_tree_is_safe() {
+  local status_line
+  local changed_path
+
+  while IFS= read -r status_line; do
+    [ -z "$status_line" ] && continue
+    changed_path="${status_line:3}"
+    if [[ "$changed_path" == *" -> "* ]]; then
+      changed_path="${changed_path##* -> }"
+    fi
+    if ! path_allowed_for_bootstrap_reentry "$changed_path"; then
+      return 1
+    fi
+  done < <(git status --porcelain)
+
+  return 0
+}
+
 ###############################################################################
 # 1. Read local version and syncDirectories
 ###############################################################################
@@ -147,10 +194,14 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
 fi
 
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then
-  echo "ERROR: working tree has uncommitted changes — refusing to upgrade without a clean rollback point."
-  echo "Commit or stash your changes, then retry."
-  rm -rf "$WORK_DIR"
-  exit 1
+  if bootstrap_reentry_dirty_tree_is_safe; then
+    echo "WARNING: detected bootstrap re-entry with staged sync-target files; continuing upgrade."
+  else
+    echo "ERROR: working tree has uncommitted changes — refusing to upgrade without a clean rollback point."
+    echo "Commit or stash your changes, then retry."
+    rm -rf "$WORK_DIR"
+    exit 1
+  fi
 fi
 
 if ! git symbolic-ref -q HEAD >/dev/null; then

--- a/scripts/template-sync.test.sh
+++ b/scripts/template-sync.test.sh
@@ -22,6 +22,7 @@ fail() {
 
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT
+SCRIPT_SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 REPO_DIR="$WORK_DIR/repo"
 mkdir -p "$REPO_DIR/scripts/lib"
@@ -100,6 +101,91 @@ else
   fail "template-sync.sh execution failed"
 fi
 
+popd >/dev/null
+
+echo ""
+echo "Scenario 2: bootstrap re-entry dirty state is allowed for sync-target paths"
+
+REENTRY_DIR="$WORK_DIR/reentry"
+mkdir -p "$REENTRY_DIR/scripts/lib"
+
+cat > "$REENTRY_DIR/.agile-flow-version" <<'JSON'
+{
+  "version": "0.0.1",
+  "syncDirectories": [
+    "scripts"
+  ]
+}
+JSON
+
+cat > "$REENTRY_DIR/scripts/template-sync.sh" <<'SH'
+#!/usr/bin/env bash
+echo "legacy placeholder"
+SH
+chmod +x "$REENTRY_DIR/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$REENTRY_DIR/scripts/lib/overrides.sh"
+
+mkdir -p "$WORK_DIR/reentry-upstream/scripts"
+cp scripts/template-sync.sh "$WORK_DIR/reentry-upstream/scripts/template-sync.sh"
+tar -czf "$WORK_DIR/reentry-upstream.tar.gz" -C "$WORK_DIR/reentry-upstream" .
+
+cat > "$WORK_DIR/bin/curl-reentry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"/releases/latest"* ]]; then
+  printf '{"tag_name":"v1.0.4","html_url":"https://example.invalid/release","tarball_url":"https://example.invalid/reentry-upstream.tar.gz"}'
+  exit 0
+fi
+if [[ "$*" == *"reentry-upstream.tar.gz"* ]]; then
+  out=''
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+      out="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  cp "$TEST_REENTRY_TARBALL" "$out"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$WORK_DIR/bin/curl-reentry"
+
+mkdir -p "$WORK_DIR/reentry-bin"
+cp "$WORK_DIR/bin/curl-reentry" "$WORK_DIR/reentry-bin/curl"
+chmod +x "$WORK_DIR/reentry-bin/curl"
+
+pushd "$REENTRY_DIR" >/dev/null
+git init >/dev/null
+git add .
+git commit -m "init reentry" >/dev/null
+git init --bare "$WORK_DIR/reentry-origin.git" >/dev/null
+git remote add origin "$WORK_DIR/reentry-origin.git"
+git push -u origin HEAD >/dev/null
+
+cp "$SCRIPT_SOURCE_DIR/template-sync.sh" scripts/template-sync.sh
+git add scripts/template-sync.sh .agile-flow-version
+
+if TEST_REENTRY_TARBALL="$WORK_DIR/reentry-upstream.tar.gz" PATH="$WORK_DIR/reentry-bin:$PATH" bash scripts/template-sync.sh > "$WORK_DIR/reentry.log" 2>&1; then
+  pass "bootstrap re-entry run exits successfully"
+  if grep -q "detected bootstrap re-entry" "$WORK_DIR/reentry.log"; then
+    pass "bootstrap warning is emitted"
+  else
+    fail "expected bootstrap warning in re-entry run"
+  fi
+
+  DOWNLOAD_COUNT=$(grep -c "Downloading release tarball..." "$WORK_DIR/reentry.log" || true)
+  if [ "$DOWNLOAD_COUNT" = "1" ]; then
+    pass "download banner appears once in re-entry path"
+  else
+    fail "expected a single download banner in re-entry path"
+  fi
+else
+  cat "$WORK_DIR/reentry.log"
+  fail "bootstrap re-entry scenario failed"
+fi
 popd >/dev/null
 
 echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"


### PR DESCRIPTION
## Summary
Fixes the bootstrap-upgrade failure where pre-v1.0.3 on-disk `scripts/template-sync.sh` can self-overwrite, re-enter, and then fail the clean-tree guard before branch/PR creation.

## Changes
- `scripts/template-sync.sh`
  - add bootstrap-safe dirty-tree evaluation:
    - `path_allowed_for_bootstrap_reentry`
    - `bootstrap_reentry_dirty_tree_is_safe`
  - allow dirty tree only when changed paths are sync targets/runtime-protected/version file
  - keep hard-fail behavior for any unrelated dirty path
- `scripts/template-sync.test.sh`
  - keep runtime-protected self-overwrite regression
  - add explicit bootstrap re-entry scenario asserting:
    - successful run
    - warning emitted
    - single `Downloading release tarball...` occurrence

## Validation
- `bash scripts/template-sync.test.sh`
  - Results: 5 passed, 0 failed

## Incident note
`v1.0.4` retest remains NO-GO for this issue (double download banner + clean-tree abort), so this PR is the release-blocking hotfix for the next patch tag.
