### PR TITLE
fix(report-issue): Handle AskUserQuestion 4-option limit for components

### DIFF
--- a/.claude/commands/report-issue.md
+++ b/.claude/commands/report-issue.md
@@ -28,7 +28,7 @@ issues you own). Use it for problems that exist in the upstream framework files.
    - What went wrong (be specific)
    - Severity: p1 (critical, blocks everyone), p2 (significant, workaround exists),
      p3 (minor or improvement)
-   - Component: provisioning, ci, claude-commands, patterns, docs, or other
+   - Component: You'll be prompted to select from available components in a two-step process
 
 3. **Validate severity input**. Before running the script, ensure the severity is one of the valid values: p1, p2, or p3. If invalid, return error: "Invalid severity. Valid options: p1, p2, p3"
 

--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -229,16 +229,49 @@ if [ -z "$COMPONENT" ]; then
     echo "ERROR: --component required in non-interactive mode." >&2
     exit 1
   fi
-  echo ""
-  echo "Component:"
-  echo "  provisioning    setup, roster, env provisioning scripts"
-  echo "  ci              GitHub Actions, CI/CD workflows"
-  echo "  claude-commands /slash commands"
-  echo "  patterns        architectural patterns and practices"
-  echo "  docs            documentation"
-  echo "  other           anything else"
-  printf "> "
-  read -r COMPONENT
+  
+  # Two-tier component selection to handle AskUserQuestion 4-option limit
+  while true; do
+    echo ""
+    echo "Component (select main components or see more):"
+    echo "  provisioning    setup, roster, env provisioning scripts"
+    echo "  ci              GitHub Actions, CI/CD workflows"
+    echo "  claude-commands /slash commands"
+    echo "  docs            documentation"
+    echo "  more            see additional components"
+    printf "> "
+    read -r COMPONENT
+    
+    case "$COMPONENT" in
+      provisioning|ci|claude-commands|docs)
+        break
+        ;;
+      more)
+        echo ""
+        echo "Additional components:"
+        echo "  patterns        architectural patterns and practices"
+        echo "  other           anything else"
+        echo "  back            return to main components"
+        printf "> "
+        read -r COMPONENT
+        
+        case "$COMPONENT" in
+          patterns|other)
+            break
+            ;;
+          back)
+            continue  # Go back to main component selection
+            ;;
+          *)
+            echo "ERROR: Please select 'patterns', 'other', or 'back'." >&2
+            ;;
+        esac
+        ;;
+      *)
+        echo "ERROR: Please select a valid component or 'more' for additional options." >&2
+        ;;
+    esac
+  done
 fi
 
 case "$COMPONENT" in


### PR DESCRIPTION
## Summary

Implements two-tier component selection to work within AskUserQuestion's 4-option limit while keeping all 6 components accessible.

## Changes Made

- **Interactive Mode**: Split component selection into two screens
  - Main menu: 4 core components (provisioning, ci, claude-commands, docs) + "more" option
  - Secondary menu: 2 additional components (patterns, other) + "back" option  
- **Navigation**: "Back" option returns to main menu correctly
- **Error Handling**: Invalid selections show helpful error messages and re-prompt
- **Non-interactive Mode**: Unchanged - still accepts all 6 components directly via --component flag

## Testing Completed

✅ **All 6 components selectable** via interactive workflow  
✅ **Navigation works**: "more" → secondary menu, "back" → main menu  
✅ **Error handling**: Invalid inputs show errors and re-prompt  
✅ **Non-interactive mode**: All components work with --component flag  
✅ **Dry-run testing**: All component selections produce correct output  
✅ **Shell syntax**: bash -n validation passes  

## Files Modified

- : Updated instructions to reflect new two-step selection
- : Implemented two-tier selection logic with navigation

## Definition of Done

- [x] Two-tier component selection implemented within 4-option constraints
- [x] First prompt: Top 4 most common components + "More components" option  
- [x] Second prompt: Remaining 2 components + "Back to main components" option
- [x] All 6 original components remain selectable through the workflow
- [x] Manual test: Successfully select each of the 6 components through the new flow
- [x] Manual test: "Back" option works correctly to return to first prompt
- [x] Component validation in report-issue.sh unchanged (same valid component names)
- [x] PR reviewer can test complete component selection workflow

Resolves #232