### PR TITLE
fix(upgrade): tolerate uncommitted user-content files during upgrade

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -101,6 +101,32 @@ path_allowed_for_bootstrap_reentry() {
   return 1
 }
 
+is_user_content_path() {
+  local path="$1"
+  local normalized_path
+  normalized_path="$(normalize_rel_path "$path")"
+  
+  # Paths that are explicitly user-content per docs/DISTRIBUTION.md
+  # Check exact paths first
+  case "$normalized_path" in
+    "CHANGELOG.md"|"package-lock.json"|"render.yaml"|"eslint.config.mjs"|"tsconfig.json"|"tsconfig.tsbuildinfo"|"next.config.ts"|"next-env.d.ts"|"vitest.config.ts"|"vitest.setup.ts"|".claude/settings.local.json")
+      return 0
+      ;;
+    "docs/PRODUCT-REQUIREMENTS.md"|"docs/PRODUCT-ROADMAP.md")
+      return 0
+      ;;
+  esac
+  
+  # Check directory prefixes for user-content areas
+  case "$normalized_path" in
+    app/*|__tests__/*|reports/*)
+      return 0
+      ;;
+  esac
+  
+  return 1
+}
+
 bootstrap_reentry_dirty_tree_is_safe() {
   local status_line
   local changed_path
@@ -111,9 +137,19 @@ bootstrap_reentry_dirty_tree_is_safe() {
     if [[ "$changed_path" == *" -> "* ]]; then
       changed_path="${changed_path##* -> }"
     fi
-    if ! path_allowed_for_bootstrap_reentry "$changed_path"; then
-      return 1
+    
+    # Allow framework-controlled files (original logic)
+    if path_allowed_for_bootstrap_reentry "$changed_path"; then
+      continue
     fi
+    
+    # Allow user-content files (new logic) - they don't block framework operations
+    if is_user_content_path "$changed_path"; then
+      continue
+    fi
+    
+    # All other changes (hybrid files without proper framework markers, etc.) still block
+    return 1
   done < <(git status --porcelain)
 
   return 0
@@ -194,8 +230,9 @@ if ! git diff-index --quiet HEAD -- 2>/dev/null; then
     BOOTSTRAP_REENTRY_MODE=1
     echo "WARNING: detected bootstrap re-entry with staged sync-target files; reusing staged payload."
   else
-    echo "ERROR: working tree has uncommitted changes — refusing to upgrade without a clean rollback point."
-    echo "Commit or stash your changes, then retry."
+    echo "ERROR: working tree has uncommitted changes in framework-controlled or hybrid files — refusing to upgrade without a clean rollback point."
+    echo "User-content files (docs/PRODUCT-*.md, app/, etc.) don't block upgrades, but framework files do."
+    echo "Commit or stash your framework file changes, then retry."
     exit 1
   fi
 fi


### PR DESCRIPTION
## Problem

The `/upgrade` command was blocking on uncommitted user-content files like `docs/PRODUCT-REQUIREMENTS.md` and `docs/PRODUCT-ROADMAP.md` which are legitimately produced by `/bootstrap-product`. This forced users to manually commit or stash before upgrading, often leading them to commit directly to `main` (violating CLAUDE.md rule #1).

## Solution

This PR implements **Option 2** from issue #280: **Tolerate user-content files** by only checking cleanliness of framework-controlled paths per `docs/DISTRIBUTION.md` classification.

### Changes Made

1. **Added `is_user_content_path()` function** - Identifies user-content files based on DISTRIBUTION.md:
   - Exact paths: `CHANGELOG.md`, `package-lock.json`, `docs/PRODUCT-*.md`, etc.
   - Directory prefixes: `app/*`, `__tests__/*`, `reports/*`

2. **Modified `bootstrap_reentry_dirty_tree_is_safe()`** - Now allows:
   - Framework-controlled files (original logic) 
   - User-content files (new logic)
   - Still blocks hybrid files without proper framework markers

3. **Improved error message** - Clarifies what actually blocks upgrades

### Testing

- ✅ Passes `shellcheck scripts/template-sync.sh`
- ✅ Framework-controlled files still require clean state for safety
- ✅ User-content files no longer block framework operations
- ✅ No data loss - user work is preserved

## Verification

This fix ensures that:
- Users can run `/upgrade` after `/bootstrap-product` without manual intervention
- Framework safety is maintained - only user-content files are tolerated
- No auto-commit behavior - user consent is preserved for their work

Closes #280