### PR TITLE
fix(sync): write version to .agile-flow-meta/version after template sync

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -377,9 +377,13 @@ with open('$VERSION_FILE', 'r') as f:
 data['version'] = '$LATEST_VERSION'
 with open('$VERSION_FILE', 'w') as f:
     json.dump(data, f, indent=2)
-    f.write('\n')
+    f.write('\\n')
 "
 git add "$VERSION_FILE"
+
+# Create .agile-flow-meta directory and write version file
+mkdir -p .agile-flow-meta
+echo "$LATEST_VERSION" > .agile-flow-meta/version
 
 COMMIT_MSG="chore(sync): update Agile Flow framework to v${LATEST_VERSION}"
 # Scope the bot identity to this single commit using -c so running locally


### PR DESCRIPTION
Fixes #282

## Summary
After running  via Local version : 0.1.0
Sync targets  : .claude/agents
.claude/commands
.claude/hooks
.claude/skills
scripts
starters
Protected overrides: 1 pattern(s)
Latest version: 1.0.6
Update available: 0.1.0 -> 1.0.6
Downloading release tarball...
Created rollback tag: pre-upgrade-20260518-145305 (local-only)
SKIP (runtime-protected): scripts/lib/overrides.sh
SKIP (runtime-protected): scripts/template-sync.sh
Skipped 2 runtime-protected file(s).
Already up to date. All synced files match the latest release., the file  was being created but left empty. This caused  to have empty  metadata in report YAML front matter.

## Changes
- ✅ Creates  directory if it doesn't exist
- ✅ Writes  to  after successful sync  
- ✅ Handles both upgrades and first-time installs
- ✅ Passes shellcheck validation

## Testing
- [x] shellcheck passes
- [x] No breaking changes to existing sync functionality

## Definition of Done
- [x] Local version : 0.1.0
Sync targets  : .claude/agents
.claude/commands
.claude/hooks
.claude/skills
scripts
starters
Protected overrides: 1 pattern(s)
Latest version: 1.0.6
Update available: 0.1.0 -> 1.0.6
Downloading release tarball...
Created rollback tag: pre-upgrade-20260518-145308 (local-only)
SKIP (runtime-protected): scripts/lib/overrides.sh
SKIP (runtime-protected): scripts/template-sync.sh
Skipped 2 runtime-protected file(s).
Already up to date. All synced files match the latest release. writes version to 
- [x] File contains correct version string after upgrade
- [x] First-time installs also populate the file (same logic path)
- [ ]  correctly reads  (will verify after merge)
- [ ] PR merged

The fix ensures that after template sync,  contains the correct version string that  can read for upstream metadata.