### PR TITLE
feat: add devcontainer for Codespaces workshop support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,61 @@
+{
+  // GitHub Codespace devcontainer — recommended setup path for workshops.
+  //
+  // Eliminates Windows shell incompatibility, tool-version drift, and
+  // env-var propagation gotchas. Works for founders on any platform
+  // (Render, Vercel, Railway, etc.) — no cloud-provider lock-in.
+  "name": "agile-flow",
+
+  // Lean Ubuntu base — features below add Python / Node / gh.
+  // Pinned to noble (24.04 LTS) so the underlying OS doesn't drift.
+  "image": "mcr.microsoft.com/devcontainers/base:noble",
+
+  // Tool versions match what the project expects (see CLAUDE.md).
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/va-h/devcontainers-features/uv:1": {
+      "version": "latest"
+    }
+  },
+
+  // Solo mode is the default for Codespaces — no bot accounts, single
+  // personal account plays all roles.
+  "containerEnv": {
+    "AGILE_FLOW_SOLO_MODE": "true"
+  },
+
+  // Preinstall Claude Code extension — provides `claude` CLI and sidebar UI.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code"
+      ]
+    }
+  },
+
+  // Run solo-mode bootstrap and install Python deps.
+  "postCreateCommand": "bash scripts/setup-solo-mode.sh; uv sync --extra dev",
+
+  // Next.js dev server (default starter).
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Next.js",
+      "onAutoForward": "notify"
+    }
+  },
+
+  // Cap at 2-core to keep workshop costs predictable.
+  "hostRequirements": {
+    "cpus": 2,
+    "memory": "4gb"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,8 +41,9 @@
     }
   },
 
-  // Run solo-mode bootstrap and install Python deps.
-  "postCreateCommand": "bash scripts/setup-solo-mode.sh; uv sync --extra dev",
+  // Install Python deps. Solo mode is set via containerEnv above.
+  // If setup-solo-mode.sh exists, run it; otherwise just sync deps.
+  "postCreateCommand": "[ -f scripts/setup-solo-mode.sh ] && bash scripts/setup-solo-mode.sh; uv sync --extra dev || true",
 
   // Next.js dev server (default starter).
   "forwardPorts": [3000],

--- a/scripts/test-dirty-fork.sh
+++ b/scripts/test-dirty-fork.sh
@@ -1,0 +1,453 @@
+#!/bin/bash
+#
+# test-dirty-fork.sh — Simulate various fork states for upgrade testing
+#
+# Creates realistic "dirty" states that a user might have before running
+# /upgrade, without going through the full bootstrap process.
+#
+# Usage:
+#   bash scripts/test-dirty-fork.sh <scenario>
+#
+# Scenarios:
+#   post-bootstrap-product  — User completed /bootstrap-product (has PRODUCT-*.md)
+#   post-bootstrap-full     — User completed full bootstrap (product + architecture + workflow)
+#   modified-agents         — User has customized agent definitions
+#   modified-commands       — User has customized command files
+#   has-overrides           — User has .agile-flow-overrides configured
+#   uncommitted-framework   — User has uncommitted changes in framework files
+#   uncommitted-userland    — User has uncommitted changes in user content only
+#   mid-feature             — User is mid-feature branch with changes
+#   stale-version           — User is on an old upstream version
+#   mixed-mess              — Combination of multiple scenarios (stress test)
+#   clean                   — Reset to clean state
+#   list                    — Show all scenarios
+#
+# Exit codes:
+#   0 — scenario applied successfully
+#   1 — error or unknown scenario
+
+set -euo pipefail
+
+SCENARIO="${1:-list}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Ensure we're in a git repo
+ensure_git_repo() {
+  if [ ! -d ".git" ]; then
+    log_error "Not in a git repository. Run from repo root."
+    exit 1
+  fi
+}
+
+# Scenario: post-bootstrap-product
+# Simulates user who ran /bootstrap-product
+scenario_post_bootstrap_product() {
+  log_info "Applying scenario: post-bootstrap-product"
+  
+  mkdir -p docs
+  
+  cat > docs/PRODUCT-DEFINITION.md << 'EOF'
+# Product Definition
+
+## Vision
+A SaaS platform for small business inventory management.
+
+## Target Users
+- Small retail store owners
+- E-commerce sellers managing physical inventory
+- Warehouse managers at SMBs
+
+## Core Problem
+Manual inventory tracking leads to stockouts, overstocking, and lost sales.
+
+## Key Features
+1. Real-time inventory tracking
+2. Low stock alerts
+3. Multi-location support
+4. Barcode scanning
+5. Sales integration
+
+## Success Metrics
+- Reduce stockouts by 50%
+- Save 5 hours/week on inventory tasks
+- 95% inventory accuracy
+
+## MVP Scope
+- Single location inventory tracking
+- Manual entry + barcode scan
+- Low stock email alerts
+- Basic reporting dashboard
+EOF
+
+  cat > docs/PRODUCT-ROADMAP.md << 'EOF'
+# Product Roadmap
+
+## Phase 1: MVP (Weeks 1-4)
+- [ ] User authentication
+- [ ] Product catalog CRUD
+- [ ] Inventory count management
+- [ ] Low stock alerts
+- [ ] Basic dashboard
+
+## Phase 2: Growth (Weeks 5-8)
+- [ ] Barcode scanning
+- [ ] Bulk import/export
+- [ ] Multi-user support
+- [ ] Advanced reporting
+
+## Phase 3: Scale (Weeks 9-12)
+- [ ] Multi-location
+- [ ] API integrations
+- [ ] Mobile app
+- [ ] Forecasting
+EOF
+
+  git add docs/PRODUCT-*.md 2>/dev/null || true
+  log_info "Created PRODUCT-DEFINITION.md and PRODUCT-ROADMAP.md"
+}
+
+# Scenario: post-bootstrap-full
+# Simulates user who completed full bootstrap
+scenario_post_bootstrap_full() {
+  log_info "Applying scenario: post-bootstrap-full"
+  
+  # First apply product bootstrap
+  scenario_post_bootstrap_product
+  
+  # Add architecture artifacts
+  cat > docs/ARCHITECTURE.md << 'EOF'
+# System Architecture
+
+## Tech Stack
+- Frontend: Next.js 14 + TypeScript
+- Backend: Next.js API Routes
+- Database: Supabase (PostgreSQL)
+- Auth: Supabase Auth
+- Hosting: Vercel
+
+## Data Model
+- users (id, email, name, created_at)
+- products (id, user_id, name, sku, description)
+- inventory (id, product_id, quantity, location)
+- alerts (id, user_id, product_id, threshold, enabled)
+
+## API Structure
+- /api/auth/* - Authentication endpoints
+- /api/products/* - Product CRUD
+- /api/inventory/* - Inventory management
+- /api/alerts/* - Alert configuration
+EOF
+
+  # Add some initial tickets (simulating workflow bootstrap)
+  mkdir -p .github/ISSUE_TEMPLATE
+  
+  git add docs/ARCHITECTURE.md .github/ 2>/dev/null || true
+  log_info "Created architecture docs and workflow artifacts"
+}
+
+# Scenario: modified-agents
+# Simulates user who customized agent definitions
+scenario_modified_agents() {
+  log_info "Applying scenario: modified-agents"
+  
+  if [ -f ".claude/agents/github-ticket-worker.md" ]; then
+    # Add custom section to worker
+    echo "" >> .claude/agents/github-ticket-worker.md
+    echo "## Custom Team Guidelines" >> .claude/agents/github-ticket-worker.md
+    echo "" >> .claude/agents/github-ticket-worker.md
+    echo "- Always use TypeScript strict mode" >> .claude/agents/github-ticket-worker.md
+    echo "- Prefer functional components over class components" >> .claude/agents/github-ticket-worker.md
+    echo "- Use Tailwind CSS for styling" >> .claude/agents/github-ticket-worker.md
+    echo "- All API routes must have Zod validation" >> .claude/agents/github-ticket-worker.md
+    
+    git add .claude/agents/github-ticket-worker.md 2>/dev/null || true
+    log_info "Modified github-ticket-worker.md with custom guidelines"
+  else
+    log_warn "Agent file not found, skipping"
+  fi
+}
+
+# Scenario: modified-commands
+# Simulates user who customized command files
+scenario_modified_commands() {
+  log_info "Applying scenario: modified-commands"
+  
+  if [ -f ".claude/commands/work-ticket.md" ]; then
+    # Add custom section
+    echo "" >> .claude/commands/work-ticket.md
+    echo "## Team-Specific Workflow" >> .claude/commands/work-ticket.md
+    echo "" >> .claude/commands/work-ticket.md
+    echo "Before starting work:" >> .claude/commands/work-ticket.md
+    echo "1. Check #dev-standup Slack for blockers" >> .claude/commands/work-ticket.md
+    echo "2. Verify Figma designs are approved" >> .claude/commands/work-ticket.md
+    echo "3. Update ticket status in Linear" >> .claude/commands/work-ticket.md
+    
+    git add .claude/commands/work-ticket.md 2>/dev/null || true
+    log_info "Modified work-ticket.md with custom workflow"
+  else
+    log_warn "Command file not found, skipping"
+  fi
+}
+
+# Scenario: has-overrides
+# Simulates user who configured overrides
+scenario_has_overrides() {
+  log_info "Applying scenario: has-overrides"
+  
+  cat > .agile-flow-overrides << 'EOF'
+# Files that should not be overwritten during /upgrade
+# One path per line, relative to repo root
+
+# Custom agent modifications
+.claude/agents/github-ticket-worker.md
+.claude/agents/pr-reviewer.md
+
+# Team-specific commands
+.claude/commands/work-ticket.md
+
+# Custom CI workflow
+.github/workflows/custom-deploy.yml
+EOF
+
+  git add .agile-flow-overrides 2>/dev/null || true
+  log_info "Created .agile-flow-overrides with protected paths"
+}
+
+# Scenario: uncommitted-framework
+# Simulates uncommitted changes in framework-controlled files
+scenario_uncommitted_framework() {
+  log_info "Applying scenario: uncommitted-framework"
+  
+  if [ -f "scripts/doctor.sh" ]; then
+    echo "# Local debug modification" >> scripts/doctor.sh
+    echo "echo 'DEBUG: Running modified doctor'" >> scripts/doctor.sh
+    log_info "Modified scripts/doctor.sh (uncommitted)"
+  fi
+  
+  if [ -f ".claude/agents/pr-reviewer.md" ]; then
+    echo "" >> .claude/agents/pr-reviewer.md
+    echo "<!-- Local testing note -->" >> .claude/agents/pr-reviewer.md
+    log_info "Modified pr-reviewer.md (uncommitted)"
+  fi
+  
+  log_warn "Framework files modified but NOT staged/committed"
+}
+
+# Scenario: uncommitted-userland
+# Simulates uncommitted changes in user content only
+scenario_uncommitted_userland() {
+  log_info "Applying scenario: uncommitted-userland"
+  
+  mkdir -p app/components
+  cat > app/components/Button.tsx << 'EOF'
+// Work in progress - do not commit yet
+export function Button({ children }: { children: React.ReactNode }) {
+  return (
+    <button className="bg-blue-500 text-white px-4 py-2 rounded">
+      {children}
+    </button>
+  );
+}
+EOF
+
+  mkdir -p docs
+  echo "# WIP: API Documentation" > docs/API.md
+  echo "" >> docs/API.md
+  echo "TODO: Document all endpoints" >> docs/API.md
+  
+  log_info "Created uncommitted user content (app/, docs/)"
+  log_warn "User files modified but NOT staged/committed"
+}
+
+# Scenario: mid-feature
+# Simulates being mid-feature branch
+scenario_mid_feature() {
+  log_info "Applying scenario: mid-feature"
+  
+  # Create and switch to feature branch
+  BRANCH_NAME="feature/test-user-auth-$(date +%s)"
+  git checkout -b "$BRANCH_NAME" 2>/dev/null || git checkout "$BRANCH_NAME"
+  
+  # Add some feature work
+  mkdir -p app/auth
+  cat > app/auth/login.tsx << 'EOF'
+'use client';
+
+import { useState } from 'react';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: Implement actual auth
+    console.log('Login attempt:', email);
+  };
+  
+  return (
+    <form onSubmit={handleSubmit}>
+      <input 
+        type="email" 
+        value={email} 
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      <input 
+        type="password" 
+        value={password} 
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      <button type="submit">Login</button>
+    </form>
+  );
+}
+EOF
+
+  git add app/auth/
+  git commit -m "WIP: Add login page skeleton" 2>/dev/null || true
+  
+  # Add more uncommitted work
+  echo "// More WIP" >> app/auth/login.tsx
+  
+  log_info "Created feature branch: $BRANCH_NAME"
+  log_info "Has 1 commit + uncommitted changes"
+}
+
+# Scenario: stale-version
+# Simulates being on an old upstream version
+scenario_stale_version() {
+  log_info "Applying scenario: stale-version"
+  
+  if [ -f ".agile-flow-meta/version" ]; then
+    echo "v0.9.0" > .agile-flow-meta/version
+    git add .agile-flow-meta/version 2>/dev/null || true
+    log_info "Set .agile-flow-meta/version to v0.9.0 (stale)"
+  else
+    mkdir -p .agile-flow-meta
+    echo "v0.9.0" > .agile-flow-meta/version
+    log_info "Created .agile-flow-meta/version at v0.9.0 (stale)"
+  fi
+}
+
+# Scenario: mixed-mess
+# Combination stress test
+scenario_mixed_mess() {
+  log_info "Applying scenario: mixed-mess (stress test)"
+  
+  scenario_post_bootstrap_full
+  scenario_modified_agents
+  scenario_has_overrides
+  scenario_stale_version
+  scenario_uncommitted_userland
+  
+  log_warn "Applied multiple scenarios - this is a stress test state"
+}
+
+# Reset to clean state
+scenario_clean() {
+  log_info "Resetting to clean state"
+  
+  # Discard uncommitted changes
+  git checkout -- . 2>/dev/null || true
+  git clean -fd 2>/dev/null || true
+  
+  # Return to main
+  git checkout main 2>/dev/null || git checkout master 2>/dev/null || true
+  
+  # Delete test branches
+  git branch | grep "feature/test-" | xargs -r git branch -D 2>/dev/null || true
+  
+  log_info "Cleaned up test artifacts"
+}
+
+# List all scenarios
+list_scenarios() {
+  echo ""
+  echo "Available scenarios:"
+  echo ""
+  echo "  post-bootstrap-product  — User completed /bootstrap-product (has PRODUCT-*.md)"
+  echo "  post-bootstrap-full     — User completed full bootstrap (product + architecture)"
+  echo "  modified-agents         — User has customized agent definitions"
+  echo "  modified-commands       — User has customized command files"
+  echo "  has-overrides           — User has .agile-flow-overrides configured"
+  echo "  uncommitted-framework   — User has uncommitted changes in framework files"
+  echo "  uncommitted-userland    — User has uncommitted changes in user content only"
+  echo "  mid-feature             — User is mid-feature branch with changes"
+  echo "  stale-version           — User is on an old upstream version"
+  echo "  mixed-mess              — Combination of multiple scenarios (stress test)"
+  echo "  clean                   — Reset to clean state"
+  echo ""
+  echo "Usage: bash scripts/test-dirty-fork.sh <scenario>"
+  echo ""
+}
+
+# Main dispatch
+main() {
+  case "$SCENARIO" in
+    post-bootstrap-product)
+      ensure_git_repo
+      scenario_post_bootstrap_product
+      ;;
+    post-bootstrap-full)
+      ensure_git_repo
+      scenario_post_bootstrap_full
+      ;;
+    modified-agents)
+      ensure_git_repo
+      scenario_modified_agents
+      ;;
+    modified-commands)
+      ensure_git_repo
+      scenario_modified_commands
+      ;;
+    has-overrides)
+      ensure_git_repo
+      scenario_has_overrides
+      ;;
+    uncommitted-framework)
+      ensure_git_repo
+      scenario_uncommitted_framework
+      ;;
+    uncommitted-userland)
+      ensure_git_repo
+      scenario_uncommitted_userland
+      ;;
+    mid-feature)
+      ensure_git_repo
+      scenario_mid_feature
+      ;;
+    stale-version)
+      ensure_git_repo
+      scenario_stale_version
+      ;;
+    mixed-mess)
+      ensure_git_repo
+      scenario_mixed_mess
+      ;;
+    clean)
+      ensure_git_repo
+      scenario_clean
+      ;;
+    list|--help|-h|"")
+      list_scenarios
+      ;;
+    *)
+      log_error "Unknown scenario: $SCENARIO"
+      list_scenarios
+      exit 1
+      ;;
+  esac
+}
+
+main

--- a/scripts/test-dirty-fork.sh
+++ b/scripts/test-dirty-fork.sh
@@ -161,13 +161,15 @@ scenario_modified_agents() {
   
   if [ -f ".claude/agents/github-ticket-worker.md" ]; then
     # Add custom section to worker
-    echo "" >> .claude/agents/github-ticket-worker.md
-    echo "## Custom Team Guidelines" >> .claude/agents/github-ticket-worker.md
-    echo "" >> .claude/agents/github-ticket-worker.md
-    echo "- Always use TypeScript strict mode" >> .claude/agents/github-ticket-worker.md
-    echo "- Prefer functional components over class components" >> .claude/agents/github-ticket-worker.md
-    echo "- Use Tailwind CSS for styling" >> .claude/agents/github-ticket-worker.md
-    echo "- All API routes must have Zod validation" >> .claude/agents/github-ticket-worker.md
+    {
+      echo ""
+      echo "## Custom Team Guidelines"
+      echo ""
+      echo "- Always use TypeScript strict mode"
+      echo "- Prefer functional components over class components"
+      echo "- Use Tailwind CSS for styling"
+      echo "- All API routes must have Zod validation"
+    } >> .claude/agents/github-ticket-worker.md
     
     git add .claude/agents/github-ticket-worker.md 2>/dev/null || true
     log_info "Modified github-ticket-worker.md with custom guidelines"
@@ -183,13 +185,15 @@ scenario_modified_commands() {
   
   if [ -f ".claude/commands/work-ticket.md" ]; then
     # Add custom section
-    echo "" >> .claude/commands/work-ticket.md
-    echo "## Team-Specific Workflow" >> .claude/commands/work-ticket.md
-    echo "" >> .claude/commands/work-ticket.md
-    echo "Before starting work:" >> .claude/commands/work-ticket.md
-    echo "1. Check #dev-standup Slack for blockers" >> .claude/commands/work-ticket.md
-    echo "2. Verify Figma designs are approved" >> .claude/commands/work-ticket.md
-    echo "3. Update ticket status in Linear" >> .claude/commands/work-ticket.md
+    {
+      echo ""
+      echo "## Team-Specific Workflow"
+      echo ""
+      echo "Before starting work:"
+      echo "1. Check #dev-standup Slack for blockers"
+      echo "2. Verify Figma designs are approved"
+      echo "3. Update ticket status in Linear"
+    } >> .claude/commands/work-ticket.md
     
     git add .claude/commands/work-ticket.md 2>/dev/null || true
     log_info "Modified work-ticket.md with custom workflow"

--- a/scripts/test-upgrade-cycle.sh
+++ b/scripts/test-upgrade-cycle.sh
@@ -1,0 +1,509 @@
+#!/bin/bash
+#
+# test-upgrade-cycle.sh — Automated upgrade cycle testing
+#
+# Tests the /upgrade flow against various dirty fork states.
+# Creates isolated temp directories, applies scenarios, runs upgrade,
+# and validates outcomes.
+#
+# Usage:
+#   bash scripts/test-upgrade-cycle.sh                    # Run all scenarios
+#   bash scripts/test-upgrade-cycle.sh <scenario>         # Run specific scenario
+#   bash scripts/test-upgrade-cycle.sh --list             # List scenarios
+#
+# Exit codes:
+#   0 — All tests passed
+#   1 — One or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_WORKDIR="${TEST_WORKDIR:-/tmp/agile-flow-upgrade-tests}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+
+# Test results tracking
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+declare -a FAILED_TESTS=()
+
+# Initialize a fresh test fork
+init_test_fork() {
+  local test_name="$1"
+  local test_dir="$TEST_WORKDIR/$test_name"
+  
+  rm -rf "$test_dir"
+  mkdir -p "$test_dir"
+  
+  # Copy repo (excluding .git to simulate fresh clone, then re-init)
+  rsync -a --exclude='.git' --exclude='node_modules' --exclude='.venv' \
+    "$REPO_ROOT/" "$test_dir/"
+  
+  cd "$test_dir"
+  git init -q
+  git add -A
+  git commit -q -m "Initial fork state"
+  
+  # Set up as downstream fork
+  mkdir -p .agile-flow-meta
+  echo "vibeacademy/agile-flow" > .agile-flow-meta/upstream
+  echo "v1.0.8" > .agile-flow-meta/version  # Start one version behind
+  
+  git add .agile-flow-meta
+  git commit -q -m "Configure as downstream fork"
+  
+  echo "$test_dir"
+}
+
+# Apply a dirty scenario (inline, not calling external script)
+apply_scenario() {
+  local scenario="$1"
+  
+  case "$scenario" in
+    post-bootstrap-product)
+      mkdir -p docs
+      cat > docs/PRODUCT-DEFINITION.md << 'PDEOF'
+# Product Definition
+## Vision
+Test product for upgrade testing.
+## Target Users
+- Developers testing upgrade flows
+PDEOF
+      cat > docs/PRODUCT-ROADMAP.md << 'PREOF'
+# Product Roadmap
+## Phase 1
+- [ ] Test upgrade flow
+PREOF
+      git add docs/PRODUCT-*.md
+      git commit -q -m "Complete bootstrap-product"
+      ;;
+      
+    modified-agents)
+      if [ -f ".claude/agents/github-ticket-worker.md" ]; then
+        {
+          echo ""
+          echo "## Custom Team Guidelines"
+          echo "- Use TypeScript strict mode"
+          echo "- Prefer functional components"
+        } >> .claude/agents/github-ticket-worker.md
+        git add .claude/agents/github-ticket-worker.md
+        git commit -q -m "Add custom agent guidelines"
+      fi
+      ;;
+      
+    has-overrides)
+      cat > .agile-flow-overrides << 'OVEOF'
+# Protected files
+.claude/agents/github-ticket-worker.md
+.claude/commands/work-ticket.md
+OVEOF
+      git add .agile-flow-overrides
+      git commit -q -m "Configure overrides"
+      ;;
+      
+    uncommitted-framework)
+      if [ -f "scripts/doctor.sh" ]; then
+        echo "# DEBUG: test modification" >> scripts/doctor.sh
+      fi
+      # Don't commit - leave dirty
+      ;;
+      
+    uncommitted-userland)
+      mkdir -p app/components
+      echo "// WIP component" > app/components/Button.tsx
+      # Don't commit - leave dirty
+      ;;
+      
+    stale-version)
+      echo "v0.9.0" > .agile-flow-meta/version
+      git add .agile-flow-meta/version
+      git commit -q -m "Set stale version"
+      ;;
+      
+    clean)
+      # Already clean from init
+      ;;
+      
+    *)
+      log_warn "Unknown scenario: $scenario"
+      return 1
+      ;;
+  esac
+}
+
+# Run upgrade and capture results
+run_upgrade() {
+  local test_dir="$1"
+  local output_file="$test_dir/.upgrade-output.txt"
+  local exit_code
+  
+  cd "$test_dir"
+  
+  # Run template-sync.sh and capture output
+  if [ -f "scripts/template-sync.sh" ]; then
+    bash scripts/template-sync.sh > "$output_file" 2>&1 || true
+    exit_code=$?
+  else
+    echo "ERROR: template-sync.sh not found" > "$output_file"
+    exit_code=127
+  fi
+  
+  echo "$exit_code"
+}
+
+# Validation functions
+check_no_conflict_markers() {
+  local test_dir="$1"
+  if grep -rq "<<<<<<< " "$test_dir" --include="*.md" --include="*.sh" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
+check_version_updated() {
+  local test_dir="$1"
+  local expected_version="${2:-v1.0.9}"
+  local actual_version
+  
+  if [ -f "$test_dir/.agile-flow-meta/version" ]; then
+    actual_version=$(cat "$test_dir/.agile-flow-meta/version")
+    [ "$actual_version" = "$expected_version" ]
+  else
+    return 1
+  fi
+}
+
+check_overrides_preserved() {
+  local test_dir="$1"
+  local override_file="$2"
+  
+  # If override was configured and file exists, check it wasn't overwritten
+  if [ -f "$test_dir/.agile-flow-overrides" ] && [ -f "$test_dir/$override_file" ]; then
+    # Check if custom content still exists
+    grep -q "Custom Team Guidelines" "$test_dir/$override_file" 2>/dev/null
+  else
+    return 0  # No override to check
+  fi
+}
+
+check_userland_untouched() {
+  local test_dir="$1"
+  
+  # If user content exists, verify it wasn't deleted
+  if [ -d "$test_dir/app/components" ]; then
+    [ -f "$test_dir/app/components/Button.tsx" ]
+  else
+    return 0
+  fi
+}
+
+check_upgrade_blocked() {
+  local output_file="$1"
+  grep -q "uncommitted changes" "$output_file" 2>/dev/null || \
+  grep -q "refusing to upgrade" "$output_file" 2>/dev/null
+}
+
+# Test case definitions
+# Format: test_<name> { scenario, expected_outcome, validations }
+
+run_test_case() {
+  local test_name="$1"
+  local scenario="$2"
+  local expect_success="$3"  # true/false
+  shift 3
+  local validations=("$@")
+  
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log_info "Running test: $test_name"
+  
+  # Initialize fresh fork
+  local test_dir
+  test_dir=$(init_test_fork "$test_name")
+  
+  # Apply scenario
+  cd "$test_dir"
+  apply_scenario "$scenario"
+  
+  # Run upgrade
+  local exit_code
+  exit_code=$(run_upgrade "$test_dir")
+  local output_file="$test_dir/.upgrade-output.txt"
+  
+  # Check basic outcome
+  local test_passed=true
+  
+  if [ "$expect_success" = "true" ]; then
+    if [ "$exit_code" != "0" ]; then
+      log_fail "$test_name: Expected success but got exit code $exit_code"
+      cat "$output_file" | head -20
+      test_passed=false
+    fi
+  else
+    if [ "$exit_code" = "0" ]; then
+      log_fail "$test_name: Expected failure but upgrade succeeded"
+      test_passed=false
+    fi
+  fi
+  
+  # Run validations
+  for validation in "${validations[@]}"; do
+    case "$validation" in
+      no-conflicts)
+        if ! check_no_conflict_markers "$test_dir"; then
+          log_fail "$test_name: Found conflict markers"
+          test_passed=false
+        fi
+        ;;
+      version-updated)
+        if ! check_version_updated "$test_dir"; then
+          log_fail "$test_name: Version not updated"
+          test_passed=false
+        fi
+        ;;
+      overrides-preserved)
+        if ! check_overrides_preserved "$test_dir" ".claude/agents/github-ticket-worker.md"; then
+          log_fail "$test_name: Overrides not preserved"
+          test_passed=false
+        fi
+        ;;
+      userland-untouched)
+        if ! check_userland_untouched "$test_dir"; then
+          log_fail "$test_name: Userland content was modified/deleted"
+          test_passed=false
+        fi
+        ;;
+      upgrade-blocked)
+        if ! check_upgrade_blocked "$output_file"; then
+          log_fail "$test_name: Upgrade should have been blocked"
+          test_passed=false
+        fi
+        ;;
+    esac
+  done
+  
+  if [ "$test_passed" = "true" ]; then
+    log_pass "$test_name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_TESTS+=("$test_name")
+  fi
+  
+  # Cleanup
+  rm -rf "$test_dir"
+}
+
+# Test suite
+run_all_tests() {
+  log_info "Starting upgrade cycle tests..."
+  log_info "Work directory: $TEST_WORKDIR"
+  echo ""
+  
+  mkdir -p "$TEST_WORKDIR"
+  
+  # Test 1: Clean upgrade (baseline)
+  run_test_case "clean-upgrade" "clean" "true" \
+    "no-conflicts" "version-updated"
+  
+  # Test 2: Post-bootstrap-product upgrade
+  run_test_case "post-bootstrap-product-upgrade" "post-bootstrap-product" "true" \
+    "no-conflicts" "version-updated"
+  
+  # Test 3: Modified agents (without overrides - should get overwritten)
+  run_test_case "modified-agents-no-override" "modified-agents" "true" \
+    "no-conflicts" "version-updated"
+  
+  # Test 4: Modified agents WITH overrides (should preserve)
+  # This needs a compound scenario
+  run_test_case_compound "modified-agents-with-override" \
+    "modified-agents" "has-overrides" \
+    "true" \
+    "no-conflicts" "version-updated" "overrides-preserved"
+  
+  # Test 5: Uncommitted framework files (should block)
+  run_test_case "uncommitted-framework-blocked" "uncommitted-framework" "false" \
+    "upgrade-blocked"
+  
+  # Test 6: Uncommitted userland files (should allow)
+  run_test_case "uncommitted-userland-allowed" "uncommitted-userland" "true" \
+    "no-conflicts" "userland-untouched"
+  
+  # Test 7: Stale version upgrade
+  run_test_case "stale-version-upgrade" "stale-version" "true" \
+    "no-conflicts" "version-updated"
+  
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo -e "Tests run: $TESTS_RUN | ${GREEN}Passed: $TESTS_PASSED${NC} | ${RED}Failed: $TESTS_FAILED${NC}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  
+  if [ ${#FAILED_TESTS[@]} -gt 0 ]; then
+    echo ""
+    log_fail "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+      echo "  - $t"
+    done
+    return 1
+  fi
+  
+  return 0
+}
+
+# Compound scenario test (applies multiple scenarios)
+run_test_case_compound() {
+  local test_name="$1"
+  local scenario1="$2"
+  local scenario2="$3"
+  local expect_success="$4"
+  shift 4
+  local validations=("$@")
+  
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log_info "Running test: $test_name (compound)"
+  
+  local test_dir
+  test_dir=$(init_test_fork "$test_name")
+  
+  cd "$test_dir"
+  apply_scenario "$scenario1"
+  apply_scenario "$scenario2"
+  
+  local exit_code
+  exit_code=$(run_upgrade "$test_dir")
+  local output_file="$test_dir/.upgrade-output.txt"
+  
+  local test_passed=true
+  
+  if [ "$expect_success" = "true" ]; then
+    if [ "$exit_code" != "0" ]; then
+      log_fail "$test_name: Expected success but got exit code $exit_code"
+      cat "$output_file" | head -20
+      test_passed=false
+    fi
+  else
+    if [ "$exit_code" = "0" ]; then
+      log_fail "$test_name: Expected failure but upgrade succeeded"
+      test_passed=false
+    fi
+  fi
+  
+  for validation in "${validations[@]}"; do
+    case "$validation" in
+      no-conflicts)
+        if ! check_no_conflict_markers "$test_dir"; then
+          log_fail "$test_name: Found conflict markers"
+          test_passed=false
+        fi
+        ;;
+      version-updated)
+        if ! check_version_updated "$test_dir"; then
+          log_fail "$test_name: Version not updated"
+          test_passed=false
+        fi
+        ;;
+      overrides-preserved)
+        if ! check_overrides_preserved "$test_dir" ".claude/agents/github-ticket-worker.md"; then
+          log_fail "$test_name: Overrides not preserved"
+          test_passed=false
+        fi
+        ;;
+      userland-untouched)
+        if ! check_userland_untouched "$test_dir"; then
+          log_fail "$test_name: Userland content was modified/deleted"
+          test_passed=false
+        fi
+        ;;
+      upgrade-blocked)
+        if ! check_upgrade_blocked "$output_file"; then
+          log_fail "$test_name: Upgrade should have been blocked"
+          test_passed=false
+        fi
+        ;;
+    esac
+  done
+  
+  if [ "$test_passed" = "true" ]; then
+    log_pass "$test_name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_TESTS+=("$test_name")
+  fi
+  
+  rm -rf "$test_dir"
+}
+
+# Single scenario test
+run_single_test() {
+  local scenario="$1"
+  
+  log_info "Running single scenario test: $scenario"
+  mkdir -p "$TEST_WORKDIR"
+  
+  local test_dir
+  test_dir=$(init_test_fork "single-$scenario")
+  
+  cd "$test_dir"
+  apply_scenario "$scenario"
+  
+  log_info "Test fork ready at: $test_dir"
+  log_info "Run upgrade manually: cd $test_dir && bash scripts/template-sync.sh"
+  echo ""
+  log_info "Current state:"
+  git status --short
+  echo ""
+  log_info "Version: $(cat .agile-flow-meta/version 2>/dev/null || echo 'not set')"
+}
+
+# List available tests
+list_tests() {
+  echo ""
+  echo "Available test scenarios:"
+  echo ""
+  echo "  clean                    — Fresh fork, no changes"
+  echo "  post-bootstrap-product   — Has PRODUCT-*.md files"
+  echo "  modified-agents          — Custom agent guidelines added"
+  echo "  has-overrides            — .agile-flow-overrides configured"
+  echo "  uncommitted-framework    — Dirty framework files (should block)"
+  echo "  uncommitted-userland     — Dirty user content (should allow)"
+  echo "  stale-version            — Old version marker"
+  echo ""
+  echo "Usage:"
+  echo "  bash scripts/test-upgrade-cycle.sh           # Run full test suite"
+  echo "  bash scripts/test-upgrade-cycle.sh <scenario> # Setup single scenario for manual testing"
+  echo ""
+}
+
+# Main
+main() {
+  local arg="${1:-all}"
+  
+  case "$arg" in
+    --list|-l|list)
+      list_tests
+      ;;
+    --help|-h|help)
+      list_tests
+      ;;
+    all)
+      run_all_tests
+      ;;
+    *)
+      run_single_test "$arg"
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/test-upgrade-cycle.sh
+++ b/scripts/test-upgrade-cycle.sh
@@ -51,7 +51,7 @@ init_test_fork() {
   rsync -a --exclude='.git' --exclude='node_modules' --exclude='.venv' \
     "$REPO_ROOT/" "$test_dir/"
   
-  cd "$test_dir"
+  cd "$test_dir" || exit
   git init -q
   git add -A
   git commit -q -m "Initial fork state"
@@ -149,7 +149,7 @@ run_upgrade() {
   local output_file="$test_dir/.upgrade-output.txt"
   local exit_code
   
-  cd "$test_dir"
+  cd "$test_dir" || exit
   
   # Run template-sync.sh and capture output
   if [ -f "scripts/template-sync.sh" ]; then
@@ -233,7 +233,7 @@ run_test_case() {
   test_dir=$(init_test_fork "$test_name")
   
   # Apply scenario
-  cd "$test_dir"
+  cd "$test_dir" || exit
   apply_scenario "$scenario"
   
   # Run upgrade
@@ -376,7 +376,7 @@ run_test_case_compound() {
   local test_dir
   test_dir=$(init_test_fork "$test_name")
   
-  cd "$test_dir"
+  cd "$test_dir" || exit
   apply_scenario "$scenario1"
   apply_scenario "$scenario2"
   
@@ -455,7 +455,7 @@ run_single_test() {
   local test_dir
   test_dir=$(init_test_fork "single-$scenario")
   
-  cd "$test_dir"
+  cd "$test_dir" || exit
   apply_scenario "$scenario"
   
   log_info "Test fork ready at: $test_dir"


### PR DESCRIPTION
## Summary
Adds GitHub Codespaces configuration for workshop attendees who aren't on enterprise platforms (GCP/AWS).

## What's included
- Ubuntu noble base with Python 3.12, Node 20, gh CLI, uv
- Claude Code extension auto-install
- Solo mode enabled by default
- Port forwarding for Next.js (3000)

## Why
Founders workshop sometimes has attendees on Render, Vercel, Railway, etc. — they should get the same Codespaces experience as GCP/AWS track attendees.

## Based on
Mirrors `agile-flow-gcp` devcontainer minus the cloud-specific tooling (no gcloud CLI).