### PR TITLE
chore(rebrand): Phase 2c — package metadata + README badges

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,6 +1,6 @@
 # Claude Code Configuration
 
-This directory contains agent policies, slash commands, and settings for Claude Code projects using the Agile Flow template.
+This directory contains agent policies, slash commands, and settings for Claude Code projects using the Gemba Flow template.
 
 ## Directory Structure
 

--- a/.claude/commands/bootstrap-workflow.md
+++ b/.claude/commands/bootstrap-workflow.md
@@ -275,7 +275,7 @@ Your project is now ready for development!
 5. Review proposed changes
 6. Confirm to apply
 
-When complete, your Agile Flow project is fully operational!
+When complete, your Gemba Flow project is fully operational!
 
 ## Next Steps
 

--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -2,7 +2,7 @@
 description: "Run a comprehensive health check of the local environment and remote configuration"
 ---
 
-# /doctor — Agile Flow Health Check
+# /doctor — Gemba Flow Health Check
 
 Run a comprehensive diagnostic of the local environment and remote
 configuration. Surfaces every issue that could block a workshop participant.
@@ -53,7 +53,7 @@ configuration. Surfaces every issue that could block a workshop participant.
 1. Format a **health report table** combining local + remote results:
 
    ```text
-   ## Agile Flow Health Report
+   ## Gemba Flow Health Report
 
    ### Local Checks (from scripts/doctor.sh)
    PASS: {n}  WARN: {n}  FAIL: {n}  SKIP: {n}

--- a/.claude/commands/report-issue.md
+++ b/.claude/commands/report-issue.md
@@ -1,10 +1,10 @@
 ---
-description: "Report a bug or issue from this fork back to the upstream Agile Flow repo"
+description: "Report a bug or issue from this fork back to the upstream Gemba Flow repo"
 ---
 
 # /report-issue — Report an Issue to Upstream
 
-File a structured bug report or feedback item against the upstream Agile Flow repo
+File a structured bug report or feedback item against the upstream Gemba Flow repo
 from this downstream fork. The report is delivered as a GitHub issue with a
 `downstream-report` label so upstream maintainers can triage it automatically.
 

--- a/.claude/commands/upgrade.md
+++ b/.claude/commands/upgrade.md
@@ -1,10 +1,10 @@
 ---
-description: "Upgrade Agile Flow framework files to the latest release"
+description: "Upgrade Gemba Flow framework files to the latest release"
 ---
 
-# /upgrade — Agile Flow Framework Upgrade
+# /upgrade — Gemba Flow Framework Upgrade
 
-Check for a newer version of Agile Flow and sync framework files from the
+Check for a newer version of Gemba Flow and sync framework files from the
 latest upstream release. User content is never modified.
 
 ## Instructions
@@ -95,7 +95,7 @@ End your output with a Result Block:
 **Result:** Upgrade complete
 From: v0.9.0
 To: v1.0.0
-PR: #42 — chore(sync): update Agile Flow framework to v1.0.0
+PR: #42 — chore(sync): update Gemba Flow framework to v1.0.0
 Action: Review and merge the PR to finalize the upgrade
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Agile Flow will be documented in this file.
+All notable changes to Gemba Flow will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- FRAMEWORK:START -->
-# Agile Flow - Claude Code Project Template
+# Gemba Flow - Claude Code Project Template
 
 ## >>> CRITICAL RULES — Read These First <<<
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,6 +1,6 @@
 # Versioning Policy
 
-Agile Flow follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+Gemba Flow follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## Version Format
 

--- a/docs/AGENT-WORKFLOW-SUMMARY.md
+++ b/docs/AGENT-WORKFLOW-SUMMARY.md
@@ -1,6 +1,6 @@
 # Agent Workflow Summary
 
-Comprehensive reference for the Agile Flow agent-powered development workflow.
+Comprehensive reference for the Gemba Flow agent-powered development workflow.
 
 ## Table of Contents
 
@@ -822,7 +822,7 @@ gh auth switch --user {org}-worker
 
 ## Summary
 
-The Agile Flow workflow provides:
+The Gemba Flow workflow provides:
 
 1. **Automated implementation** via github-ticket-worker
 2. **Automated review** via pr-reviewer

--- a/docs/ARTIFACT-FLOW.md
+++ b/docs/ARTIFACT-FLOW.md
@@ -1,6 +1,6 @@
 # Artifact Flow
 
-How documents, tickets, and code flow through the Agile Flow system — who
+How documents, tickets, and code flow through the Gemba Flow system — who
 produces each artifact, what it contains, and who consumes it.
 
 ---

--- a/docs/BRANCHING-STRATEGY.md
+++ b/docs/BRANCHING-STRATEGY.md
@@ -1,6 +1,6 @@
 # Branching Strategy
 
-This document explains why the Agile Flow template requires trunk-based
+This document explains why the Gemba Flow template requires trunk-based
 development and how the branching model keeps your project safe. It is
 written for founders and builders who may be new to Git workflows.
 
@@ -16,7 +16,7 @@ into the car.
 
 Software works the same way:
 
-| Car Factory | Software (Agile Flow) |
+| Car Factory | Software (Gemba Flow) |
 |-------------|----------------------|
 | Test bench | **Feature branch** — an isolated workspace where you build and test one change |
 | Component inspection | **CI checks** — automated tests that verify the change before it goes anywhere |
@@ -123,7 +123,7 @@ quickly avoid this entirely.
 
 ## How It Works in This Template
 
-Here is the concrete flow when a ticket is worked in Agile Flow:
+Here is the concrete flow when a ticket is worked in Gemba Flow:
 
 ```
 1. Agent picks up a ticket from the Ready column

--- a/docs/CONVENTIONAL-COMMITS.md
+++ b/docs/CONVENTIONAL-COMMITS.md
@@ -123,7 +123,7 @@ single line of code.
 ### Automated changelogs and releases
 
 Tools can generate changelogs automatically from conventional commits.
-The Agile Flow template's release workflow (`release.yml`) already uses
+The Gemba Flow template's release workflow (`release.yml`) already uses
 `CHANGELOG.md` alongside commit types. Structured commits make it
 possible to answer "what shipped in this release?" without manual
 work.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,6 +1,6 @@
 # Distribution: Framework / User-Content Boundary
 
-This document classifies every file and directory in the Agile Flow template
+This document classifies every file and directory in the Gemba Flow template
 repository. The classification drives update behavior: which files are safe
 to overwrite during framework updates, which must never be touched, and
 which contain both framework and user sections.
@@ -9,7 +9,7 @@ which contain both framework and user sections.
 
 | Category | Meaning | Update Behavior |
 |----------|---------|-----------------|
-| **framework** | Controlled by Agile Flow | Safe to overwrite during sync |
+| **framework** | Controlled by Gemba Flow | Safe to overwrite during sync |
 | **user-content** | Owned by the user | Never modified by updates |
 | **hybrid** | Both framework and user sections | Only framework-marked sections updated |
 
@@ -35,7 +35,7 @@ Content **outside** markers in hybrid files is user-owned. Content
 |------|----------|-----------|-----------------|
 | `CLAUDE.md` | hybrid | Framework rules above the TEMPLATE comment; user fills in project info below | Update framework sections only |
 | `README.md` | hybrid | Framework badges and structure; user adds project-specific content | Update framework sections only |
-| `LICENSE` | framework | License terms set by Agile Flow | Overwrite |
+| `LICENSE` | framework | License terms set by Gemba Flow | Overwrite |
 | `bootstrap.sh` | framework | Template bootstrap wizard | Overwrite |
 | `VERSIONING.md` | framework | Versioning policy | Overwrite |
 | `CHANGELOG.md` | user-content | User's project changelog | Never touch |

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-Answers for founders and non-engineers using the Agile Flow template.
+Answers for founders and non-engineers using the Gemba Flow template.
 
 ---
 
@@ -36,7 +36,7 @@ Then open a pull request on GitHub to propose merging your branch into
 > account for everything. Bot accounts are optional and mainly useful for
 > teams that want a clear audit trail.
 
-For **team setups**, Agile Flow uses three separate identities so there is
+For **team setups**, Gemba Flow uses three separate identities so there is
 a clear record of who did what. Your personal account is for final
 decisions (approving and merging). A "worker" bot account writes code and
 opens pull requests. A "reviewer" bot account reviews pull requests. This
@@ -238,7 +238,7 @@ gh pr create --title "Add my new feature" --body "Description of changes"
 **Merging** is the act of combining your changes into the main codebase.
 When you work on a branch, your changes are isolated -- only you can see
 them. Merging takes those isolated changes and folds them into `main` so
-they become part of the official project. In Agile Flow, only humans can
+they become part of the official project. In Gemba Flow, only humans can
 merge; the AI agents can propose and review changes, but a person always
 makes the final call.
 
@@ -252,7 +252,7 @@ makes the final call.
 
 ---
 
-## "How do I upgrade to a newer version of Agile Flow?"
+## "How do I upgrade to a newer version of Gemba Flow?"
 
 Run `/upgrade` from Claude Code. This checks for a newer release, syncs
 framework files into your project, and opens a pull request for you to review.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,6 +1,6 @@
-# Getting Started with Agile Flow
+# Getting Started with Gemba Flow
 
-A step-by-step guide to set up your project using the Agile Flow template.
+A step-by-step guide to set up your project using the Gemba Flow template.
 This guide is written for founders and non-engineers -- every step includes
 what you should see when it works.
 
@@ -229,7 +229,7 @@ Save everything and push it to GitHub.
 git add -A
 
 # Save a snapshot with a description
-git commit -m "Initialize project with Agile Flow template"
+git commit -m "Initialize project with Gemba Flow template"
 
 # Upload to GitHub
 git push -u origin main
@@ -355,7 +355,7 @@ This usually means Phase 3 (agent configuration) did not complete. Run:
 
 ## Checking for Updates
 
-Agile Flow tracks its version in the `.agile-flow-version` file at your
+Gemba Flow tracks its version in the `.agile-flow-version` file at your
 project root. To check which version you are running:
 
 ```bash

--- a/docs/LEAN-PRINCIPLES.md
+++ b/docs/LEAN-PRINCIPLES.md
@@ -1,6 +1,6 @@
-# Lean Principles in Agile Flow
+# Lean Principles in Gemba Flow
 
-Agile Flow is a waste elimination system. Every agent, command, hook, and
+Gemba Flow is a waste elimination system. Every agent, command, hook, and
 workflow constraint exists to close a specific leak in the software delivery
 pipeline. The leaks are not new — they are the seven wastes identified by
 Toyota's lean manufacturing system, translated for software delivery by
@@ -13,7 +13,7 @@ is a way that code generation decouples from value delivery.
 
 ## The Seven Wastes
 
-| Manufacturing Waste | Software Waste | Agile Flow Countermeasure |
+| Manufacturing Waste | Software Waste | Gemba Flow Countermeasure |
 |---------------------|----------------|--------------------------|
 | Inventory | Partially Done Work | Pull system, WIP limits, one-ticket-at-a-time |
 | Overproduction | Extra Features | PM/PO gate, scope lock, feature evaluation |
@@ -35,7 +35,7 @@ obsolescence before delivery.
 half-finished PRs faster than humans can review them. Without constraints,
 you accumulate inventory at machine speed.
 
-**Agile Flow countermeasures:**
+**Gemba Flow countermeasures:**
 
 | Practice | How it helps |
 |----------|-------------|
@@ -60,7 +60,7 @@ to build a login page and it will add OAuth, magic links, biometric auth,
 and a password strength meter — none of which were requested. Overproduction
 is the default mode for generative AI.
 
-**Agile Flow countermeasures:**
+**Gemba Flow countermeasures:**
 
 | Practice | How it helps |
 |----------|-------------|
@@ -89,7 +89,7 @@ files, re-discovers the same patterns, and makes the same mistakes —
 every single time. Relearning waste becomes *catastrophic* at agent speed
 because the agent does not know what it does not know.
 
-**Agile Flow countermeasures:**
+**Gemba Flow countermeasures:**
 
 | Practice | How it helps |
 |----------|-------------|
@@ -116,7 +116,7 @@ Context windows do not transfer. If the worker agent's implementation
 intent is not captured in the PR description, the reviewer agent
 reviews blind.
 
-**Agile Flow countermeasures:**
+**Gemba Flow countermeasures:**
 
 | Practice | How it helps |
 |----------|-------------|
@@ -146,7 +146,7 @@ decisions. A PR that sits unreviewed for two days wasted the agent's
 speed advantage entirely. The bottleneck shifts from code production to
 human review bandwidth.
 
-**Agile Flow countermeasures:**
+**Gemba Flow countermeasures:**
 
 | Practice | How it helps |
 |----------|-------------|
@@ -173,7 +173,7 @@ of ramping up on different work items reduces focus and productivity.
 tasks means losing context, which means relearning (waste #3). An agent
 that juggles three tickets simultaneously will do all three poorly.
 
-**Agile Flow countermeasures:**
+**Gemba Flow countermeasures:**
 
 | Practice | How it helps |
 |----------|-------------|
@@ -201,7 +201,7 @@ with equal confidence whether the code is correct or hallucinated.
 Defect generation can outpace defect detection unless the system is
 designed to prevent it.
 
-**Agile Flow countermeasures:**
+**Gemba Flow countermeasures:**
 
 | Practice | How it helps |
 |----------|-------------|

--- a/docs/MEMORY-ARCHITECTURE.md
+++ b/docs/MEMORY-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Memory Architecture — Agent Institutional Knowledge
 
-How agile-flow agents persist, retrieve, and share knowledge across sessions.
+How gembaflow agents persist, retrieve, and share knowledge across sessions.
 For context engineering principles behind these choices, see
 [CONTEXT-OPTIMIZATIONS.md](CONTEXT-OPTIMIZATIONS.md).
 

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -1,6 +1,6 @@
 # Platform Guide
 
-Agile Flow supports multiple deployment platforms. Your choice is stored
+Gemba Flow supports multiple deployment platforms. Your choice is stored
 in `.claude/PROJECT.md` and read by the `devops-engineer` and
 `system-architect` agents.
 
@@ -188,7 +188,7 @@ Instance > connect your repo.
 
 ## Database: Supabase (Recommended)
 
-Supabase is the recommended database for Agile Flow projects. Its native
+Supabase is the recommended database for Gemba Flow projects. Its native
 **branching** feature creates an isolated Postgres instance for each PR —
 migrations auto-applied, data fully isolated between PRs. Render's managed
 Postgres cannot do this (all preview environments share the same database).

--- a/docs/SDLC.md
+++ b/docs/SDLC.md
@@ -1,6 +1,6 @@
 # Framework SDLC
 
-How `agile-flow` is developed, tested, released, and propagated to its
+How `gembaflow` is developed, tested, released, and propagated to its
 downstream cloud variants. This document is written from the perspective of
 a contributor to the framework itself — not a user building on it.
 
@@ -8,7 +8,7 @@ a contributor to the framework itself — not a user building on it.
 
 ## Framework vs. Downstream — The Critical Distinction
 
-`agile-flow` is a **framework product**. Its consumers are:
+`gembaflow` is a **framework product**. Its consumers are:
 
 - `agile-flow-gcp` — the GCP Cloud Run + Neon variant
 - `agile-flow-aws` — the AWS variant (same structural pattern)
@@ -19,17 +19,17 @@ CI workflow structure, documentation templates, and starter projects.
 Cloud variants own: platform-specific deployment, database layer, and any
 agent prompts rewritten with platform guardrails.
 
-**A PR against `agile-flow` is not a product change. It is a framework
+**A PR against `gembaflow` is not a product change. It is a framework
 change.** Every such change propagates — or can propagate — to all downstream
 variants. This carries obligations that no other PR type does.
 
 ---
 
-## What a PR Against `agile-flow` Means
+## What a PR Against `gembaflow` Means
 
 ### Downstream propagation
 
-Merging to `agile-flow` main does not automatically update cloud variants.
+Merging to `gembaflow` main does not automatically update cloud variants.
 Variants pull changes on their own schedule using two sync paths:
 
 | Sync path | When used | Mechanism |
@@ -157,7 +157,7 @@ manually by the PR author before tagging.
 
 ## Per-PR Responsibilities
 
-Every PR against `agile-flow` main must satisfy this checklist before merge.
+Every PR against `gembaflow` main must satisfy this checklist before merge.
 
 ### Always required
 

--- a/docs/SENTRY-SETUP.md
+++ b/docs/SENTRY-SETUP.md
@@ -1,6 +1,6 @@
 # Error Telemetry Setup
 
-This guide covers error capture and automatic bug triage for the Agile Flow
+This guide covers error capture and automatic bug triage for the Gemba Flow
 starter app.
 
 ## Zero-Config (Default)
@@ -13,7 +13,7 @@ issues labeled `bug:auto` automatically.
 **Requirements:**
 
 - `GITHUB_TOKEN` environment variable set (for creating issues)
-- `GITHUB_REPOSITORY` environment variable set (e.g., `your-org/agile-flow`)
+- `GITHUB_REPOSITORY` environment variable set (e.g., `your-org/gembaflow`)
 - `RENDER_EXTERNAL_URL` is provided automatically by Render
 
 **How it works:**
@@ -71,7 +71,7 @@ This is not needed for the zero-config flow, which creates issues directly.
 | Variable | Required | Purpose |
 |----------|----------|---------|
 | `GITHUB_TOKEN` | Yes (zero-config) | API token for creating GitHub issues |
-| `GITHUB_REPOSITORY` | Yes (zero-config) | Target repo (e.g., `org/agile-flow`) |
+| `GITHUB_REPOSITORY` | Yes (zero-config) | Target repo (e.g., `org/gembaflow`) |
 | `RENDER_EXTERNAL_URL` | Auto (Render) | App's public URL for self-DSN construction |
 | `SENTRY_DSN` | No | External Sentry/GlitchTip DSN (overrides self-DSN) |
 | `APP_URL` | No | Fallback app URL if not on Render |

--- a/docs/SORTING-AND-BATCHING.md
+++ b/docs/SORTING-AND-BATCHING.md
@@ -1,6 +1,6 @@
 # Sorting and Batching
 
-Sorting work before executing it is the single highest-leverage improvement you can make to delivery cadence. Everything else in agile-flow — ticket format, branching, backlog grooming — is downstream of this principle.
+Sorting work before executing it is the single highest-leverage improvement you can make to delivery cadence. Everything else in gembaflow — ticket format, branching, backlog grooming — is downstream of this principle.
 
 ---
 
@@ -42,7 +42,7 @@ This is why effort estimates hold and budgets don't blow up. The variance in tic
 
 ---
 
-## How agile-flow Enforces This
+## How gembaflow Enforces This
 
 Sorting and batching aren't just advice — they're built into the workflow at multiple points:
 

--- a/docs/SYNC-RULES.md
+++ b/docs/SYNC-RULES.md
@@ -1,6 +1,6 @@
 # Sync Rules: Upstream ↔ Downstream
 
-This document tracks intentional differences between the upstream Agile Flow
+This document tracks intentional differences between the upstream Gemba Flow
 framework and its downstream forks. See `DISTRIBUTION.md` for the master file
 classification.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,7 +1,7 @@
-# Upgrading Agile Flow
+# Upgrading Gemba Flow
 
 This guide explains how to update your project to a newer version of the
-Agile Flow framework. Upgrades only touch framework-controlled files (agents,
+Gemba Flow framework. Upgrades only touch framework-controlled files (agents,
 commands, hooks, skills, scripts). Your application code, product docs, and
 configuration customizations are never modified.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agile-flow-starter",
+  "name": "gembaflow-starter",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agile-flow"
+name = "gembaflow"
 version = "0.1.0"
-description = "Agile Flow Framework"
+description = "Gemba Flow Framework"
 requires-python = ">=3.9"
 dependencies = [
     "behave>=1.2.6",

--- a/starters/fastapi/pyproject.toml
+++ b/starters/fastapi/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "agile-flow-starter"
+name = "gembaflow-starter"
 version = "0.9.0"
-description = "Minimal FastAPI starter app for Agile Flow workshops"
+description = "Minimal FastAPI starter app for Gemba Flow workshops"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",

--- a/uv.lock
+++ b/uv.lock
@@ -7,31 +7,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "agile-flow"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "behave" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "behave", specifier = ">=1.2.6" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
-]
-provides-extras = ["dev"]
-
-[[package]]
 name = "behave"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -360,6 +335,31 @@ sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
+
+[[package]]
+name = "gembaflow"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "behave" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "behave", specifier = ">=1.2.6" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
## Summary

Phase 2c of the agile-flow → Gemba Flow rebrand. Phase 2a handled URL rewrites and agent source footers; this PR is the package metadata + display-string finishing pass.

- **`package.json`** name: `agile-flow-starter` → `gembaflow-starter`.
- **`pyproject.toml`** name: `agile-flow` → `gembaflow`; description: `Agile Flow Framework` → `Gemba Flow Framework`.
- **`starters/fastapi/pyproject.toml`** name + description flipped.
- **`uv.lock`** regenerated (picks up the new package name automatically).
- **Display strings** in `CLAUDE.md`, `VERSIONING.md`, `CHANGELOG.md` (intro only), `.claude/README.md`, four `.claude/commands/*.md`, and fifteen `docs/*.md` flipped from current-state "Agile Flow" / `agile-flow` to "Gemba Flow" / `gembaflow`.

Versions are intentionally not bumped — release pipeline tags will pick up the rename on next release.

## Intentionally left alone (per ticket guardrails)

- Dotfile names (`.agile-flow-version`, `.agile-flow-overrides`, `.agile-flow-meta/`, `.agile-flow-reports/`) — Phase 4.
- Sync-branch prefix `agile-flow-sync/v...` — Phase 4.
- Env var names (`AGILE_FLOW_*`) — Phase 2b (parallel).
- Variant fork names (`agile-flow-gcp`, `agile-flow-aws`) — still the actual fork repo names; renames are downstream phases.
- CHANGELOG entries from past releases ([1.1.0], [0.9.0]) and their compare URLs — historical record.
- `reports/session-journals/*`, `docs/PATTERN-LIBRARY.md` #327 reference, `docs/plans/*`, `docs/research/*`, `docs/defect-dispositions/*` — historical references.
- README version badge `.agile-flow-version` link — dotfile name (Phase 4).
- `scripts/report-issue.sh` `agile_flow_report:` YAML key (and the mirror in `report-issue.md` doc) — script-level rename owned by Phase 2b.

## Test plan

- [ ] `uv sync --extra dev` builds `gembaflow==0.1.0` cleanly (verified locally).
- [ ] `grep -rn "agile-flow\|Agile Flow\|agileflow" . --include='package.json' --include='pyproject.toml' --include='*.md' --exclude-dir=.git --exclude-dir=node_modules` returns only the guardrail-protected categories above.
- [ ] Package names match `gembaflow*` in `package.json`, `pyproject.toml`, `starters/fastapi/pyproject.toml`.
- [ ] README badges resolve against `vibeacademy/gembaflow`.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)