### PR TITLE
feat(docs): add HTML acceptance report template for /report-issue

### DIFF
--- a/docs/reports/report-issue-acceptance-template.html
+++ b/docs/reports/report-issue-acceptance-template.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Acceptance Report: /report-issue</title>
+  <style>
+    :root {
+      --color-pass: #22c55e;
+      --color-fail: #ef4444;
+      --color-skip: #f59e0b;
+      --color-border: #e5e7eb;
+      --color-bg-header: #f9fafb;
+      --color-bg-pass: #f0fdf4;
+      --color-bg-fail: #fef2f2;
+      --color-text: #111827;
+      --color-text-muted: #6b7280;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: var(--color-text);
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 2rem;
+      background: #fff;
+    }
+
+    header {
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 2px solid var(--color-border);
+    }
+
+    h1 {
+      font-size: 1.75rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .meta {
+      color: var(--color-text-muted);
+      font-size: 0.9rem;
+    }
+
+    .meta span {
+      margin-right: 1.5rem;
+    }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+
+    .summary-card {
+      padding: 1rem;
+      border-radius: 8px;
+      border: 1px solid var(--color-border);
+      text-align: center;
+    }
+
+    .summary-card.total {
+      background: var(--color-bg-header);
+    }
+
+    .summary-card.passed {
+      background: var(--color-bg-pass);
+      border-color: var(--color-pass);
+    }
+
+    .summary-card.failed {
+      background: var(--color-bg-fail);
+      border-color: var(--color-fail);
+    }
+
+    .summary-card .count {
+      font-size: 2rem;
+      font-weight: 700;
+    }
+
+    .summary-card .label {
+      font-size: 0.875rem;
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .summary-card.passed .count {
+      color: var(--color-pass);
+    }
+
+    .summary-card.failed .count {
+      color: var(--color-fail);
+    }
+
+    h2 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin: 2rem 0 1rem;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+
+    th, td {
+      padding: 0.75rem 1rem;
+      text-align: left;
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    th {
+      background: var(--color-bg-header);
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+      color: var(--color-text-muted);
+    }
+
+    tr:hover {
+      background: var(--color-bg-header);
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+
+    .status.pass {
+      background: var(--color-bg-pass);
+      color: var(--color-pass);
+    }
+
+    .status.fail {
+      background: var(--color-bg-fail);
+      color: var(--color-fail);
+    }
+
+    .status.skip {
+      background: #fef3c7;
+      color: var(--color-skip);
+    }
+
+    .test-id {
+      font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    .category {
+      font-size: 0.8rem;
+      color: var(--color-text-muted);
+      background: var(--color-bg-header);
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+    }
+
+    .assertions {
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    footer {
+      margin-top: 3rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--color-border);
+      font-size: 0.8rem;
+      color: var(--color-text-muted);
+    }
+
+    code {
+      font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+      font-size: 0.85em;
+      background: var(--color-bg-header);
+      padding: 0.125rem 0.375rem;
+      border-radius: 4px;
+    }
+
+    @media print {
+      body {
+        padding: 0;
+      }
+      .summary-card {
+        break-inside: avoid;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Acceptance Report: /report-issue</h1>
+    <div class="meta">
+      <span><strong>Script:</strong> <code>scripts/test-report-issue.sh</code></span>
+      <span><strong>Date:</strong> <!-- PLACEHOLDER: DATE --></span>
+      <span><strong>Version:</strong> <!-- PLACEHOLDER: VERSION --></span>
+    </div>
+  </header>
+
+  <section class="summary">
+    <div class="summary-card total">
+      <div class="count"><!-- PLACEHOLDER: TOTAL -->12</div>
+      <div class="label">Total Tests</div>
+    </div>
+    <div class="summary-card passed">
+      <div class="count"><!-- PLACEHOLDER: PASSED -->0</div>
+      <div class="label">Passed</div>
+    </div>
+    <div class="summary-card failed">
+      <div class="count"><!-- PLACEHOLDER: FAILED -->0</div>
+      <div class="label">Failed</div>
+    </div>
+  </section>
+
+  <h2>Test Results</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th style="width: 60px">ID</th>
+        <th>Test Case</th>
+        <th style="width: 100px">Category</th>
+        <th style="width: 80px">Assertions</th>
+        <th style="width: 80px">Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- Test 1: Missing .agile-flow-meta directory -->
+      <tr>
+        <td class="test-id">T01</td>
+        <td>Error when <code>.agile-flow-meta</code> directory is missing</td>
+        <td><span class="category">Setup</span></td>
+        <td class="assertions">2</td>
+        <td><span class="status"><!-- PLACEHOLDER: T01_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 2: Missing upstream file -->
+      <tr>
+        <td class="test-id">T02</td>
+        <td>Error when <code>.agile-flow-meta/upstream</code> is missing</td>
+        <td><span class="category">Setup</span></td>
+        <td class="assertions">1</td>
+        <td><span class="status"><!-- PLACEHOLDER: T02_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 3: Empty upstream file -->
+      <tr>
+        <td class="test-id">T03</td>
+        <td>Error when <code>.agile-flow-meta/upstream</code> is empty</td>
+        <td><span class="category">Setup</span></td>
+        <td class="assertions">1</td>
+        <td><span class="status"><!-- PLACEHOLDER: T03_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 4: Invalid severity value -->
+      <tr>
+        <td class="test-id">T04</td>
+        <td>Error on invalid severity value (must be p1, p2, or p3)</td>
+        <td><span class="category">Validation</span></td>
+        <td class="assertions">1</td>
+        <td><span class="status"><!-- PLACEHOLDER: T04_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 5: Invalid component value -->
+      <tr>
+        <td class="test-id">T05</td>
+        <td>Error on invalid component value</td>
+        <td><span class="category">Validation</span></td>
+        <td class="assertions">1</td>
+        <td><span class="status"><!-- PLACEHOLDER: T05_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 6: Empty title -->
+      <tr>
+        <td class="test-id">T06</td>
+        <td>Error when title is empty</td>
+        <td><span class="category">Validation</span></td>
+        <td class="assertions">1</td>
+        <td><span class="status"><!-- PLACEHOLDER: T06_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 7: Fallback path (gh not available) -->
+      <tr>
+        <td class="test-id">T07</td>
+        <td>Fallback to manual submission when <code>gh</code> CLI unavailable</td>
+        <td><span class="category">Fallback</span></td>
+        <td class="assertions">5</td>
+        <td><span class="status"><!-- PLACEHOLDER: T07_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 8: Happy path with mocked gh success -->
+      <tr>
+        <td class="test-id">T08</td>
+        <td>Happy path with successful <code>gh issue create</code></td>
+        <td><span class="category">Happy Path</span></td>
+        <td class="assertions">4</td>
+        <td><span class="status"><!-- PLACEHOLDER: T08_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 9: Unknown flag handling -->
+      <tr>
+        <td class="test-id">T09</td>
+        <td>Error on unknown flag</td>
+        <td><span class="category">Validation</span></td>
+        <td class="assertions">1</td>
+        <td><span class="status"><!-- PLACEHOLDER: T09_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 10: Non-interactive mode requires all fields -->
+      <tr>
+        <td class="test-id">T10</td>
+        <td>Non-interactive mode requires <code>--severity</code></td>
+        <td><span class="category">Validation</span></td>
+        <td class="assertions">1</td>
+        <td><span class="status"><!-- PLACEHOLDER: T10_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 11: Git URL parsing (git@ format) -->
+      <tr>
+        <td class="test-id">T11</td>
+        <td>Parse <code>git@</code> format upstream URL</td>
+        <td><span class="category">Parsing</span></td>
+        <td class="assertions">1</td>
+        <td><span class="status"><!-- PLACEHOLDER: T11_STATUS --></span></td>
+      </tr>
+
+      <!-- Test 12: Title with special characters -->
+      <tr>
+        <td class="test-id">T12</td>
+        <td>Handle title with special characters (quotes, backslash)</td>
+        <td><span class="category">Edge Case</span></td>
+        <td class="assertions">2</td>
+        <td><span class="status"><!-- PLACEHOLDER: T12_STATUS --></span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    <p>
+      Generated by <code>scripts/test-report-issue.sh</code> | 
+      Agile Flow Acceptance Testing | 
+      <a href="https://github.com/vibeacademy/agile-flow/issues/213">#213</a>
+    </p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Creates the HTML acceptance report template for `/report-issue` command testing.

## Changes

- Add `docs/reports/report-issue-acceptance-template.html`
- Include all 12 test cases from `test-report-issue.sh`:
  - T01-T03: Setup validation (missing/empty .agile-flow-meta)
  - T04-T06, T09-T10: Input validation (severity, component, title, flags)
  - T07: Fallback path when gh CLI unavailable
  - T08: Happy path with successful issue creation
  - T11: Git URL parsing (git@ format)
  - T12: Edge case handling (special characters)
- Summary cards for total/passed/failed counts
- Placeholder markers for automated population from test script output
- Clean, professional styling consistent with /upgrade report format

## Checklist

- [x] `uv run ruff check . --fix` passes
- [x] HTML validated as well-formed

Closes #213