### PR TITLE
refactor(env): Phase 2b — dual-read env var shim

### DIFF
--- a/.claude/hooks/ensure-github-account.sh
+++ b/.claude/hooks/ensure-github-account.sh
@@ -15,8 +15,16 @@
 
 set -euo pipefail
 
-WORKER_ACCOUNT="${AGILE_FLOW_WORKER_ACCOUNT:-va-worker}"
-REVIEWER_ACCOUNT="${AGILE_FLOW_REVIEWER_ACCOUNT:-va-reviewer}"
+# Dual-read shim for the agile-flow → Gemba Flow env-var rebrand.
+# Prefers GEMBAFLOW_*, falls back to the deprecated AGILE_FLOW_*.
+# See scripts/lib/env-compat.sh for the migration policy.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HOOK_DIR}/../.." && pwd)"
+# shellcheck source=../../scripts/lib/env-compat.sh
+source "${REPO_ROOT}/scripts/lib/env-compat.sh"
+
+WORKER_ACCOUNT="$(gf_worker_account)"
+REVIEWER_ACCOUNT="$(gf_reviewer_account)"
 
 # Read JSON input from stdin
 input=$(cat)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
   // Solo mode is the default for Codespaces — no bot accounts, single
   // personal account plays all roles.
   "containerEnv": {
-    "AGILE_FLOW_SOLO_MODE": "true"
+    "GEMBAFLOW_SOLO_MODE": "true"
   },
 
   // Preinstall Claude Code extension — provides `claude` CLI and sidebar UI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,12 @@ errors, typos): skip ticket ceremony but still use branch + PR.
 
 The `.claude/hooks/ensure-github-account.sh` hook auto-switches accounts:
 
-- **Worker** (`AGILE_FLOW_WORKER_ACCOUNT`, default: `va-worker`) — PR creation
-- **Reviewer** (`AGILE_FLOW_REVIEWER_ACCOUNT`, default: `va-reviewer`) — PR reviews
+- **Worker** (`GEMBAFLOW_WORKER_ACCOUNT`, default: `va-worker`) — PR creation
+- **Reviewer** (`GEMBAFLOW_REVIEWER_ACCOUNT`, default: `va-reviewer`) — PR reviews
+
+> The deprecated `AGILE_FLOW_WORKER_ACCOUNT` / `AGILE_FLOW_REVIEWER_ACCOUNT`
+> names still work via a dual-read shim (see `scripts/lib/env-compat.sh`)
+> and will be removed in a future release.
 
 ### GitHub CLI (`gh`)
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,19 @@ NC='\033[0m' # No Color
 # Status file to track progress
 STATUS_FILE=".claude/.bootstrap-status"
 
+# Dual-read shim for the agile-flow → Gemba Flow env-var rebrand.
+# Prefers GEMBAFLOW_*, falls back to the deprecated AGILE_FLOW_*.
+# See scripts/lib/env-compat.sh for the migration policy.
+BOOTSTRAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/env-compat.sh
+source "${BOOTSTRAP_DIR}/scripts/lib/env-compat.sh"
+
+# Resolved values from the dual-read shim (prefer GEMBAFLOW_*, fall back
+# to deprecated AGILE_FLOW_*). Stored in plain bash vars so the rest of
+# this script (and code paths that reassign via `unset`) stays readable.
+BOOTSTRAP_WORKER_ACCOUNT="$(gf_env GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT)"
+BOOTSTRAP_REVIEWER_ACCOUNT="$(gf_env GEMBAFLOW_REVIEWER_ACCOUNT AGILE_FLOW_REVIEWER_ACCOUNT)"
+
 print_header() {
     echo ""
     echo -e "${CYAN}╔════════════════════════════════════════════════════════════╗${NC}"
@@ -292,16 +305,17 @@ phase0_environment() {
     echo "  human commit history clean and makes bot actions easy to audit."
     echo ""
 
-    if [ -n "$AGILE_FLOW_WORKER_ACCOUNT" ]; then
-        print_success "Worker account already configured: ${AGILE_FLOW_WORKER_ACCOUNT}"
+    if [ -n "$BOOTSTRAP_WORKER_ACCOUNT" ]; then
+        print_success "Worker account already configured: ${BOOTSTRAP_WORKER_ACCOUNT}"
         echo ""
         read -p "  Keep this account? (Y/n): " keep_worker
         if [[ "$keep_worker" =~ ^[Nn]$ ]]; then
-            unset AGILE_FLOW_WORKER_ACCOUNT
+            BOOTSTRAP_WORKER_ACCOUNT=""
+            unset GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT
         fi
     fi
 
-    if [ -z "$AGILE_FLOW_WORKER_ACCOUNT" ]; then
+    if [ -z "$BOOTSTRAP_WORKER_ACCOUNT" ]; then
         echo "  The worker bot account should follow the naming convention:"
         echo "    {org}-worker   (e.g. acme-worker)"
         echo ""
@@ -322,7 +336,7 @@ phase0_environment() {
         read -p "  Press Enter to authenticate ${worker_account} (or 's' to skip): " worker_login
         if [[ "$worker_login" =~ ^[Ss]$ ]]; then
             print_warning "Skipped worker account login."
-            print_info "Set it manually later: export AGILE_FLOW_WORKER_ACCOUNT=${worker_account}"
+            print_info "Set it manually later: export GEMBAFLOW_WORKER_ACCOUNT=${worker_account}"
         else
             echo ""
             print_info "Logging in as ${worker_account}..."
@@ -334,7 +348,8 @@ phase0_environment() {
                 echo "  You can retry later with: gh auth login"
                 return 1
             }
-            persist_env_var "AGILE_FLOW_WORKER_ACCOUNT" "$worker_account"
+            persist_env_var "GEMBAFLOW_WORKER_ACCOUNT" "$worker_account"
+            BOOTSTRAP_WORKER_ACCOUNT="$worker_account"
             print_success "Worker account set: ${worker_account}"
 
             # Verify project scope on worker account
@@ -362,20 +377,21 @@ phase0_environment() {
     echo "  approving its own pull requests."
     echo ""
 
-    if [ -n "$AGILE_FLOW_REVIEWER_ACCOUNT" ]; then
-        print_success "Reviewer account already configured: ${AGILE_FLOW_REVIEWER_ACCOUNT}"
+    if [ -n "$BOOTSTRAP_REVIEWER_ACCOUNT" ]; then
+        print_success "Reviewer account already configured: ${BOOTSTRAP_REVIEWER_ACCOUNT}"
         echo ""
         read -p "  Keep this account? (Y/n): " keep_reviewer
         if [[ "$keep_reviewer" =~ ^[Nn]$ ]]; then
-            unset AGILE_FLOW_REVIEWER_ACCOUNT
+            BOOTSTRAP_REVIEWER_ACCOUNT=""
+            unset GEMBAFLOW_REVIEWER_ACCOUNT AGILE_FLOW_REVIEWER_ACCOUNT
         fi
     fi
 
-    if [ -z "$AGILE_FLOW_REVIEWER_ACCOUNT" ]; then
+    if [ -z "$BOOTSTRAP_REVIEWER_ACCOUNT" ]; then
         # Derive from worker account if available
         local reviewer_account=""
-        if [ -n "$AGILE_FLOW_WORKER_ACCOUNT" ]; then
-            local org_from_worker="${AGILE_FLOW_WORKER_ACCOUNT%-worker}"
+        if [ -n "$BOOTSTRAP_WORKER_ACCOUNT" ]; then
+            local org_from_worker="${BOOTSTRAP_WORKER_ACCOUNT%-worker}"
             reviewer_account="${org_from_worker}-reviewer"
             echo "  Based on your worker account, the reviewer account would be:"
             echo "    ${reviewer_account}"
@@ -403,7 +419,7 @@ phase0_environment() {
         read -p "  Press Enter to authenticate ${reviewer_account} (or 's' to skip): " reviewer_login
         if [[ "$reviewer_login" =~ ^[Ss]$ ]]; then
             print_warning "Skipped reviewer account login."
-            print_info "Set it manually later: export AGILE_FLOW_REVIEWER_ACCOUNT=${reviewer_account}"
+            print_info "Set it manually later: export GEMBAFLOW_REVIEWER_ACCOUNT=${reviewer_account}"
         else
             echo ""
             print_info "Logging in as ${reviewer_account}..."
@@ -415,7 +431,8 @@ phase0_environment() {
                 echo "  You can retry later with: gh auth login"
                 return 1
             }
-            persist_env_var "AGILE_FLOW_REVIEWER_ACCOUNT" "$reviewer_account"
+            persist_env_var "GEMBAFLOW_REVIEWER_ACCOUNT" "$reviewer_account"
+            BOOTSTRAP_REVIEWER_ACCOUNT="$reviewer_account"
             print_success "Reviewer account set: ${reviewer_account}"
 
             # Verify project scope on reviewer account
@@ -448,16 +465,26 @@ phase0_environment() {
         print_warning "skipped some account logins above — you can fix it later."
     fi
 
-    if [ -n "$AGILE_FLOW_WORKER_ACCOUNT" ]; then
-        print_success "AGILE_FLOW_WORKER_ACCOUNT = ${AGILE_FLOW_WORKER_ACCOUNT}"
+    # Re-read after persist_env_var (which exports in the current shell)
+    # so the summary reflects what was just configured. Use the shim
+    # so an existing AGILE_FLOW_* still surfaces (with the deprecation
+    # warning already printed at script start).
+    local worker_now reviewer_now worker_src reviewer_src
+    worker_now="$(gf_env GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT)"
+    reviewer_now="$(gf_env GEMBAFLOW_REVIEWER_ACCOUNT AGILE_FLOW_REVIEWER_ACCOUNT)"
+    worker_src="$(gf_env_source_label GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT)"
+    reviewer_src="$(gf_env_source_label GEMBAFLOW_REVIEWER_ACCOUNT AGILE_FLOW_REVIEWER_ACCOUNT)"
+
+    if [ -n "$worker_now" ]; then
+        print_success "Worker account = ${worker_now} (from ${worker_src})"
     else
-        print_warning "AGILE_FLOW_WORKER_ACCOUNT is not set."
+        print_warning "GEMBAFLOW_WORKER_ACCOUNT is not set."
     fi
 
-    if [ -n "$AGILE_FLOW_REVIEWER_ACCOUNT" ]; then
-        print_success "AGILE_FLOW_REVIEWER_ACCOUNT = ${AGILE_FLOW_REVIEWER_ACCOUNT}"
+    if [ -n "$reviewer_now" ]; then
+        print_success "Reviewer account = ${reviewer_now} (from ${reviewer_src})"
     else
-        print_warning "AGILE_FLOW_REVIEWER_ACCOUNT is not set."
+        print_warning "GEMBAFLOW_REVIEWER_ACCOUNT is not set."
     fi
 
     # -----------------------------------------------------------------------

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -25,6 +25,13 @@ if [ -z "$BASH_VERSION" ]; then
     exec bash "$0" "$@"
 fi
 
+# Dual-read shim for the agile-flow → Gemba Flow env-var rebrand.
+# Prefers GEMBAFLOW_*, falls back to the deprecated AGILE_FLOW_*.
+# See scripts/lib/env-compat.sh for the migration policy.
+DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/env-compat.sh
+source "${DOCTOR_DIR}/lib/env-compat.sh"
+
 # ───────────────────────────────────────────────────────────────────
 #  Colors
 # ───────────────────────────────────────────────────────────────────
@@ -292,40 +299,54 @@ else
     fail "GitHub Auth" "Not authenticated with gh" "Run: gh auth login"
 fi
 
-# AGILE_FLOW_WORKER_ACCOUNT (WARN)
-if [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ]; then
-    pass "GitHub Auth" "AGILE_FLOW_WORKER_ACCOUNT set: $AGILE_FLOW_WORKER_ACCOUNT"
+# Worker account env var (WARN) — dual-read GEMBAFLOW_* / AGILE_FLOW_*
+DOCTOR_WORKER_ACCOUNT="$(gf_env GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT)"
+DOCTOR_WORKER_SRC="$(gf_env_source_label GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT)"
+if [ -n "$DOCTOR_WORKER_ACCOUNT" ]; then
+    pass "GitHub Auth" "Worker account env set (${DOCTOR_WORKER_SRC}): $DOCTOR_WORKER_ACCOUNT"
 
     # Test worker account is in keyring
-    if "$GH_CMD" auth switch --user "$AGILE_FLOW_WORKER_ACCOUNT" &>/dev/null 2>&1; then
-        pass "GitHub Auth" "Worker account ($AGILE_FLOW_WORKER_ACCOUNT) in gh keyring"
+    if "$GH_CMD" auth switch --user "$DOCTOR_WORKER_ACCOUNT" &>/dev/null 2>&1; then
+        pass "GitHub Auth" "Worker account ($DOCTOR_WORKER_ACCOUNT) in gh keyring"
         # Restore original user
         if [ -n "$ORIGINAL_GH_USER" ]; then
             "$GH_CMD" auth switch --user "$ORIGINAL_GH_USER" &>/dev/null 2>&1 || true
         fi
     else
-        warn "GitHub Auth" "Worker account ($AGILE_FLOW_WORKER_ACCOUNT) not in gh keyring" "Run: gh auth login for this account"
+        warn "GitHub Auth" "Worker account ($DOCTOR_WORKER_ACCOUNT) not in gh keyring" "Run: gh auth login for this account"
+    fi
+
+    # Nudge users still on the deprecated name to migrate.
+    if [ -z "${GEMBAFLOW_WORKER_ACCOUNT:-}" ] && [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ]; then
+        warn "GitHub Auth" "AGILE_FLOW_WORKER_ACCOUNT is deprecated" "Rename to GEMBAFLOW_WORKER_ACCOUNT in your shell rc"
     fi
 else
-    warn "GitHub Auth" "AGILE_FLOW_WORKER_ACCOUNT not set" "export AGILE_FLOW_WORKER_ACCOUNT=\"{org}-worker\""
+    warn "GitHub Auth" "GEMBAFLOW_WORKER_ACCOUNT not set" "export GEMBAFLOW_WORKER_ACCOUNT=\"{org}-worker\""
 fi
 
-# AGILE_FLOW_REVIEWER_ACCOUNT (WARN)
-if [ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ]; then
-    pass "GitHub Auth" "AGILE_FLOW_REVIEWER_ACCOUNT set: $AGILE_FLOW_REVIEWER_ACCOUNT"
+# Reviewer account env var (WARN) — dual-read GEMBAFLOW_* / AGILE_FLOW_*
+DOCTOR_REVIEWER_ACCOUNT="$(gf_env GEMBAFLOW_REVIEWER_ACCOUNT AGILE_FLOW_REVIEWER_ACCOUNT)"
+DOCTOR_REVIEWER_SRC="$(gf_env_source_label GEMBAFLOW_REVIEWER_ACCOUNT AGILE_FLOW_REVIEWER_ACCOUNT)"
+if [ -n "$DOCTOR_REVIEWER_ACCOUNT" ]; then
+    pass "GitHub Auth" "Reviewer account env set (${DOCTOR_REVIEWER_SRC}): $DOCTOR_REVIEWER_ACCOUNT"
 
     # Test reviewer account is in keyring
-    if "$GH_CMD" auth switch --user "$AGILE_FLOW_REVIEWER_ACCOUNT" &>/dev/null 2>&1; then
-        pass "GitHub Auth" "Reviewer account ($AGILE_FLOW_REVIEWER_ACCOUNT) in gh keyring"
+    if "$GH_CMD" auth switch --user "$DOCTOR_REVIEWER_ACCOUNT" &>/dev/null 2>&1; then
+        pass "GitHub Auth" "Reviewer account ($DOCTOR_REVIEWER_ACCOUNT) in gh keyring"
         # Restore original user
         if [ -n "$ORIGINAL_GH_USER" ]; then
             "$GH_CMD" auth switch --user "$ORIGINAL_GH_USER" &>/dev/null 2>&1 || true
         fi
     else
-        warn "GitHub Auth" "Reviewer account ($AGILE_FLOW_REVIEWER_ACCOUNT) not in gh keyring" "Run: gh auth login for this account"
+        warn "GitHub Auth" "Reviewer account ($DOCTOR_REVIEWER_ACCOUNT) not in gh keyring" "Run: gh auth login for this account"
+    fi
+
+    # Nudge users still on the deprecated name to migrate.
+    if [ -z "${GEMBAFLOW_REVIEWER_ACCOUNT:-}" ] && [ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ]; then
+        warn "GitHub Auth" "AGILE_FLOW_REVIEWER_ACCOUNT is deprecated" "Rename to GEMBAFLOW_REVIEWER_ACCOUNT in your shell rc"
     fi
 else
-    warn "GitHub Auth" "AGILE_FLOW_REVIEWER_ACCOUNT not set" "export AGILE_FLOW_REVIEWER_ACCOUNT=\"{org}-reviewer\""
+    warn "GitHub Auth" "GEMBAFLOW_REVIEWER_ACCOUNT not set" "export GEMBAFLOW_REVIEWER_ACCOUNT=\"{org}-reviewer\""
 fi
 
 # Final restore — ensure we always end on the original user

--- a/scripts/lib/env-compat.sh
+++ b/scripts/lib/env-compat.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# env-compat.sh — Dual-read shim for the agile-flow → Gemba Flow env-var rebrand.
+#
+# Reads the new GEMBAFLOW_* variable first, falls back to the deprecated
+# AGILE_FLOW_* variable, and prints a one-line deprecation warning (once
+# per shell session per variable) when the old name is the only one set.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/env-compat.sh"
+#
+#   # Read a variable with a default
+#   account=$(gf_env GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT va-worker)
+#
+#   # Read without a default (returns empty if neither set)
+#   account=$(gf_env GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT)
+#
+#   # Convenience wrappers for the three vars covered by Phase 2b
+#   account=$(gf_worker_account)     # defaults to va-worker
+#   account=$(gf_reviewer_account)   # defaults to va-reviewer
+#   solo=$(gf_solo_mode)             # defaults to (empty)
+#
+# Deprecation policy: AGILE_FLOW_* will be removed in a future release.
+# Migration: rename the variable in your shell rc / Codespaces secrets /
+# devcontainer env from AGILE_FLOW_<NAME> to GEMBAFLOW_<NAME>.
+
+# Track which old vars we have already warned about in this shell session
+# so we do not spam the user with the same deprecation line repeatedly.
+# Exported so subshells inherit the dedupe state.
+export _GF_ENV_COMPAT_WARNED="${_GF_ENV_COMPAT_WARNED:-}"
+
+# _gf_env_warn_once <old_var_name>
+#
+# Print the deprecation warning to stderr the first time we see <old_var_name>
+# in this shell session. Subsequent calls for the same name are silent.
+_gf_env_warn_once() {
+    local old_name="$1"
+    case ":${_GF_ENV_COMPAT_WARNED}:" in
+        *":${old_name}:"*) return 0 ;;
+    esac
+    echo "WARNING: ${old_name} is deprecated; rename to ${old_name/AGILE_FLOW_/GEMBAFLOW_} (old name will be removed in a future release)" >&2
+    export _GF_ENV_COMPAT_WARNED="${_GF_ENV_COMPAT_WARNED}:${old_name}"
+}
+
+# gf_env <new_var_name> <old_var_name> [default]
+#
+# Echo the value of <new_var_name> if set, else <old_var_name> if set
+# (with a one-time deprecation warning), else [default] if provided,
+# else empty. Always returns 0.
+gf_env() {
+    local new_name="$1"
+    local old_name="$2"
+    local default_value="${3:-}"
+
+    # Indirect expansion — works on bash 3.2+ (macOS default).
+    local new_value="${!new_name:-}"
+    local old_value="${!old_name:-}"
+
+    if [ -n "$new_value" ]; then
+        printf '%s' "$new_value"
+        return 0
+    fi
+
+    if [ -n "$old_value" ]; then
+        _gf_env_warn_once "$old_name"
+        printf '%s' "$old_value"
+        return 0
+    fi
+
+    printf '%s' "$default_value"
+    return 0
+}
+
+# Convenience wrappers for the three vars covered by Phase 2b. Keeping the
+# defaults colocated here means callers do not repeat the magic strings.
+gf_worker_account() {
+    gf_env GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT "va-worker"
+}
+
+gf_reviewer_account() {
+    gf_env GEMBAFLOW_REVIEWER_ACCOUNT AGILE_FLOW_REVIEWER_ACCOUNT "va-reviewer"
+}
+
+gf_solo_mode() {
+    gf_env GEMBAFLOW_SOLO_MODE AGILE_FLOW_SOLO_MODE ""
+}
+
+# gf_env_source_label <new_var_name> <old_var_name>
+#
+# Echo a human-readable label describing which env-var name supplied the
+# value, e.g. "GEMBAFLOW_WORKER_ACCOUNT" or "AGILE_FLOW_WORKER_ACCOUNT (deprecated)".
+# Used by doctor.sh to surface which name is in effect. Echoes "unset" if neither
+# is set.
+gf_env_source_label() {
+    local new_name="$1"
+    local old_name="$2"
+
+    if [ -n "${!new_name:-}" ]; then
+        printf '%s' "$new_name"
+    elif [ -n "${!old_name:-}" ]; then
+        printf '%s (deprecated)' "$old_name"
+    else
+        printf 'unset'
+    fi
+}

--- a/scripts/setup-accounts.sh
+++ b/scripts/setup-accounts.sh
@@ -20,6 +20,18 @@ if [ -z "$BASH_VERSION" ]; then
     exec bash "$0" "$@"
 fi
 
+# Dual-read shim for the agile-flow → Gemba Flow env-var rebrand.
+# Prefers GEMBAFLOW_*, falls back to the deprecated AGILE_FLOW_*.
+# See scripts/lib/env-compat.sh for the migration policy.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/env-compat.sh
+source "${SCRIPT_DIR}/lib/env-compat.sh"
+
+# Resolved values from the dual-read shim. Captured once at script start
+# so the deprecation warning (if any) fires at most once per invocation.
+SETUP_WORKER_ACCOUNT="$(gf_env GEMBAFLOW_WORKER_ACCOUNT AGILE_FLOW_WORKER_ACCOUNT)"
+SETUP_REVIEWER_ACCOUNT="$(gf_env GEMBAFLOW_REVIEWER_ACCOUNT AGILE_FLOW_REVIEWER_ACCOUNT)"
+
 # ───────────────────────────────────────────────────────────────────
 #  Colors (from doctor.sh)
 # ───────────────────────────────────────────────────────────────────
@@ -171,7 +183,7 @@ worker_account="${org_prefix}-worker"
 reviewer_account="${org_prefix}-reviewer"
 
 # Check if worker already configured and matches
-if [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ] && [ "$AGILE_FLOW_WORKER_ACCOUNT" = "$worker_account" ]; then
+if [ -n "${SETUP_WORKER_ACCOUNT:-}" ] && [ "$SETUP_WORKER_ACCOUNT" = "$worker_account" ]; then
     # Verify it's actually in the keyring
     if gh auth switch --user "$worker_account" &>/dev/null 2>&1; then
         print_success "Worker account already configured: ${worker_account}"
@@ -179,11 +191,11 @@ if [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ] && [ "$AGILE_FLOW_WORKER_ACCOUNT" = "
         gh auth switch --user "$PERSONAL_USER" &>/dev/null 2>&1 || true
     else
         print_warning "Worker env var set but account not in keyring. Will re-authenticate."
-        AGILE_FLOW_WORKER_ACCOUNT=""
+        SETUP_WORKER_ACCOUNT=""
     fi
 fi
 
-if [ -z "${AGILE_FLOW_WORKER_ACCOUNT:-}" ] || [ "${AGILE_FLOW_WORKER_ACCOUNT:-}" != "$worker_account" ]; then
+if [ -z "${SETUP_WORKER_ACCOUNT:-}" ] || [ "${SETUP_WORKER_ACCOUNT:-}" != "$worker_account" ]; then
     echo ""
     echo "  Worker account: ${worker_account}"
     echo ""
@@ -230,7 +242,8 @@ if [ -z "${AGILE_FLOW_WORKER_ACCOUNT:-}" ] || [ "${AGILE_FLOW_WORKER_ACCOUNT:-}"
         # Restore personal before persisting env var
         gh auth switch --user "$PERSONAL_USER" &>/dev/null 2>&1 || true
 
-        persist_env_var "AGILE_FLOW_WORKER_ACCOUNT" "$worker_account"
+        persist_env_var "GEMBAFLOW_WORKER_ACCOUNT" "$worker_account"
+        SETUP_WORKER_ACCOUNT="$worker_account"
     else
         print_error "Worker account login failed. Check your PAT and try again."
         exit 1
@@ -246,17 +259,17 @@ echo -e "${CYAN}--- Step 3/4: Reviewer bot account ---${NC}"
 echo ""
 
 # Check if reviewer already configured and matches
-if [ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ] && [ "$AGILE_FLOW_REVIEWER_ACCOUNT" = "$reviewer_account" ]; then
+if [ -n "${SETUP_REVIEWER_ACCOUNT:-}" ] && [ "$SETUP_REVIEWER_ACCOUNT" = "$reviewer_account" ]; then
     if gh auth switch --user "$reviewer_account" &>/dev/null 2>&1; then
         print_success "Reviewer account already configured: ${reviewer_account}"
         gh auth switch --user "$PERSONAL_USER" &>/dev/null 2>&1 || true
     else
         print_warning "Reviewer env var set but account not in keyring. Will re-authenticate."
-        AGILE_FLOW_REVIEWER_ACCOUNT=""
+        SETUP_REVIEWER_ACCOUNT=""
     fi
 fi
 
-if [ -z "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ] || [ "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" != "$reviewer_account" ]; then
+if [ -z "${SETUP_REVIEWER_ACCOUNT:-}" ] || [ "${SETUP_REVIEWER_ACCOUNT:-}" != "$reviewer_account" ]; then
     echo ""
     echo "  Reviewer account: ${reviewer_account}"
     echo ""
@@ -306,7 +319,8 @@ if [ -z "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ] || [ "${AGILE_FLOW_REVIEWER_ACCOUNT
         # Restore personal before persisting env var
         gh auth switch --user "$PERSONAL_USER" &>/dev/null 2>&1 || true
 
-        persist_env_var "AGILE_FLOW_REVIEWER_ACCOUNT" "$reviewer_account"
+        persist_env_var "GEMBAFLOW_REVIEWER_ACCOUNT" "$reviewer_account"
+        SETUP_REVIEWER_ACCOUNT="$reviewer_account"
     else
         print_error "Reviewer account login failed. Check your PAT and try again."
         exit 1
@@ -325,8 +339,8 @@ echo ""
 gh auth switch --user "$PERSONAL_USER" &>/dev/null 2>&1 || true
 
 # Build summary
-worker_display="${AGILE_FLOW_WORKER_ACCOUNT:-$worker_account}"
-reviewer_display="${AGILE_FLOW_REVIEWER_ACCOUNT:-$reviewer_account}"
+worker_display="${SETUP_WORKER_ACCOUNT:-$worker_account}"
+reviewer_display="${SETUP_REVIEWER_ACCOUNT:-$reviewer_account}"
 
 # Check keyring status for each bot
 worker_status="in keyring"


### PR DESCRIPTION
## Summary

Phase 2b of the agile-flow → Gemba Flow rebrand: rename the env-var prefix from `AGILE_FLOW_*` to `GEMBAFLOW_*` with a backward-compatible dual-read shim. Old vars keep working; users get a one-line deprecation nudge to migrate.

- New helper `scripts/lib/env-compat.sh` (`gf_env`, `gf_worker_account`, `gf_reviewer_account`, `gf_solo_mode`, `gf_env_source_label`)
- `bootstrap.sh`, `scripts/setup-accounts.sh`, `scripts/doctor.sh`, and `.claude/hooks/ensure-github-account.sh` now read via the shim
- `bootstrap.sh` and `setup-accounts.sh` persist only the new `GEMBAFLOW_*` name to shell rc (never the deprecated form)
- `.devcontainer/devcontainer.json` `containerEnv` switched to `GEMBAFLOW_SOLO_MODE`
- `CLAUDE.md` updated with new names + a note that the old ones still work

## Variables migrated

| New (preferred) | Deprecated (fallback) | Default |
|---|---|---|
| `GEMBAFLOW_WORKER_ACCOUNT` | `AGILE_FLOW_WORKER_ACCOUNT` | `va-worker` |
| `GEMBAFLOW_REVIEWER_ACCOUNT` | `AGILE_FLOW_REVIEWER_ACCOUNT` | `va-reviewer` |
| `GEMBAFLOW_SOLO_MODE` | `AGILE_FLOW_SOLO_MODE` | (empty) |

## DRY decision

Extracted a helper at `scripts/lib/env-compat.sh` and source it from every consumer. The dual-read pattern repeats across four call sites, and a future Phase 4+ removal of `AGILE_FLOW_*` is a one-file delete instead of a multi-file scrub.

## Test plan

- [x] Sourced helper in a fresh bash; ran six scenarios covering: neither set → default applied; only new set → no warning; only old set → one warning + correct value; both set → new wins, no warning; multiple calls from same shell → dedupes to exactly one warning via the exported `_GF_ENV_COMPAT_WARNED` sentinel.
- [x] `bash -n` on all four modified scripts + the new helper.
- [x] `uv sync --extra dev` (pre-push hook).
- [ ] Manual: shell with only `AGILE_FLOW_WORKER_ACCOUNT` set → `doctor.sh` reports deprecated source + warns.
- [ ] Manual: shell with only `GEMBAFLOW_WORKER_ACCOUNT` set → `doctor.sh` reports new source, no warning.
- [ ] Manual: shell with both set → `doctor.sh` reports new source, no warning.

## Strict guardrails honored

- Old `AGILE_FLOW_*` reads preserved as fallback (not removed).
- No dotfile renames (Phase 4).
- No package metadata changes (Phase 2c — parallel).
- No URL rewrites (Phase 2a — already done).
- Warning is one-line, goes to stderr, fires at most once per script invocation.

Closes #333