### PR TITLE
fix(report-issue): Fix empty upstream_version producing malformed YAML

### DIFF
--- a/features/report-issue.feature
+++ b/features/report-issue.feature
@@ -84,3 +84,26 @@ Feature: Report Issue to Upstream
     When user runs report-issue.sh in non-interactive mode without body
     Then exit code is 1
     And error output indicates body required in non-interactive mode
+
+  # Empty version field cases
+
+  Scenario: .agile-flow-version file with empty string version
+    Given .agile-flow-version exists with empty string version field
+    And gh CLI is not available or authentication fails
+    When user runs report-issue.sh with valid inputs
+    Then exit code is 0
+    And report file contains upstream_version unknown
+
+  Scenario: .agile-flow-version file with whitespace-only version
+    Given .agile-flow-version exists with whitespace-only version field
+    And gh CLI is not available or authentication fails
+    When user runs report-issue.sh with valid inputs
+    Then exit code is 0
+    And report file contains upstream_version unknown
+
+  Scenario: .agile-flow-version file with null version
+    Given .agile-flow-version exists with null version field
+    And gh CLI is not available or authentication fails
+    When user runs report-issue.sh with valid inputs
+    Then exit code is 0
+    And report file contains upstream_version unknown

--- a/features/steps/report_issue_steps.py
+++ b/features/steps/report_issue_steps.py
@@ -812,3 +812,85 @@ def error_indicates_body_required_in_non_interactive_mode():
     assert all(phrase in output.lower() for phrase in expected_phrases), (
         f"Expected error about missing body in non-interactive mode. Output: {output}"
     )
+
+
+# ============================================================================
+# Empty version field step definitions
+# ============================================================================
+
+
+@given(".agile-flow-version exists with empty string version field")
+def agile_flow_version_exists_with_empty_string_version(
+    temp_git_repo, mock_upstream_repo
+):
+    """Create .agile-flow-version with empty string version field."""
+    version_file = temp_git_repo / ".agile-flow-version"
+    version_data = {
+        "upstream": f"https://github.com/{mock_upstream_repo}",
+        "version": "",  # empty string version
+        "commit": "abc123def456",
+    }
+    version_file.write_text(json.dumps(version_data, indent=2) + "\n")
+
+
+@given(".agile-flow-version exists with whitespace-only version field")
+def agile_flow_version_exists_with_whitespace_version(
+    temp_git_repo, mock_upstream_repo
+):
+    """Create .agile-flow-version with whitespace-only version field."""
+    version_file = temp_git_repo / ".agile-flow-version"
+    version_data = {
+        "upstream": f"https://github.com/{mock_upstream_repo}",
+        "version": "   ",  # whitespace-only version
+        "commit": "abc123def456",
+    }
+    version_file.write_text(json.dumps(version_data, indent=2) + "\n")
+
+
+@given(".agile-flow-version exists with null version field")
+def agile_flow_version_exists_with_null_version(temp_git_repo, mock_upstream_repo):
+    """Create .agile-flow-version with null version field."""
+    version_file = temp_git_repo / ".agile-flow-version"
+    version_data = {
+        "upstream": f"https://github.com/{mock_upstream_repo}",
+        "version": None,
+        "commit": "abc123def456",
+    }
+    version_file.write_text(json.dumps(version_data, indent=2) + "\n")
+
+
+@then("report file contains upstream_version unknown")
+def report_file_contains_upstream_version_unknown(temp_git_repo):
+    """Verify report file contains upstream_version: unknown."""
+    global _test_result
+    assert _test_result is not None, "Script was not run"
+
+    reports_dir = temp_git_repo / ".agile-flow-reports"
+    assert reports_dir.exists(), "Reports directory was not created"
+
+    report_files = list(reports_dir.glob("report-*.md"))
+    assert len(report_files) > 0, "No report file was created"
+
+    report_file = report_files[-1]  # Get the most recent report
+    content = report_file.read_text()
+
+    # Check for the exact YAML line - no trailing whitespace
+    assert "upstream_version: unknown" in content, (
+        f"Expected 'upstream_version: unknown' in report: {content}"
+    )
+
+    # Also verify that there's no trailing whitespace after the colon
+    lines = content.split("\n")
+    upstream_version_line = None
+    for line in lines:
+        if line.startswith("upstream_version:"):
+            upstream_version_line = line
+            break
+
+    assert upstream_version_line is not None, "upstream_version line not found"
+
+    # Ensure the line is exactly "upstream_version: unknown" (no trailing spaces)
+    assert upstream_version_line == "upstream_version: unknown", (
+        f"Expected 'upstream_version: unknown', got '{upstream_version_line}' "
+        f"(line ends with: {repr(upstream_version_line[-10:])})"
+    )

--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -98,8 +98,16 @@ if [ "$UPSTREAM_URL" = "null" ] || [ -z "$UPSTREAM_URL" ]; then
 fi
 
 UPSTREAM_VERSION=$(jq -r '.version' "$VERSION_FILE" 2>/dev/null || echo "unknown")
+
+# Handle empty, null, whitespace-only, or missing version field
 if [ "$UPSTREAM_VERSION" = "null" ] || [ -z "$UPSTREAM_VERSION" ]; then
   UPSTREAM_VERSION="unknown"
+else
+  # Strip leading and trailing whitespace, then check if empty
+  UPSTREAM_VERSION=$(echo "$UPSTREAM_VERSION" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  if [ -z "$UPSTREAM_VERSION" ]; then
+    UPSTREAM_VERSION="unknown"
+  fi
 fi
 
 # Extract org/repo from https or git@ GitHub URLs


### PR DESCRIPTION
## Summary

Fixes #233 - Resolves malformed YAML generation when .agile-flow-version file contains empty, null, or whitespace-only version fields.

## Changes

**Bug Fix:**
- Enhanced version field validation in  to handle edge cases:
  - Empty strings () → set to 
  - Null values () → set to 
  - Whitespace-only strings () → stripped and set to 
  - Missing version field → set to 

**YAML Output:**
- Ensures  is generated (no trailing whitespace)
- Maintains valid YAML structure that can be parsed by standard libraries

**Test Coverage:**
- Added comprehensive BDD scenarios for all edge cases
- Test validation includes YAML structure verification

## Validation

### Manual Testing
Verified the fix with all problematic version field scenarios:



### YAML Validation
- Verified no trailing whitespace using 
- Generated YAML parses successfully with Python 

## Files Modified

-  - Enhanced version field handling logic
-  - Added edge case test scenarios  
-  - Added step definitions for new tests

## Backwards Compatibility

✅ Maintains full backwards compatibility
✅ Valid version values continue to work unchanged
✅ Only affects edge cases that previously generated malformed YAML