### PR TITLE
fix(commands): replace broken MCP pre-flight with gh CLI check

### DIFF
--- a/.claude/commands/bootstrap-workflow.md
+++ b/.claude/commands/bootstrap-workflow.md
@@ -82,9 +82,9 @@ Before running this phase, ensure you have:
 Before any board or ticket operations, verify the following. STOP and report
 to the user if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
+1. **`gh` CLI is authenticated and the repository is accessible** — Run
+   `gh auth status` and `gh repo view --json nameWithOwner`. If either fails,
+   STOP and instruct the user to fix the issue.
 2. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.

--- a/.claude/commands/create-ticket.md
+++ b/.claude/commands/create-ticket.md
@@ -9,9 +9,9 @@ Create a new ticket on the project board with guided workflow.
 Before creating any ticket, verify the following. STOP and report to the user
 if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
+1. **`gh` CLI is authenticated and the repository is accessible** — Run
+   `gh auth status` and `gh repo view --json nameWithOwner`. If either fails,
+   STOP and instruct the user to fix the issue.
 2. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.

--- a/.claude/commands/quick-fix.md
+++ b/.claude/commands/quick-fix.md
@@ -12,8 +12,9 @@ Before any work, verify the following. STOP and report if any check fails.
 1. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
-2. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call. If the
-   MCP server is not connected, STOP.
+2. **`gh` CLI is authenticated and the repository is accessible** — Run
+   `gh auth status` and `gh repo view --json nameWithOwner`. If either fails,
+   STOP and instruct the user to fix the issue.
 
 ## When to Use This Command
 

--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -11,9 +11,9 @@ Launch the github-ticket-worker agent to implement the next prioritized ticket.
 Before starting work on any ticket, verify the following. STOP and report to
 the user if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
+1. **`gh` CLI is authenticated and the repository is accessible** — Run
+   `gh auth status` and `gh repo view --json nameWithOwner`. If either fails,
+   STOP and instruct the user to fix the issue.
 2. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.


### PR DESCRIPTION
## Summary

- Replaces the always-failing **"MCP GitHub server is reachable"** pre-flight check (broken since the GitHub MCP server was removed in #163) with a falsifiable `gh` CLI check: `gh auth status` + `gh repo view --json nameWithOwner`.
- Modifies 4 slash command spec files: `.claude/commands/create-ticket.md`, `.claude/commands/quick-fix.md`, `.claude/commands/work-ticket.md`, `.claude/commands/bootstrap-workflow.md`.
- Original check is replaced **in the same numbered slot** in each file; all other pre-flight checks (account, hooks, board access) are untouched.

References:
- Flagged in PR #189's review as a follow-up
- Confirmed as a real-world problem by the cubrox session journal 2026-05-25 §9.7
- `docs/PATTERN-LIBRARY.md` §20 still references the historical GitHub MCP vs gh CLI comparison — out of scope here per the ticket; flagging for a separate doc-only follow-up.

## Test plan

- [x] `grep -rln -i "MCP.*server\|mcp__github" .claude/commands/create-ticket.md .claude/commands/quick-fix.md .claude/commands/work-ticket.md .claude/commands/bootstrap-workflow.md` returns no matches
- [x] Each of the 4 files has an equivalent `gh`-based pre-flight in the same numbered slot as the removed MCP check
- [x] `./scripts/lint-agent-policies.sh` passes (0 errors, 0 warnings)
- [x] `./scripts/validation/validate-commands.sh` passes (all 25 command files PASS)
- [x] Rendering: each pre-flight block remains a properly-numbered markdown list with no broken fences
- [ ] Manual smoke (post-merge): invoke `/create-ticket` and confirm it runs `gh auth status` + `gh repo view --json nameWithOwner` as its first check

Closes #329