### PR TITLE
docs(report-issue): document stdin-paste fallback for description

### DIFF
--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -47,6 +47,28 @@ Flags:
   --force-codespaces-token  Continue despite Codespaces token limitations
   --help, -h             Show this help message
 
+Description Entry Modes:
+  The script supports three ways to provide the issue description:
+  
+  1. EDITOR mode (interactive, EDITOR set):
+     - When $EDITOR is set and the command is available
+     - Opens your configured editor with a template
+     - Save and close the file when done
+  
+  2. File mode (non-interactive, --body-file):
+     - Read description from an existing file
+     - Use with --body-file path/to/description.md
+     - File must exist and be readable
+  
+  3. Stdin mode (interactive, EDITOR unset/unavailable):
+     - Paste or type description directly into terminal
+     - End with a line containing only '.' (dot) to finish
+     - Example:
+       > Enter issue description (end with '.' on its own line):
+       > This is my issue description.
+       > It can span multiple lines.
+       > .
+
 Examples:
   # Interactive mode (prompts for inputs)
   bash scripts/report-issue.sh
@@ -391,9 +413,7 @@ TEMPLATE
     "$EDITOR" "$DESCRIPTION_FILE"
   else
     echo ""
-    echo "Paste your description below."
-    echo "Include: what happened, steps to reproduce, expected vs actual behaviour."
-    echo "Enter a line with just '.' when done:"
+    echo "Enter issue description (end with '.' on its own line):"
     echo ""
     DESC_LINES=""
     while IFS= read -r line; do


### PR DESCRIPTION
Fixes #234

## Changes Made

**Inline Prompt Enhancement:**
- Replaced verbose multi-line prompt with clear instruction: "Enter issue description (end with '.' on its own line):"
- Prompt now appears only when EDITOR is unset/unavailable (stdin mode)
- No change to existing dot terminator behavior - maintains backward compatibility

**Help Text Documentation:**
- Added comprehensive "Description Entry Modes" section documenting all three input methods:
  1. **EDITOR mode** (interactive, EDITOR set): Opens configured editor with template  
  2. **File mode** (non-interactive, --body-file): Reads from existing file
  3. **Stdin mode** (interactive, EDITOR unset): Terminal input with dot termination
- Included example showing multi-line stdin input ending with '.' on its own line
- Clear explanation of when each mode is triggered

## Testing Performed

✅ **Manual verification of all Definition of Done criteria:**
- Stdin prompt appears when EDITOR unset: `env -u EDITOR ./scripts/report-issue.sh`
- No stdin prompt with EDITOR mode: `EDITOR=echo ./scripts/report-issue.sh` 
- No stdin prompt with --body-file mode (non-interactive)
- Help text shows comprehensive documentation: `./scripts/report-issue.sh --help`
- Shellcheck passes with no warnings

## Reviewer Testing

To test the stdin prompt improvement:
```bash
unset EDITOR && ./scripts/report-issue.sh --dry-run
# Follow prompts, then enter description ending with '.' on its own line
```

The prompt should clearly indicate: "Enter issue description (end with '.' on its own line):"