### PR TITLE
refactor(rebrand): Phase 2a — rewrite URLs and agent footers to gembaflow

### DIFF
--- a/.agile-flow-meta/upstream
+++ b/.agile-flow-meta/upstream
@@ -1,1 +1,1 @@
-https://github.com/vibeacademy/agile-flow
+https://github.com/vibeacademy/gembaflow

--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -582,5 +582,5 @@ Next grooming: after current sprint completes
 
 Your goal is to ensure the team always has clear, high-value, well-defined work ready to pick up, while maintaining a healthy backlog that reflects the product vision.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/agile-product-manager.md
+++ b/.claude/agents/agile-product-manager.md
@@ -473,5 +473,5 @@ When reporting on product decisions:
 
 Your goal is to ensure the product delivers value to customers and the business. You are the guardian of product-market fit, the voice of the customer, and the steward of strategic direction. Focus on outcomes over outputs, and always tie decisions back to customer value and business impact.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -222,5 +222,5 @@ To add a new platform:
 4. Add rollback procedure to Rollback section
 5. Document required secrets in `docs/CI-CD-GUIDE.md`
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -448,5 +448,5 @@ Status: CI pending
 
 Remember: You are autonomous within the boundaries of the Ready column and trunk-based development workflow. Quality and correctness are more important than speed.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -572,5 +572,5 @@ See `docs/MEMORY-ARCHITECTURE.md` for full naming conventions.
 
 Your role is to be a guardian of quality while enabling velocity. Provide confident GO recommendations when standards are met, but never compromise on the fundamentals. The human reviewer will perform the final approval and merge after reading your detailed assessment.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -257,5 +257,5 @@ Required changes: 0
 
 You are meticulous, thorough, and relentlessly focused on quality. You balance speed with rigor, knowing when to dig deep and when to move fast. Your test plans and reports are the definitive source of truth for project quality.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -572,5 +572,5 @@ Risks: 1 (eventual consistency in refund flow)
 
 You are ready to provide expert architectural guidance on cloud patterns, distributed systems, and domain-driven design.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/commands/report-issue.md
+++ b/.claude/commands/report-issue.md
@@ -87,7 +87,7 @@ The script generates a YAML front-matter Markdown file in .agile-flow-reports/:
 ```
 ---
 agile_flow_report: true
-upstream: https://github.com/vibeacademy/agile-flow
+upstream: https://github.com/vibeacademy/gembaflow
 fork_commit: abc123def456...
 upstream_version: v2.1.0 @ def789abc012
 severity: p2
@@ -106,7 +106,7 @@ End your response with a Result Block:
 ---
 
 **Result:** Issue filed
-URL: https://github.com/vibeacademy/agile-flow/issues/42
+URL: https://github.com/vibeacademy/gembaflow/issues/42
 Severity: p2
 Component: provisioning
 Report: .agile-flow-reports/report-20260508-143022.md
@@ -119,7 +119,7 @@ Or if fallback was used:
 
 **Result:** Report saved (manual submission required)
 Report: .agile-flow-reports/report-20260508-143022.md
-Browser URL: https://github.com/vibeacademy/agile-flow/issues/new?...
+Browser URL: https://github.com/vibeacademy/gembaflow/issues/new?...
 ```
 
 Or on error:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     name: Deploy to Render
     runs-on: ubuntu-latest
-    if: github.repository != 'vibeacademy/agile-flow'
+    if: github.repository != 'vibeacademy/gembaflow'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cleanup:
     name: Cleanup Preview Resources
-    if: github.repository != 'vibeacademy/agile-flow'
+    if: github.repository != 'vibeacademy/gembaflow'
     runs-on: ubuntu-latest
     steps:
       - name: Setup Supabase CLI

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   ci:
     name: CI Checks
-    if: github.repository != 'vibeacademy/agile-flow'
+    if: github.repository != 'vibeacademy/gembaflow'
     uses: ./.github/workflows/ci.yml
 
   wait-for-supabase:
     name: Wait for Supabase Branch
-    if: github.repository != 'vibeacademy/agile-flow'
+    if: github.repository != 'vibeacademy/gembaflow'
     runs-on: ubuntu-latest
     outputs:
       branch_ready: ${{ steps.check.outputs.conclusion || 'skipped' }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- FRAMEWORK:START -->
-# Agile Flow
+# Gemba Flow
 
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-0.1.0-green.svg)](.agile-flow-version) [![Use this template](https://img.shields.io/badge/Use_this-template-2ea44f)](https://github.com/vibeacademy/agile-flow/generate)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-0.1.0-green.svg)](.agile-flow-version) [![Use this template](https://img.shields.io/badge/Use_this-template-2ea44f)](https://github.com/vibeacademy/gembaflow/generate)
 
 A Claude Code project template that bootstraps a complete agile development workflow with specialized AI agents.
 
@@ -15,7 +15,7 @@ reports or dashboards, but firsthand. The word *gemba* (現場) means "the
 actual place." You cannot improve a process you have not seen. You
 cannot catch problems from a summary.
 
-Agile Flow applies the same principle to AI-assisted development. When
+Gemba Flow applies the same principle to AI-assisted development. When
 agents write code on your behalf, you are the factory manager. If you
 are not observing the work as it actually happens, you cannot be a
 responsible supervisor — and you expose yourself to risks you cannot
@@ -38,7 +38,7 @@ human supervisors to walk the *gemba*.
 
 ## What This Is
 
-Agile Flow provides a team of AI agents that work together to manage your software project:
+Gemba Flow provides a team of AI agents that work together to manage your software project:
 
 | Agent | Role |
 |-------|------|
@@ -54,7 +54,7 @@ The agents hand off work to each other through a structured workflow, with human
 
 ### What This Does NOT Include
 
-Agile Flow is a **workflow template**, not a full application. You provide:
+Gemba Flow is a **workflow template**, not a full application. You provide:
 
 - **Your application code** — the template ships a minimal starter app; you replace it with your own
 - **Your database** — Supabase is recommended and documented, but you choose your data layer
@@ -69,7 +69,7 @@ Agile Flow is a **workflow template**, not a full application. You provide:
 
 ## How It Works: Progressive Refinement
 
-Agile Flow uses **progressive refinement** - each phase builds context that makes subsequent phases more focused and effective.
+Gemba Flow uses **progressive refinement** - each phase builds context that makes subsequent phases more focused and effective.
 
 ```
 Phase 1: Product Definition
@@ -140,7 +140,7 @@ Once bootstrap is complete, use the standard workflow:
 ```
 
 Use `/report-issue` to send structured bug reports or suggestions back to the
-upstream Agile Flow maintainers. This creates a feedback loop that helps improve
+upstream Gemba Flow maintainers. This creates a feedback loop that helps improve
 the framework for everyone. See [`.claude/commands/report-issue.md`](.claude/commands/report-issue.md) for details.
 
 ## Project Structure
@@ -196,7 +196,7 @@ You'll need:
 
 #### Authenticating with GitHub
 
-Agile Flow uses the `gh` CLI for all GitHub operations. Authenticate
+Gemba Flow uses the `gh` CLI for all GitHub operations. Authenticate
 each account (human + bot accounts) using the `gh` keyring:
 
 ```bash
@@ -381,14 +381,14 @@ This is a template project. To contribute:
 
 ## Attribution
 
-Built with [Agile Flow](https://github.com/vibeacademy/agile-flow) by
+Built with [Gemba Flow](https://github.com/vibeacademy/gembaflow) by
 [VibeAcademy](https://vibeacademy.com).
 ## License
 
 Business Source License 1.1 — see [LICENSE](LICENSE) for full terms.
 
-You may use Agile Flow for any purpose, including production use, except
-for offering a commercial product that competes with Agile Flow (a
+You may use Gemba Flow for any purpose, including production use, except
+for offering a commercial product that competes with Gemba Flow (a
 developer workflow automation framework). On 2029-03-06, this version
 converts to the Apache License 2.0.
 <!-- FRAMEWORK:END -->

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -36,4 +36,4 @@ MAJOR.MINOR.PATCH
 
 ## Current Version
 
-See the latest [GitHub Release](https://github.com/vibeacademy/agile-flow/releases) or the top entry in [CHANGELOG.md](./CHANGELOG.md).
+See the latest [GitHub Release](https://github.com/vibeacademy/gembaflow/releases) or the top entry in [CHANGELOG.md](./CHANGELOG.md).

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Agile Flow Bootstrap Wizard
+# Gemba Flow Bootstrap Wizard
 # Guides users through progressive refinement of project context
 
 set -e
@@ -24,7 +24,7 @@ STATUS_FILE=".claude/.bootstrap-status"
 print_header() {
     echo ""
     echo -e "${CYAN}╔════════════════════════════════════════════════════════════╗${NC}"
-    echo -e "${CYAN}║${NC}              ${BLUE}Agile Flow Bootstrap Wizard${NC}                   ${CYAN}║${NC}"
+    echo -e "${CYAN}║${NC}              ${BLUE}Gemba Flow Bootstrap Wizard${NC}                   ${CYAN}║${NC}"
     echo -e "${CYAN}╚════════════════════════════════════════════════════════════╝${NC}"
     echo ""
 }
@@ -176,7 +176,7 @@ persist_env_var() {
     else
         {
             echo ""
-            echo "# Added by Agile Flow bootstrap"
+            echo "# Added by Gemba Flow bootstrap"
             echo "export ${var_name}=\"${var_value}\""
         } >> "$profile"
         print_info "Added ${var_name} to ${profile}"
@@ -190,7 +190,7 @@ phase0_environment() {
     print_phase "0" "Environment Setup"
 
     echo ""
-    echo "This phase ensures your local environment has everything Agile Flow"
+    echo "This phase ensures your local environment has everything Gemba Flow"
     echo "needs before we start defining your product. It covers:"
     echo "  - Required CLI tools (gh, claude)"
     echo "  - GitHub account authentication (human + bot accounts)"
@@ -239,7 +239,7 @@ phase0_environment() {
     else
         print_error "Claude Code CLI is not installed."
         echo ""
-        echo "  Claude Code is the AI coding agent that powers Agile Flow."
+        echo "  Claude Code is the AI coding agent that powers Gemba Flow."
         echo ""
         echo "  Install it with:"
         echo "    npm install -g @anthropic-ai/claude-code"
@@ -287,7 +287,7 @@ phase0_environment() {
     # -----------------------------------------------------------------------
     print_step 4 $total_steps "Authenticate worker bot account"
 
-    echo "  Agile Flow uses a separate GitHub bot account for automated work"
+    echo "  Gemba Flow uses a separate GitHub bot account for automated work"
     echo "  (creating branches, opening PRs, pushing code). This keeps the"
     echo "  human commit history clean and makes bot actions easy to audit."
     echo ""
@@ -503,7 +503,7 @@ phase0_environment() {
     # -----------------------------------------------------------------------
     print_step 8 $total_steps "Set up pre-push git hook"
 
-    echo "  Agile Flow ships a pre-push hook in scripts/hooks/ that enforces"
+    echo "  Gemba Flow ships a pre-push hook in scripts/hooks/ that enforces"
     echo "  agent policies before code reaches the remote. We point git at"
     echo "  that directory so the hook runs automatically."
     echo ""
@@ -632,7 +632,7 @@ phase0_environment() {
         if [ -f ".claude/settings.template.json" ]; then
             print_warning ".mcp.json not found or being reset."
             echo ""
-            echo "  Agile Flow uses MCP (Model Context Protocol) servers to give"
+            echo "  Gemba Flow uses MCP (Model Context Protocol) servers to give"
             echo "  Claude Code access to GitHub, memory, and other integrations."
             echo ""
             print_info "Creating .mcp.json with default MCP servers..."
@@ -930,7 +930,7 @@ show_completion() {
     echo -e "${GREEN}║${NC}            ${GREEN}Bootstrap Complete!${NC}                              ${GREEN}║${NC}"
     echo -e "${GREEN}╚════════════════════════════════════════════════════════════╝${NC}"
     echo ""
-    echo "Your Agile Flow project is ready for development!"
+    echo "Your Gemba Flow project is ready for development!"
     echo ""
     echo -e "${CYAN}Next steps:${NC}"
     echo "  1. Start Claude Code: ${GREEN}claude${NC}"
@@ -955,7 +955,7 @@ show_completion() {
     if [ -f ".agile-flow-version" ]; then
         af_version=$(jq -r '.version // "unknown"' .agile-flow-version 2>/dev/null)
     fi
-    echo -e "Powered by ${CYAN}Agile Flow${NC} v${af_version} — https://github.com/vibeacademy/agile-flow"
+    echo -e "Powered by ${CYAN}Gemba Flow${NC} v${af_version} — https://github.com/vibeacademy/gembaflow"
     echo ""
 }
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -35,7 +35,7 @@ talk to GitHub on your behalf. To create one:
 
 ## Step 1: Create Your Project from the Template
 
-Go to the [Agile Flow template](https://github.com/vibeacademy/agile-flow)
+Go to the [Gemba Flow template](https://github.com/vibeacademy/gembaflow)
 on GitHub and click **"Use this template" > "Create a new repository"**.
 
 - **Owner**: Choose your GitHub account or organization.
@@ -363,7 +363,7 @@ jq .version .agile-flow-version
 ```
 
 To see if a newer version is available, visit the
-[Agile Flow releases page](https://github.com/vibeacademy/agile-flow/releases).
+[Gemba Flow releases page](https://github.com/vibeacademy/gembaflow/releases).
 
 The `/doctor` command also checks for updates automatically and will warn
 you if a newer version is available.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -20,7 +20,7 @@ The `/doctor` command also checks for updates automatically and warns you if
 a newer version is available.
 
 To see all available releases, visit the
-[Agile Flow releases page](https://github.com/vibeacademy/agile-flow/releases).
+[Gemba Flow releases page](https://github.com/vibeacademy/gembaflow/releases).
 
 ---
 
@@ -51,7 +51,7 @@ The workflow runs the same sync script and opens a pull request.
 
 ## What Happens During an Upgrade
 
-1. The sync script fetches the latest release from `vibeacademy/agile-flow`.
+1. The sync script fetches the latest release from `vibeacademy/gembaflow`.
 2. It compares your local version (from `.agile-flow-version`) to the latest.
 3. If an update is available, it downloads the release and copies only the
    directories listed in `syncDirectories` (inside `.agile-flow-version`):
@@ -157,7 +157,7 @@ edited locally. To resolve:
 If the automated sync does not work for your setup, you can upgrade manually:
 
 1. Download the latest release from the
-   [releases page](https://github.com/vibeacademy/agile-flow/releases).
+   [releases page](https://github.com/vibeacademy/gembaflow/releases).
 2. Extract the archive.
 3. Copy the framework directories (`.claude/agents`, `.claude/commands`,
    `.claude/hooks`, `.claude/skills`, `scripts`, `starters`) into your

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Agile Flow Doctor — Local Diagnostic Script
+# Gemba Flow Doctor — Local Diagnostic Script
 #
 # Validates the full configuration needed for the workshop:
 #   CLI tools, git config, GitHub auth, MCP config, Claude settings,
@@ -114,7 +114,7 @@ resolve_cmd() {
 # ───────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${CYAN}╔════════════════════════════════════════════════════════════╗${NC}"
-echo -e "${CYAN}║${NC}              ${BLUE}Agile Flow Doctor${NC}                              ${CYAN}║${NC}"
+echo -e "${CYAN}║${NC}              ${BLUE}Gemba Flow Doctor${NC}                              ${CYAN}║${NC}"
 echo -e "${CYAN}╚════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
@@ -136,21 +136,21 @@ if [ -f ".agile-flow-version" ]; then
         local_version=$("$JQ_CMD" -r '.version' .agile-flow-version 2>/dev/null || echo "")
         if [ -n "$local_version" ]; then
             # Fetch latest release from GitHub
-            latest_json=$(curl -s --max-time 5 https://api.github.com/repos/vibeacademy/agile-flow/releases/latest 2>/dev/null || echo "")
+            latest_json=$(curl -s --max-time 5 https://api.github.com/repos/vibeacademy/gembaflow/releases/latest 2>/dev/null || echo "")
             if [ -n "$latest_json" ]; then
                 latest_version=$(echo "$latest_json" | "$JQ_CMD" -r '.tag_name // empty' 2>/dev/null | sed 's/^v//')
                 release_url=$(echo "$latest_json" | "$JQ_CMD" -r '.html_url // empty' 2>/dev/null)
                 if [ -n "$latest_version" ]; then
                     if [ "$local_version" = "$latest_version" ]; then
-                        pass "Framework Version" "Agile Flow v${local_version} (up to date)"
+                        pass "Framework Version" "Gemba Flow v${local_version} (up to date)"
                     else
-                        warn "Framework Version" "Agile Flow v${local_version} (update available: v${latest_version})" "${release_url}"
+                        warn "Framework Version" "Gemba Flow v${local_version} (update available: v${latest_version})" "${release_url}"
                     fi
                 else
-                    warn "Framework Version" "Agile Flow v${local_version} (could not check for updates)" "GitHub API returned unexpected response"
+                    warn "Framework Version" "Gemba Flow v${local_version} (could not check for updates)" "GitHub API returned unexpected response"
                 fi
             else
-                warn "Framework Version" "Agile Flow v${local_version} (could not check for updates)" "GitHub API unreachable"
+                warn "Framework Version" "Gemba Flow v${local_version} (could not check for updates)" "GitHub API unreachable"
             fi
         else
             warn "Framework Version" "Version manifest unreadable" "Check .agile-flow-version format"

--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# report-issue.sh — Report a downstream issue to the upstream Agile Flow repo.
+# report-issue.sh — Report a downstream issue to the upstream Gemba Flow repo.
 #
 # Usage:
 #   bash scripts/report-issue.sh
@@ -31,7 +31,7 @@ DRY_RUN=false
 
 show_help() {
   cat <<'HELP'
-report-issue.sh — Report a downstream issue to the upstream Agile Flow repo.
+report-issue.sh — Report a downstream issue to the upstream Gemba Flow repo.
 
 Usage:
   bash scripts/report-issue.sh [FLAGS]

--- a/scripts/setup-accounts.sh
+++ b/scripts/setup-accounts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Agile Flow Account Setup
+# Gemba Flow Account Setup
 #
 # Streamlined setup for the three-account GitHub configuration.
 # Paste your PATs → done. No interactive gh prompts.
@@ -99,7 +99,7 @@ persist_env_var() {
     else
         {
             echo ""
-            echo "# Added by Agile Flow setup-accounts"
+            echo "# Added by Gemba Flow setup-accounts"
             echo "export ${var_name}=\"${var_value}\""
         } >> "$profile"
         print_info "Added ${var_name} to ${profile}"
@@ -124,7 +124,7 @@ trap restore_personal EXIT
 # ═══════════════════════════════════════════════════════════════════
 
 echo ""
-echo -e "${CYAN}━━━ Agile Flow Account Setup ━━━${NC}"
+echo -e "${CYAN}━━━ Gemba Flow Account Setup ━━━${NC}"
 echo ""
 
 # ───────────────────────────────────────────────────────────────────

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# template-sync.sh -- Sync framework files from vibeacademy/agile-flow releases.
+# template-sync.sh -- Sync framework files from vibeacademy/gembaflow releases.
 # Called by .github/workflows/template-sync.yml (workflow_dispatch only).
 # Guardrails:
 #   - Only syncs directories/files listed in syncDirectories (.agile-flow-version)
@@ -31,11 +31,12 @@ if ! gh auth token >/dev/null 2>&1; then
   exit 1
 fi
 
-UPSTREAM_REPO="vibeacademy/agile-flow"
-# FALLBACK_REPO is only consulted when the primary returns 404 (e.g. during the
-# agile-flow -> gembaflow rename window). The primary default stays unchanged
-# in this PR; see #331 (Phase 0.5 of the gembaflow rebrand).
-FALLBACK_REPO="vibeacademy/gembaflow"
+UPSTREAM_REPO="vibeacademy/gembaflow"
+# FALLBACK_REPO is only consulted when the primary returns 404. Post-Phase 2a
+# (#332) the primary is now gembaflow natively; the fallback points at the
+# legacy name and would only fire via GitHub's redirect if the gembaflow name
+# is ever changed again. Belt-and-suspenders — see #331 / #332.
+FALLBACK_REPO="vibeacademy/agile-flow"
 VERSION_FILE=".agile-flow-version"
 OVERRIDES_FILE=".agile-flow-overrides"
 RUNNING_SCRIPT_REL=$(python3 -c "import os,sys; print(os.path.relpath(os.path.realpath(sys.argv[1]), os.getcwd()))" "$0")
@@ -209,9 +210,9 @@ echo "Protected overrides: ${#OVERRIDE_PATTERNS[@]} pattern(s)"
 ###############################################################################
 # 2. Fetch latest release from GitHub (unauthenticated)
 ###############################################################################
-# Use -L so curl follows GitHub's 301 redirects when an upstream repo is
-# renamed (e.g. agile-flow -> gembaflow during the rebrand rollout). Without
-# -L, curl returns empty on a redirect and the next JSON parse fails silently.
+# Use -L so curl follows GitHub's 301 redirects in case an upstream repo is
+# renamed in the future. Without -L, curl returns empty on a redirect and the
+# next JSON parse fails silently.
 RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${UPSTREAM_REPO}/releases/latest" 2>/dev/null || true)
 
 # If the primary returned 404 (or curl produced no output), retry against the
@@ -466,7 +467,7 @@ mkdir -p .agile-flow-meta
 echo "$LATEST_VERSION" > .agile-flow-meta/version
 git add .agile-flow-meta/version
 
-COMMIT_MSG="chore(sync): update Agile Flow framework to v${LATEST_VERSION}"
+COMMIT_MSG="chore(sync): update Gemba Flow framework to v${LATEST_VERSION}"
 # Scope the bot identity to this single commit using -c so running locally
 # does NOT overwrite the user's per-repo git author config.
 git -c user.name="github-actions[bot]" \
@@ -481,7 +482,7 @@ for f in "${FILES_CHANGED[@]}"; do
 "
 done
 
-PR_BODY="## Agile Flow Framework Update
+PR_BODY="## Gemba Flow Framework Update
 
 Updates framework files from \`v${LOCAL_VERSION}\` to \`v${LATEST_VERSION}\`.
 
@@ -497,7 +498,7 @@ See the full release notes: ${RELEASE_URL}
 > **Please review the changes before merging.**"
 
 gh pr create \
-  --title "chore(sync): update Agile Flow framework to v${LATEST_VERSION}" \
+  --title "chore(sync): update Gemba Flow framework to v${LATEST_VERSION}" \
   --body "$PR_BODY" \
   --base main \
   --head "$SYNC_BRANCH"

--- a/scripts/template-sync.test.sh
+++ b/scripts/template-sync.test.sh
@@ -337,10 +337,10 @@ run_upstream_scenario "upstream-honored" "vibeacademy/agile-flow-gcp" "vibeacade
 run_upstream_scenario "upstream-url-normalized" "https://github.com/vibeacademy/agile-flow-gcp" "vibeacademy/agile-flow-gcp" ""
 
 # (b) absent upstream falls back to hardcoded default
-run_upstream_scenario "upstream-absent" "" "vibeacademy/agile-flow" ""
+run_upstream_scenario "upstream-absent" "" "vibeacademy/gembaflow" ""
 
 # (c) 404 from primary -> fallback URL is tried
-FAIL_URL="https://api.github.com/repos/vibeacademy/agile-flow/releases/latest"
+FAIL_URL="https://api.github.com/repos/vibeacademy/gembaflow/releases/latest"
 SCEN_DIR="$WORK_DIR/scen-fallback"
 mkdir -p "$SCEN_DIR/scripts/lib"
 cp scripts/template-sync.sh "$SCEN_DIR/scripts/template-sync.sh"
@@ -365,17 +365,17 @@ popd >/dev/null
 
 URL1=$(sed -n '1p' "$WORK_DIR/curl-fallback.log" || true)
 URL2=$(sed -n '2p' "$WORK_DIR/curl-fallback.log" || true)
-if [[ "$URL1" == *"/repos/vibeacademy/agile-flow/releases/latest" ]]; then
+if [[ "$URL1" == *"/repos/vibeacademy/gembaflow/releases/latest" ]]; then
   pass "[fallback] primary URL tried first"
 else
   fail "[fallback] expected primary URL first, got: ${URL1:-<none>}"
 fi
-if [[ "$URL2" == *"/repos/vibeacademy/gembaflow/releases/latest" ]]; then
+if [[ "$URL2" == *"/repos/vibeacademy/agile-flow/releases/latest" ]]; then
   pass "[fallback] fallback URL tried after primary 404"
 else
-  fail "[fallback] expected gembaflow fallback URL second, got: ${URL2:-<none>}"
+  fail "[fallback] expected agile-flow fallback URL second, got: ${URL2:-<none>}"
 fi
-if grep -q "retrying against fallback vibeacademy/gembaflow" "$WORK_DIR/scen-fallback.log"; then
+if grep -q "retrying against fallback vibeacademy/agile-flow" "$WORK_DIR/scen-fallback.log"; then
   pass "[fallback] informational stderr line emitted"
 else
   fail "[fallback] expected informational fallback log line"

--- a/scripts/test-report-issue.sh
+++ b/scripts/test-report-issue.sh
@@ -136,7 +136,7 @@ echo "Test 4: Error on invalid severity value"
 
 TEST_DIR="$WORK_DIR/test4"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 git commit --allow-empty -m "init" --quiet
@@ -161,7 +161,7 @@ echo "Test 5: Error on invalid component value"
 
 TEST_DIR="$WORK_DIR/test5"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 git commit --allow-empty -m "init" --quiet
@@ -186,7 +186,7 @@ echo "Test 6: Error when title is empty"
 
 TEST_DIR="$WORK_DIR/test6"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 git commit --allow-empty -m "init" --quiet
@@ -213,7 +213,7 @@ echo "Test 7: Fallback to manual submission when gh CLI unavailable"
 
 TEST_DIR="$WORK_DIR/test7"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 echo "1.0.0" > "$TEST_DIR/.agile-flow-meta/version"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
@@ -237,7 +237,7 @@ if PATH="$WORK_DIR/nogh-bin:$PATH" bash "$REPO_ROOT/scripts/report-issue.sh" --n
     cat "$WORK_DIR/test7.log"
   fi
   
-  if grep -q "github.com/vibeacademy/agile-flow/issues/new" "$WORK_DIR/test7.log"; then
+  if grep -q "github.com/vibeacademy/gembaflow/issues/new" "$WORK_DIR/test7.log"; then
     pass "pre-filled GitHub issue URL is provided"
   else
     fail "expected pre-filled GitHub issue URL"
@@ -276,7 +276,7 @@ echo "Test 8: Happy path with successful gh issue create"
 
 TEST_DIR="$WORK_DIR/test8"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 echo "1.0.0" > "$TEST_DIR/.agile-flow-meta/version"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
@@ -288,7 +288,7 @@ cat > "$WORK_DIR/mock-gh-bin/gh" <<'SH'
 #!/usr/bin/env bash
 # Mock gh issue create
 if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
-  echo "https://github.com/vibeacademy/agile-flow/issues/999"
+  echo "https://github.com/vibeacademy/gembaflow/issues/999"
   exit 0
 fi
 exit 1
@@ -335,7 +335,7 @@ echo "Test 9: Error on unknown flag"
 
 TEST_DIR="$WORK_DIR/test9"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 
@@ -360,7 +360,7 @@ echo "Test 10: Non-interactive mode requires --severity"
 
 TEST_DIR="$WORK_DIR/test10"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 git commit --allow-empty -m "init" --quiet
@@ -385,7 +385,7 @@ echo "Test 11: Parse git@ format upstream URL"
 
 TEST_DIR="$WORK_DIR/test11"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "git@github.com:vibeacademy/agile-flow.git" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "git@github.com:vibeacademy/gembaflow.git" > "$TEST_DIR/.agile-flow-meta/upstream"
 echo "1.0.0" > "$TEST_DIR/.agile-flow-meta/version"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
@@ -393,7 +393,7 @@ git commit --allow-empty -m "init" --quiet
 
 # Use mock gh
 if PATH="$WORK_DIR/mock-gh-bin:$PATH" bash "$REPO_ROOT/scripts/report-issue.sh" --non-interactive --severity p3 --component docs --title "SSH URL test" > "$WORK_DIR/test11.log" 2>&1; then
-  if grep -q "vibeacademy/agile-flow" "$WORK_DIR/test11.log"; then
+  if grep -q "vibeacademy/gembaflow" "$WORK_DIR/test11.log"; then
     pass "git@ URL parsed to correct repo"
   else
     fail "git@ URL not parsed correctly"
@@ -413,7 +413,7 @@ echo "Test 12: Handle title with special characters"
 
 TEST_DIR="$WORK_DIR/test12"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 echo "1.0.0" > "$TEST_DIR/.agile-flow-meta/version"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet

--- a/scripts/test-upgrade-cycle.sh
+++ b/scripts/test-upgrade-cycle.sh
@@ -75,7 +75,7 @@ init_test_fork() {
   
   # Set up as downstream fork
   mkdir -p .agile-flow-meta
-  echo "vibeacademy/agile-flow" > .agile-flow-meta/upstream
+  echo "vibeacademy/gembaflow" > .agile-flow-meta/upstream
   echo "v1.0.8" > .agile-flow-meta/version  # Start one version behind
   
   git add .agile-flow-meta >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Phase 2a of the agile-flow → Gemba Flow rebrand. After Phase 1 (the GitHub repo rename) shipped and was verified via smoke tests, this PR replaces the now-stale `vibeacademy/agile-flow` references in the template itself with native `vibeacademy/gembaflow` references. The system already functioned via GitHub's 301 redirect; this just removes the redirect cue so forks running `/upgrade` after the next release land on native URLs throughout.

**24 files changed** across four categories:

- **Functional code (8):** `scripts/template-sync.sh` (UPSTREAM_REPO + FALLBACK_REPO + header + display strings), `scripts/template-sync.test.sh` (fallback test fixtures inverted to match new ordering), `scripts/doctor.sh` (GitHub API URL + framework version banner), `scripts/report-issue.sh`, `scripts/setup-accounts.sh`, `scripts/test-report-issue.sh`, `scripts/test-upgrade-cycle.sh`, `.agile-flow-meta/upstream` (template seed file).
- **Agent source footers (7):** all of `.claude/agents/*.md` updated to `<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->`.
- **Display strings (1):** `bootstrap.sh` banner, narrative lines, "Powered by" footer URL.
- **Docs (5) + workflow repo guards (3):** `README.md` (H1, badges, narrative, attribution), `VERSIONING.md`, `docs/GETTING-STARTED.md`, `docs/UPGRADING.md`, `.claude/commands/report-issue.md`, and `.github/workflows/{deploy,preview-deploy,preview-cleanup}.yml` (the `if: github.repository != 'vibeacademy/gembaflow'` guards).

**FALLBACK_REPO decision:** flipped from `vibeacademy/gembaflow` (which would have been tautological with the new primary) to `vibeacademy/agile-flow`. The fallback now points at the legacy name and would only fire via GitHub's 301 redirect if `gembaflow` is ever renamed again — preserves belt-and-suspenders semantics meaningfully rather than as a no-op.

**Guardrails honored:** dotfile names unchanged, sync branch prefix `agile-flow-sync/v…` unchanged, env vars `AGILE_FLOW_*` unchanged, `package.json`/`pyproject.toml` name fields unchanged, historical references in CHANGELOG/session journals/branch-protection snapshots/research docs left intact.

## Test plan

- [ ] `grep -rn "vibeacademy/agile-flow" .` returns only historical entries (CHANGELOG, release notes, session journals, branch-protection snapshots, pattern library, research docs) plus the one intentional `FALLBACK_REPO` line and test-fixture references to `vibeacademy/agile-flow-gcp` (a different repo).
- [ ] `UPSTREAM_REPO` in `scripts/template-sync.sh` reads `vibeacademy/gembaflow`.
- [ ] Agent source footers updated across all seven `.claude/agents/*.md`.
- [ ] `.agile-flow-meta/upstream` template points at `https://github.com/vibeacademy/gembaflow`.
- [ ] `template-sync.test.sh` passes (verified: 14/14 passed locally).
- [ ] Dotfile names unchanged (`.agile-flow-version`, `.agile-flow-meta/`, `.agile-flow-overrides`); env vars unchanged (`AGILE_FLOW_*`); branch prefix unchanged (`agile-flow-sync/v…`); package metadata unchanged.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)