### PR TITLE
fix(sync): add git add .agile-flow-meta/version after writing

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -421,6 +421,7 @@ git add "$VERSION_FILE"
 # Create .agile-flow-meta directory and write version file
 mkdir -p .agile-flow-meta
 echo "$LATEST_VERSION" > .agile-flow-meta/version
+git add .agile-flow-meta/version
 
 COMMIT_MSG="chore(sync): update Agile Flow framework to v${LATEST_VERSION}"
 # Scope the bot identity to this single commit using -c so running locally


### PR DESCRIPTION
## Problem

Fixes #294 - The template-sync.sh script writes to  but forgets to stage it with , leaving the file dirty in the working tree after every  operation.

## Solution

Added  immediately after the  line, following the existing pattern used for  file.

## Changes

- **MODIFY** Local version : 0.1.0
Sync targets  : .claude/agents
.claude/commands
.claude/hooks
.claude/skills
scripts
starters
Protected overrides: 1 pattern(s)
Latest version: 1.0.7
Update available: 0.1.0 -> 1.0.7
ERROR: working tree has uncommitted changes in framework-controlled or hybrid files — refusing to upgrade without a clean rollback point.
User-content files (docs/PRODUCT-*.md, app/, etc.) don't block upgrades, but framework files do.
Commit or stash your framework file changes, then retry.: Add single line  after line 423
- Follows existing git add pattern used elsewhere in the script
- Ensures both  and  are properly staged

## Testing

- ✅ shellcheck passes with no errors
- ✅ One-line fix follows established pattern  
- ✅ Matches guardrails in issue description

## Result

After this fix,  operations will leave a clean working tree with no uncommitted  file, improving the first-upgrade experience for downstream forks.