### PR TITLE
fix(hooks): pre-push needs --extra dev for pytest/ruff on clean checkout

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -112,8 +112,8 @@ case "$STACK" in
   python)
     echo "Detected Python project"
     echo ""
-    run_check "ruff check" uv run ruff check .
-    run_check "pytest" uv run pytest --tb=short -q
+    run_check "ruff check" uv run --extra dev ruff check .
+    run_check "pytest" uv run --extra dev pytest --tb=short -q
     ;;
 
   go)


### PR DESCRIPTION
## Summary

Pre-push hook's Python branch called `uv run pytest` and `uv run ruff` without `--extra dev`. Both tools live in `[project.optional-dependencies] dev` in `pyproject.toml`, so on a fresh checkout uv could not find the binaries and the first push failed with `error: Failed to spawn: pytest`. Every new contributor hit this on their first push.

Closes #341

## Audit of `uv run` calls in `scripts/hooks/pre-push`

Only the Python branch (lines 112-117) uses `uv run`. Two calls, both updated:

| Line | Before | After |
| --- | --- | --- |
| ruff | `uv run ruff check .` | `uv run --extra dev ruff check .` |
| pytest | `uv run pytest --tb=short -q` | `uv run --extra dev pytest --tb=short -q` |

Confirmed in `pyproject.toml`: base `dependencies = ["behave>=1.2.6"]`; `dev` extra contains `ruff`, `pytest`, `pytest-cov`. So both tools genuinely need `--extra dev`.

Node.js branch (`npm`/`pnpm`/`bun exec`) and Go branch untouched — those toolchains resolve dev deps automatically.

## Test plan

- [x] Diff is two lines: `uv run <tool>` -> `uv run --extra dev <tool>` for both ruff and pytest.
- [x] Clean checkout simulation: in a worktree with no `.venv`, `uv run --extra dev pytest --tb=short -q` resolves and runs (verified with `uv sync --extra dev` in the worktree).
- [ ] Idempotent: on a project where `uv sync --extra dev` has already run, `--extra dev` is a no-op for resolution and the hook still passes.
- [ ] Downstream: `gembaflow-gcp` picks up the fix on next `/pull-upstream` since this file is not in `.gembaflow-overrides`.

Guardrails respected: did not add pytest/ruff to base deps, did not remove the `uv` availability check, did not touch Node.js or Go branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)