### PR TITLE
fix(doctor): detect IDE context for claude CLI availability

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -185,7 +185,11 @@ fi
 if CLAUDE_CMD=$(resolve_cmd claude); then
     pass "CLI Tools" "claude found at $CLAUDE_CMD"
 else
-    fail "CLI Tools" "claude not found" "npm install -g @anthropic-ai/claude-code"
+    if [[ "${CODESPACES:-}" == "true" ]] || [[ "${TERM_PROGRAM:-}" == "vscode" ]]; then
+        pass "CLI Tools" "claude CLI (IDE-provided via Claude Code extension)"
+    else
+        fail "CLI Tools" "claude not found" "npm install -g @anthropic-ai/claude-code"
+    fi
 fi
 
 # jq (FAIL)


### PR DESCRIPTION
**Problem Statement:**
`/doctor` reports FAIL when `claude` CLI is not found on `$PATH`, even in Codespaces where Claude Code is provided by the IDE extension and is clearly working (user just invoked `/doctor` through it). The summary line reads "1 failure(s) must be fixed before the workshop" — actively misleading first-time workshop users.

**Solution:**
- Add detection for Codespaces (`$CODESPACES=true`) and VS Code (`$TERM_PROGRAM=vscode`)
- PASS with note when claude is IDE-provided via Claude Code extension  
- Preserve FAIL behavior for genuine missing CLI cases in other environments

**Changes:**
- Modified `scripts/doctor.sh` lines 184-189 to detect IDE context
- When `claude` not on PATH but in IDE environment: PASS with explanatory note
- When `claude` not on PATH in non-IDE environment: FAIL as before

**Testing:**
- Shellcheck passes (pre-existing warning unrelated to changes)
- Logic follows the proposed fix in issue description exactly

Fixes #279