### PR TITLE
feat(bootstrap): Skills should offer to commit outputs to feature branch

### DIFF
--- a/.claude/commands/bootstrap-architecture.md
+++ b/.claude/commands/bootstrap-architecture.md
@@ -311,6 +311,19 @@ This phase also updates CLAUDE.md with project-specific configuration:
 - Build and test commands
 - Definition of Ready/Done refinements
 
+## Finish Up
+
+The following files were created:
+- docs/TECHNICAL-ARCHITECTURE.md
+- .claude/PROJECT.md (platform selection)
+
+Would you like me to commit these to a feature branch? (Recommended to keep `main` clean)
+
+If yes, I will:
+1. Create branch `docs/bootstrap-architecture`
+2. Commit with message `docs: add technical architecture and platform config`
+3. Push and offer to create a PR
+
 ## What Gets Unlocked
 
 After Phase 2 is complete:

--- a/.claude/commands/bootstrap-product.md
+++ b/.claude/commands/bootstrap-product.md
@@ -374,6 +374,19 @@ Use these templates when generating the documents:
 3. **Define "not building"** - Scope clarity prevents scope creep
 4. **Set measurable goals** - "Better UX" isn't measurable
 
+## Finish Up
+
+The following files were created:
+- docs/PRODUCT-REQUIREMENTS.md
+- docs/PRODUCT-ROADMAP.md
+
+Would you like me to commit these to a feature branch? (Recommended to keep `main` clean)
+
+If yes, I will:
+1. Create branch `docs/bootstrap-product`
+2. Commit with message `docs: add product requirements and roadmap`
+3. Push and offer to create a PR
+
 ## What Happens Next
 
 After completing this questionnaire:


### PR DESCRIPTION
## Problem
The bootstrap commands ( and ) generate documentation files but leave them uncommitted on . When users later run  (which requires a clean working tree), they often commit directly to , violating CLAUDE.md rule #1.

## Solution
Added a "Finish Up" section to both bootstrap skills that offers to:
1. Create an appropriate feature branch ( or )
2. Commit the generated files with conventional commit messages
3. Push the branch and offer to create a PR

## Changes
- : Added "Finish Up" section offering to commit PRD and roadmap
- : Added "Finish Up" section offering to commit architecture docs

## Testing
- User can decline and stay on  (preserves current behavior)
- Branch naming follows project conventions
- Commit messages use conventional format
- No auto-commit without user consent

Fixes #281