### PR TITLE
fix(template-sync): Phase 0.5 — redirect-safe curl + configurable upstream + gembaflow fallback

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -32,6 +32,10 @@ if ! gh auth token >/dev/null 2>&1; then
 fi
 
 UPSTREAM_REPO="vibeacademy/agile-flow"
+# FALLBACK_REPO is only consulted when the primary returns 404 (e.g. during the
+# agile-flow -> gembaflow rename window). The primary default stays unchanged
+# in this PR; see #331 (Phase 0.5 of the gembaflow rebrand).
+FALLBACK_REPO="vibeacademy/gembaflow"
 VERSION_FILE=".agile-flow-version"
 OVERRIDES_FILE=".agile-flow-overrides"
 RUNNING_SCRIPT_REL=$(python3 -c "import os,sys; print(os.path.relpath(os.path.realpath(sys.argv[1]), os.getcwd()))" "$0")
@@ -170,7 +174,33 @@ dirs = json.load(open('$VERSION_FILE')).get('syncDirectories', [])
 print('\n'.join(dirs))
 ")
 
+# Read optional `upstream` field from .agile-flow-version. Accepts either a
+# bare "owner/repo" string or a full GitHub URL; falls back to the hardcoded
+# UPSTREAM_REPO if the field is absent or empty. This lets downstream variant
+# forks (e.g. agile-flow-gcp) point /upgrade at their own upstream without
+# editing this script. See #331 (folds agile-flow-gcp#204).
+VERSION_UPSTREAM=$(python3 -c "
+import json, sys
+data = json.load(open('$VERSION_FILE'))
+val = data.get('upstream') or ''
+val = val.strip()
+# Normalize URL form -> owner/repo. Accept https://github.com/<owner>/<repo>
+# (with optional trailing .git or slash).
+for prefix in ('https://github.com/', 'http://github.com/', 'git@github.com:'):
+    if val.startswith(prefix):
+        val = val[len(prefix):]
+        break
+if val.endswith('.git'):
+    val = val[:-4]
+val = val.strip('/')
+print(val)
+")
+if [ -n "$VERSION_UPSTREAM" ]; then
+  UPSTREAM_REPO="$VERSION_UPSTREAM"
+fi
+
 echo "Local version : $LOCAL_VERSION"
+echo "Upstream repo : $UPSTREAM_REPO"
 echo "Sync targets  : $SYNC_DIRS"
 
 load_override_patterns "$OVERRIDES_FILE"
@@ -179,10 +209,23 @@ echo "Protected overrides: ${#OVERRIDE_PATTERNS[@]} pattern(s)"
 ###############################################################################
 # 2. Fetch latest release from GitHub (unauthenticated)
 ###############################################################################
-RELEASE_JSON=$(curl -sf "https://api.github.com/repos/${UPSTREAM_REPO}/releases/latest") || {
-  echo "ERROR: Could not fetch latest release from ${UPSTREAM_REPO}."
+# Use -L so curl follows GitHub's 301 redirects when an upstream repo is
+# renamed (e.g. agile-flow -> gembaflow during the rebrand rollout). Without
+# -L, curl returns empty on a redirect and the next JSON parse fails silently.
+RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${UPSTREAM_REPO}/releases/latest" 2>/dev/null || true)
+
+# If the primary returned 404 (or curl produced no output), retry against the
+# fallback repo. This only fires when the primary truly doesn't exist; a 200
+# response keeps behavior byte-for-byte identical to today.
+if [ -z "$RELEASE_JSON" ] && [ -n "${FALLBACK_REPO:-}" ] && [ "$FALLBACK_REPO" != "$UPSTREAM_REPO" ]; then
+  echo "INFO: ${UPSTREAM_REPO} not reachable; retrying against fallback ${FALLBACK_REPO}." >&2
+  RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases/latest" 2>/dev/null || true)
+fi
+
+if [ -z "$RELEASE_JSON" ]; then
+  echo "ERROR: Could not fetch latest release from ${UPSTREAM_REPO} (or fallback ${FALLBACK_REPO})."
   exit 1
-}
+fi
 
 LATEST_VERSION=$(echo "$RELEASE_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'].lstrip('v'))")
 RELEASE_URL=$(echo "$RELEASE_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['html_url'])")

--- a/scripts/template-sync.test.sh
+++ b/scripts/template-sync.test.sh
@@ -221,6 +221,166 @@ else
 fi
 popd >/dev/null
 
+###############################################################################
+# Scenario 3: configurable upstream + redirect-safe curl + 404 fallback (#331)
+###############################################################################
+# These scenarios exit early (before the tarball download) so they only need
+# to verify which curl URL was hit for the /releases/latest call. We stub
+# curl to record the URL and return a no-op JSON, and stub gh to satisfy the
+# auth precondition.
+
+UPSTREAM_DIR="$WORK_DIR/upstream-scenarios"
+mkdir -p "$UPSTREAM_DIR/scripts/lib"
+cp scripts/template-sync.sh "$UPSTREAM_DIR/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$UPSTREAM_DIR/scripts/lib/overrides.sh"
+chmod +x "$UPSTREAM_DIR/scripts/template-sync.sh"
+
+mkdir -p "$WORK_DIR/upstream-bin"
+# Curl stub: log each releases/latest URL probed and respond per the test's
+# scripted policy (env-driven). For tarball downloads, behave as a no-op.
+cat > "$WORK_DIR/upstream-bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+url=""
+for arg in "$@"; do
+  case "$arg" in
+    https://*|http://*) url="$arg" ;;
+  esac
+done
+if [[ "$url" == *"/releases/latest"* ]]; then
+  echo "$url" >> "$TEST_CURL_LOG"
+  # Policy: if TEST_PRIMARY_REPO matches the URL, return 200 JSON; if
+  # TEST_FALLBACK_REPO matches and primary was tried, return 200 JSON; else 404.
+  if [[ -n "${TEST_404_REPOS:-}" ]] && [[ ",$TEST_404_REPOS," == *",$url,"* ]]; then
+    exit 22  # curl's -f exit code for HTTP >= 400
+  fi
+  printf '{"tag_name":"v9.9.9","html_url":"https://example.invalid/r","tarball_url":"https://example.invalid/t.tar.gz"}'
+  exit 0
+fi
+if [[ "$url" == *".tar.gz"* ]]; then
+  out=''
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then out="$2"; shift 2; continue; fi
+    shift
+  done
+  : > "$out"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$WORK_DIR/upstream-bin/curl"
+
+cat > "$WORK_DIR/upstream-bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "token" ]]; then echo "fake-token"; exit 0; fi
+exit 0
+SH
+chmod +x "$WORK_DIR/upstream-bin/gh"
+
+run_upstream_scenario() {
+  local label="$1"
+  local upstream_field="$2"
+  local expected_first_repo="$3"  # owner/repo expected on the FIRST curl
+  local fail_404_repos="$4"        # comma-joined list of full URLs to 404
+  local scenario_dir="$WORK_DIR/scen-${label}"
+  local curl_log="$WORK_DIR/curl-${label}.log"
+  : > "$curl_log"
+
+  mkdir -p "$scenario_dir/scripts/lib"
+  cp scripts/template-sync.sh "$scenario_dir/scripts/template-sync.sh"
+  cp scripts/lib/overrides.sh "$scenario_dir/scripts/lib/overrides.sh"
+  chmod +x "$scenario_dir/scripts/template-sync.sh"
+  : > "$scenario_dir/.agile-flow-overrides"
+
+  if [ -n "$upstream_field" ]; then
+    cat > "$scenario_dir/.agile-flow-version" <<JSON
+{
+  "version": "9.9.9",
+  "upstream": "$upstream_field",
+  "syncDirectories": ["./scripts"]
+}
+JSON
+  else
+    cat > "$scenario_dir/.agile-flow-version" <<'JSON'
+{
+  "version": "9.9.9",
+  "syncDirectories": ["./scripts"]
+}
+JSON
+  fi
+
+  pushd "$scenario_dir" >/dev/null
+  git init >/dev/null
+  git add .
+  git commit -m "init $label" >/dev/null
+  # Run the script; since LOCAL_VERSION already matches the mock's v9.9.9,
+  # the script exits 0 right after the version fetch — exactly what we want.
+  TEST_CURL_LOG="$curl_log" \
+    TEST_404_REPOS="$fail_404_repos" \
+    PATH="$WORK_DIR/upstream-bin:$PATH" \
+    bash scripts/template-sync.sh > "$WORK_DIR/scen-${label}.log" 2>&1 || true
+  popd >/dev/null
+
+  local first_url
+  first_url=$(head -n1 "$curl_log" || true)
+  if [[ "$first_url" == *"/repos/${expected_first_repo}/releases/latest" ]]; then
+    pass "[${label}] first curl targets ${expected_first_repo}"
+  else
+    fail "[${label}] expected first curl to target ${expected_first_repo}, got: ${first_url:-<none>}"
+  fi
+}
+
+# (a) upstream field honored when present
+run_upstream_scenario "upstream-honored" "vibeacademy/agile-flow-gcp" "vibeacademy/agile-flow-gcp" ""
+
+# (a2) upstream URL form normalized to owner/repo
+run_upstream_scenario "upstream-url-normalized" "https://github.com/vibeacademy/agile-flow-gcp" "vibeacademy/agile-flow-gcp" ""
+
+# (b) absent upstream falls back to hardcoded default
+run_upstream_scenario "upstream-absent" "" "vibeacademy/agile-flow" ""
+
+# (c) 404 from primary -> fallback URL is tried
+FAIL_URL="https://api.github.com/repos/vibeacademy/agile-flow/releases/latest"
+SCEN_DIR="$WORK_DIR/scen-fallback"
+mkdir -p "$SCEN_DIR/scripts/lib"
+cp scripts/template-sync.sh "$SCEN_DIR/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$SCEN_DIR/scripts/lib/overrides.sh"
+chmod +x "$SCEN_DIR/scripts/template-sync.sh"
+: > "$SCEN_DIR/.agile-flow-overrides"
+cat > "$SCEN_DIR/.agile-flow-version" <<'JSON'
+{
+  "version": "9.9.9",
+  "syncDirectories": ["./scripts"]
+}
+JSON
+pushd "$SCEN_DIR" >/dev/null
+git init >/dev/null
+git add .
+git commit -m "init fallback" >/dev/null
+TEST_CURL_LOG="$WORK_DIR/curl-fallback.log" \
+  TEST_404_REPOS="$FAIL_URL" \
+  PATH="$WORK_DIR/upstream-bin:$PATH" \
+  bash scripts/template-sync.sh > "$WORK_DIR/scen-fallback.log" 2>&1 || true
+popd >/dev/null
+
+URL1=$(sed -n '1p' "$WORK_DIR/curl-fallback.log" || true)
+URL2=$(sed -n '2p' "$WORK_DIR/curl-fallback.log" || true)
+if [[ "$URL1" == *"/repos/vibeacademy/agile-flow/releases/latest" ]]; then
+  pass "[fallback] primary URL tried first"
+else
+  fail "[fallback] expected primary URL first, got: ${URL1:-<none>}"
+fi
+if [[ "$URL2" == *"/repos/vibeacademy/gembaflow/releases/latest" ]]; then
+  pass "[fallback] fallback URL tried after primary 404"
+else
+  fail "[fallback] expected gembaflow fallback URL second, got: ${URL2:-<none>}"
+fi
+if grep -q "retrying against fallback vibeacademy/gembaflow" "$WORK_DIR/scen-fallback.log"; then
+  pass "[fallback] informational stderr line emitted"
+else
+  fail "[fallback] expected informational fallback log line"
+fi
+
 echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
 if [ "$TESTS_FAILED" -gt 0 ]; then
   exit 1


### PR DESCRIPTION
> **DO NOT MERGE** until ready to immediately ship a release AND coordinate Phase 1 (GitHub rename). This is a deployment-coordinated change — a release of `agile-flow` containing this fix MUST ship before the rename so active forks pick it up via `/upgrade` and remain functional after the redirect lands.

## Summary

Three coupled changes to `scripts/template-sync.sh`, all required before the agile-flow → gembaflow GitHub repo rename (Phase 1) can ship safely:

1. **Configurable upstream.** Read optional `upstream` field from `.agile-flow-version`, normalize URL form to `owner/repo`, and fall back to the hardcoded `vibeacademy/agile-flow` when absent. Lets downstream variant forks (e.g. `agile-flow-gcp`) point `/upgrade` at their own upstream without editing this script. Folds `agile-flow-gcp#204`.
2. **Redirect-safe curl.** Switch `curl -sf` → `curl -fsSL` on the `/releases/latest` call so it follows GitHub's 301 after the rename. Without `-L`, curl exits empty and the next JSON parse fails silently.
3. **404 fallback.** When the primary returns 404 (or empty), retry against a hardcoded `FALLBACK_REPO="vibeacademy/gembaflow"` and emit a single informational stderr line. A 200 from the primary keeps behavior byte-for-byte identical to today.

The hardcoded primary default stays `vibeacademy/agile-flow` — flipping the canonical name is Phase 2a (#332). `RUNTIME_PROTECTED_PATHS` protection for this script is unchanged.

## Test plan

Automated tests in `scripts/template-sync.test.sh` (existing 8 + new 6 = 14 total):

- [x] **DoD-1:** `upstream` field honored when present (`upstream-honored` scenario)
- [x] **DoD-1:** URL-form `upstream` normalized to `owner/repo` (`upstream-url-normalized` scenario)
- [x] **DoD-1:** Absent `upstream` falls back to hardcoded default (`upstream-absent` scenario)
- [x] **DoD-2:** `curl -fsSL` is used (verified by inspection; mock curl in tests accepts both flag forms)
- [x] **DoD-3:** Primary 404 → fallback `vibeacademy/gembaflow` URL tried (`fallback` scenario)
- [x] **DoD-3:** Single informational stderr line emitted on fallback use
- [x] **DoD-4:** No spurious stderr when primary returns 200 (verified by `upstream-absent` scenario producing no `INFO:` line on its stderr)
- [x] **DoD-7:** Forks without `upstream` field continue working unchanged (existing 8 tests + `upstream-absent` scenario)
- [x] **Runtime-protection:** Existing self-overwrite-protection test still passes
- [ ] **DoD-5 (manual):** Verify against a known-redirecting repo or live 301 simulation — to be confirmed during release validation
- [ ] **DoD-8 (release):** Cut a normal patch release after merge so active forks pick this up on next `/upgrade`
- [ ] **DoD-9 (follow-up, separate PR):** `agile-flow-gcp` sets `"upstream": "vibeacademy/agile-flow-gcp"` in its `.agile-flow-version` (Phase 3)

## Guardrails respected

- Hardcoded `UPSTREAM_REPO` default unchanged (`vibeacademy/agile-flow`) — only the FALLBACK is gembaflow
- No other `agile-flow` → `gembaflow` string rewrites in this PR (Phase 2a scope)
- `.agile-flow-version` dotfile name unchanged (Phase 4 scope)
- No hard dependency on `vibeacademy/gembaflow` existing — fallback only fires on 404 from primary
- `scripts/template-sync.sh` still in `RUNTIME_PROTECTED_PATHS`

Closes #331
Closes vibeacademy/agile-flow-gcp#204