### PR TITLE
chore(cleanup): remove Phase 4 dual-read fallback

### DIFF
--- a/.gembaflow-overrides
+++ b/.gembaflow-overrides
@@ -7,7 +7,4 @@
 # Paths are relative to the repo root.
 
 # Metadata directory is always local — never stomped by upstream upgrades.
-# Both names listed during the Phase 4 rebrand dual-read window (#335); the
-# legacy entry can be removed in the cleanup PR after one release cycle.
 .gembaflow-meta/
-.agile-flow-meta/

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -935,11 +935,7 @@ phase4_workflow() {
     print_success "Phase 4 complete! Workflow activated."
 
     # Stamp installedAt in the version manifest if not already set.
-    # Phase 4 dual-read (#335): prefer .gembaflow-version; fall back to legacy.
     local af_manifest=".gembaflow-version"
-    if [ ! -f "$af_manifest" ] && [ -f ".agile-flow-version" ]; then
-        af_manifest=".agile-flow-version"
-    fi
     if [ -f "$af_manifest" ]; then
         local current_val
         current_val=$(jq -r '.installedAt // "null"' "$af_manifest" 2>/dev/null)
@@ -984,11 +980,7 @@ show_completion() {
     echo "  - docs/TECHNICAL-ARCHITECTURE.md - Your architecture"
     echo ""
     local af_version="unknown"
-    # Phase 4 dual-read (#335): prefer .gembaflow-version; fall back to legacy.
     local af_manifest=".gembaflow-version"
-    if [ ! -f "$af_manifest" ] && [ -f ".agile-flow-version" ]; then
-        af_manifest=".agile-flow-version"
-    fi
     if [ -f "$af_manifest" ]; then
         af_version=$(jq -r '.version // "unknown"' "$af_manifest" 2>/dev/null)
     fi

--- a/features/report-issue.feature
+++ b/features/report-issue.feature
@@ -4,7 +4,7 @@ Feature: Report Issue to Upstream
   So that bugs and problems can be tracked and fixed
 
   Scenario: Successfully report issue with gh CLI authentication
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     And gh CLI is authenticated with write access to upstream
     When user runs report-issue.sh with valid inputs
     Then exit code is 0
@@ -12,7 +12,7 @@ Feature: Report Issue to Upstream
     And report file is saved to .gembaflow-reports/
 
   Scenario: Fallback to manual submission when gh CLI fails
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     And gh CLI is not available or authentication fails
     When user runs report-issue.sh with valid inputs  
     Then exit code is 0
@@ -20,7 +20,7 @@ Feature: Report Issue to Upstream
     And fallback URL is provided for manual submission
 
   Scenario: Fallback to manual submission when gh CLI lacks write access
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     And gh CLI lacks write access to upstream (permission denied)
     When user runs report-issue.sh with valid inputs
     Then exit code is 0
@@ -30,79 +30,79 @@ Feature: Report Issue to Upstream
 
   # Error cases
 
-  Scenario: Missing .agile-flow-version file
-    Given .agile-flow-version does not exist
+  Scenario: Missing .gembaflow-version file
+    Given .gembaflow-version does not exist
     When user runs report-issue.sh
     Then exit code is 1
     And error output suggests running /upgrade
 
-  Scenario: Missing upstream field in .agile-flow-version
-    Given .agile-flow-version exists but upstream field is missing
+  Scenario: Missing upstream field in .gembaflow-version
+    Given .gembaflow-version exists but upstream field is missing
     When user runs report-issue.sh
     Then exit code is 1
     And error output suggests running /upgrade
 
   Scenario: Invalid severity value
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     When user runs report-issue.sh with --severity invalid
     Then exit code is 1
     And error output lists valid severity values p1, p2, p3
 
   Scenario: Invalid component value
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     When user runs report-issue.sh with --component invalid
     Then exit code is 1
     And error output lists valid components
 
   Scenario: Empty title
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     When user runs report-issue.sh with empty title
     Then exit code is 1
     And error output indicates title is required
 
   Scenario: Non-interactive mode with --body flag
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     When user runs report-issue.sh with --body flag
     Then exit code is 0
     And report file contains provided body content
 
   Scenario: Non-interactive mode with --body-file flag
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     And body content file exists
     When user runs report-issue.sh with --body-file flag
     Then exit code is 0
     And report file contains file body content
 
   Scenario: Non-interactive mode with both --body and --body-file
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     When user runs report-issue.sh with both body flags
     Then exit code is 1
     And error output indicates only one body source allowed
 
   Scenario: Non-interactive mode with missing body
-    Given .agile-flow-version exists with valid upstream URL
+    Given .gembaflow-version exists with valid upstream URL
     When user runs report-issue.sh in non-interactive mode without body
     Then exit code is 1
     And error output indicates body required in non-interactive mode
 
   # Empty version field cases
 
-  Scenario: .agile-flow-version file with empty string version
-    Given .agile-flow-version exists with empty string version field
+  Scenario: .gembaflow-version file with empty string version
+    Given .gembaflow-version exists with empty string version field
     And gh CLI is not available or authentication fails
     When user runs report-issue.sh with valid inputs
     Then exit code is 0
     And report file contains upstream_version unknown
 
-  Scenario: .agile-flow-version file with whitespace-only version
-    Given .agile-flow-version exists with whitespace-only version field
+  Scenario: .gembaflow-version file with whitespace-only version
+    Given .gembaflow-version exists with whitespace-only version field
     And gh CLI is not available or authentication fails
     When user runs report-issue.sh with valid inputs
     Then exit code is 0
     And report file contains upstream_version unknown
 
-  Scenario: .agile-flow-version file with null version
-    Given .agile-flow-version exists with null version field
+  Scenario: .gembaflow-version file with null version
+    Given .gembaflow-version exists with null version field
     And gh CLI is not available or authentication fails
     When user runs report-issue.sh with valid inputs
     Then exit code is 0

--- a/features/steps/report_issue_steps.py
+++ b/features/steps/report_issue_steps.py
@@ -62,14 +62,14 @@ def get_report_script_path():
     return script_path
 
 
-@given(".agile-flow-version exists with valid upstream URL")
+@given(".gembaflow-version exists with valid upstream URL")
 def agile_flow_version_exists(context):
-    """Create .agile-flow-version with valid upstream URL."""
+    """Create .gembaflow-version with valid upstream URL."""
     # Always ensure we have a temp git repo
     context.temp_git_repo = create_temp_git_repo()
 
     mock_upstream_repo = get_mock_upstream_repo()
-    version_file = context.temp_git_repo / ".agile-flow-version"
+    version_file = context.temp_git_repo / ".gembaflow-version"
     version_data = {
         "upstream": f"https://github.com/{mock_upstream_repo}",
         "version": "v2.1.0",
@@ -340,24 +340,24 @@ def fallback_url_provided(context):
 # ============================================================================
 
 
-@given(".agile-flow-version does not exist")
+@given(".gembaflow-version does not exist")
 def agile_flow_version_does_not_exist(context):
-    """Ensure .agile-flow-version file does not exist."""
+    """Ensure .gembaflow-version file does not exist."""
     # Always ensure we have a temp git repo
     context.temp_git_repo = create_temp_git_repo()
 
-    version_file = context.temp_git_repo / ".agile-flow-version"
+    version_file = context.temp_git_repo / ".gembaflow-version"
     if version_file.exists():
         version_file.unlink()
 
 
-@given(".agile-flow-version exists but upstream field is missing")
+@given(".gembaflow-version exists but upstream field is missing")
 def agile_flow_version_exists_but_upstream_missing(context):
-    """Create .agile-flow-version but without upstream field."""
+    """Create .gembaflow-version but without upstream field."""
     # Always ensure we have a temp git repo
     context.temp_git_repo = create_temp_git_repo()
 
-    version_file = context.temp_git_repo / ".agile-flow-version"
+    version_file = context.temp_git_repo / ".gembaflow-version"
     # Create JSON without upstream field
     version_data = {
         "version": "v2.1.0",
@@ -867,14 +867,14 @@ def error_indicates_body_required_in_non_interactive_mode(context):
 # ============================================================================
 
 
-@given(".agile-flow-version exists with empty string version field")
+@given(".gembaflow-version exists with empty string version field")
 def agile_flow_version_exists_with_empty_string_version(context):
-    """Create .agile-flow-version with empty string version field."""
+    """Create .gembaflow-version with empty string version field."""
     # Always ensure we have a temp git repo
     context.temp_git_repo = create_temp_git_repo()
 
     mock_upstream_repo = get_mock_upstream_repo()
-    version_file = context.temp_git_repo / ".agile-flow-version"
+    version_file = context.temp_git_repo / ".gembaflow-version"
     version_data = {
         "upstream": f"https://github.com/{mock_upstream_repo}",
         "version": "",  # empty string version
@@ -883,14 +883,14 @@ def agile_flow_version_exists_with_empty_string_version(context):
     version_file.write_text(json.dumps(version_data, indent=2) + "\n")
 
 
-@given(".agile-flow-version exists with whitespace-only version field")
+@given(".gembaflow-version exists with whitespace-only version field")
 def agile_flow_version_exists_with_whitespace_version(context):
-    """Create .agile-flow-version with whitespace-only version field."""
+    """Create .gembaflow-version with whitespace-only version field."""
     # Always ensure we have a temp git repo
     context.temp_git_repo = create_temp_git_repo()
 
     mock_upstream_repo = get_mock_upstream_repo()
-    version_file = context.temp_git_repo / ".agile-flow-version"
+    version_file = context.temp_git_repo / ".gembaflow-version"
     version_data = {
         "upstream": f"https://github.com/{mock_upstream_repo}",
         "version": "   ",  # whitespace-only version
@@ -899,14 +899,14 @@ def agile_flow_version_exists_with_whitespace_version(context):
     version_file.write_text(json.dumps(version_data, indent=2) + "\n")
 
 
-@given(".agile-flow-version exists with null version field")
+@given(".gembaflow-version exists with null version field")
 def agile_flow_version_exists_with_null_version(context):
-    """Create .agile-flow-version with null version field."""
+    """Create .gembaflow-version with null version field."""
     # Always ensure we have a temp git repo
     context.temp_git_repo = create_temp_git_repo()
 
     mock_upstream_repo = get_mock_upstream_repo()
-    version_file = context.temp_git_repo / ".agile-flow-version"
+    version_file = context.temp_git_repo / ".gembaflow-version"
     version_data = {
         "upstream": f"https://github.com/{mock_upstream_repo}",
         "version": None,

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -138,12 +138,7 @@ fi
 # ═══════════════════════════════════════════════════════════════════
 section "Framework Version"
 
-# Phase 4 dual-read (#335): prefer .gembaflow-version; fall back to legacy
-# .agile-flow-version for one release cycle.
 VERSION_MANIFEST=".gembaflow-version"
-if [ ! -f "$VERSION_MANIFEST" ] && [ -f ".agile-flow-version" ]; then
-    VERSION_MANIFEST=".agile-flow-version"
-fi
 
 if [ -f "$VERSION_MANIFEST" ]; then
     if JQ_CMD=$(resolve_cmd jq); then

--- a/scripts/lib/overrides.sh
+++ b/scripts/lib/overrides.sh
@@ -18,11 +18,6 @@
 #     Note: bash pattern matching is greedy — `*` will cross `/`, so
 #     `scripts/*.sh` also matches `scripts/lib/overrides.sh`. Use a more
 #     specific path if you need a narrower match.
-#
-# Phase 4 rebrand (#335): the default overrides path is now .gembaflow-overrides.
-# Callers passing the legacy .agile-flow-overrides path continue to work, and
-# load_override_patterns falls back to the legacy file when called with the
-# new name on a fork that has not yet migrated.
 
 # Indexed array of patterns loaded from the overrides file.
 OVERRIDE_PATTERNS=()
@@ -35,13 +30,6 @@ OVERRIDE_PATTERNS=()
 load_override_patterns() {
   local overrides_file="${1:-.gembaflow-overrides}"
   OVERRIDE_PATTERNS=()
-
-  # Phase 4 dual-read: if the requested file does not exist but the legacy
-  # .agile-flow-overrides does, transparently use it. Keeps unmigrated forks
-  # functional for one release cycle.
-  if [ ! -f "$overrides_file" ] && [ "$overrides_file" = ".gembaflow-overrides" ] && [ -f ".agile-flow-overrides" ]; then
-    overrides_file=".agile-flow-overrides"
-  fi
 
   [ -f "$overrides_file" ] || return 0
 

--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -15,16 +15,8 @@
 
 set -euo pipefail
 
-# Phase 4 rebrand (#335): prefer .gembaflow-* dotfiles; fall back to legacy
-# .agile-flow-* names for one release cycle so unmigrated forks keep working.
 VERSION_FILE=".gembaflow-version"
-if [ ! -f "$VERSION_FILE" ] && [ -f ".agile-flow-version" ]; then
-  VERSION_FILE=".agile-flow-version"
-fi
 REPORTS_DIR=".gembaflow-reports"
-if [ ! -d "$REPORTS_DIR" ] && [ -d ".agile-flow-reports" ]; then
-  REPORTS_DIR=".agile-flow-reports"
-fi
 
 # ── Parse flags ───────────────────────────────────────────────────────────────
 
@@ -118,7 +110,7 @@ done
 # ── Verify the version manifest exists ────────────────────────────────────────
 
 if [ ! -f "$VERSION_FILE" ]; then
-  echo "ERROR: .gembaflow-version file not found (also no legacy .agile-flow-version)." >&2
+  echo "ERROR: .gembaflow-version file not found." >&2
   echo "This fork does not have upstream metadata. Run /upgrade to initialise." >&2
   exit 1
 fi

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -58,17 +58,8 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
   fi
 fi
 
-# Dual-read for the dotfile rename. Prefer the new name; fall back to the
-# legacy name for one release cycle so forks that have not yet run the
-# migration above continue to function. Cleanup ticket follows in a later PR.
 VERSION_FILE=".gembaflow-version"
-if [ ! -f "$VERSION_FILE" ] && [ -f ".agile-flow-version" ]; then
-  VERSION_FILE=".agile-flow-version"
-fi
 OVERRIDES_FILE=".gembaflow-overrides"
-if [ ! -f "$OVERRIDES_FILE" ] && [ -f ".agile-flow-overrides" ]; then
-  OVERRIDES_FILE=".agile-flow-overrides"
-fi
 RUNNING_SCRIPT_REL=$(python3 -c "import os,sys; print(os.path.relpath(os.path.realpath(sys.argv[1]), os.getcwd()))" "$0")
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -205,8 +196,7 @@ dirs = json.load(open('$VERSION_FILE')).get('syncDirectories', [])
 print('\n'.join(dirs))
 ")
 
-# Read optional `upstream` field from .gembaflow-version (or the legacy
-# .agile-flow-version during the Phase 4 dual-read cycle). Accepts either a
+# Read optional `upstream` field from .gembaflow-version. Accepts either a
 # bare "owner/repo" string or a full GitHub URL; falls back to the hardcoded
 # UPSTREAM_REPO if the field is absent or empty. This lets downstream variant
 # forks point /upgrade at their own upstream without editing this script.
@@ -481,9 +471,7 @@ fi
 
 git checkout -b "$SYNC_BRANCH"
 
-# Update the version manifest ($VERSION_FILE may be .gembaflow-version or, in
-# the dual-read fallback window, the legacy .agile-flow-version) with the new
-# version.
+# Update the version manifest with the new version.
 python3 -c "
 import json
 with open('$VERSION_FILE', 'r') as f:
@@ -495,14 +483,8 @@ with open('$VERSION_FILE', 'w') as f:
 "
 git add "$VERSION_FILE"
 
-# Write the meta-dir version stamp. Prefer the new .gembaflow-meta/ name; if
-# the legacy directory still exists alongside (shouldn't, given the migration
-# step above, but defensive), write to the new one and let the migration tidy
-# up on the next run.
+# Write the meta-dir version stamp.
 META_DIR=".gembaflow-meta"
-if [ ! -d "$META_DIR" ] && [ -d ".agile-flow-meta" ]; then
-  META_DIR=".agile-flow-meta"
-fi
 mkdir -p "$META_DIR"
 echo "$LATEST_VERSION" > "$META_DIR/version"
 git add "$META_DIR/version"

--- a/scripts/validation/validate-version-parity.sh
+++ b/scripts/validation/validate-version-parity.sh
@@ -1,16 +1,10 @@
 #!/usr/bin/env bash
-# Validates that .gembaflow-version (or the legacy .agile-flow-version during
-# the Phase 4 dual-read cycle) and package.json agree on the version field.
-# Runs in CI to prevent version drift between the two files.
+# Validates that .gembaflow-version and package.json agree on the version
+# field. Runs in CI to prevent version drift between the two files.
 
 set -euo pipefail
 
-# Phase 4 dual-read (#335): prefer .gembaflow-version; fall back to legacy
-# .agile-flow-version for one release cycle so unmigrated forks keep passing CI.
 MANIFEST=".gembaflow-version"
-if [ ! -f "$MANIFEST" ] && [ -f ".agile-flow-version" ]; then
-  MANIFEST=".agile-flow-version"
-fi
 PACKAGE="package.json"
 
 if [ ! -f "$MANIFEST" ]; then


### PR DESCRIPTION
## Summary

Phase 4 of the gembaflow rebrand (#335, PR #348) introduced a dual-read fallback in six scripts so forks running on legacy `.agile-flow-*` dotfile names continued to work during the migration window. The only active fork (`gembaflow-gcp`) has now synced PR #348 and renamed its dotfiles (verified: `gembaflow-gcp` PR #230 — main has `.gembaflow-*` only, no `.agile-flow-*`). The fallback is now dead code and is removed.

## Files changed

- `scripts/template-sync.sh` — drop dual-read for `VERSION_FILE`, `OVERRIDES_FILE`, `META_DIR`. **Kept the one-time `git mv` migration step at the top of `main()`** per ticket guardrails (still useful for long-dormant forks).
- `scripts/report-issue.sh` — drop dual-read for `VERSION_FILE`, `REPORTS_DIR`. Update misleading "(also no legacy .agile-flow-version)" error message.
- `scripts/doctor.sh` — drop dual-read for `VERSION_MANIFEST`.
- `scripts/validation/validate-version-parity.sh` — drop dual-read for `MANIFEST`.
- `scripts/lib/overrides.sh` — drop legacy file fallback in `load_override_patterns`.
- `bootstrap.sh` — drop dual-read in `installedAt` stamping and the completion banner.
- `.gembaflow-overrides` — drop the `.agile-flow-meta/` legacy entry.
- `features/report-issue.feature` + `features/steps/report_issue_steps.py` — update matchers/setup to `.gembaflow-version` so the BDD suite tests the canonical path (Phase 4's worker had left these as an inadvertent regression test of the dual-read fallback).

**Net LOC: -60 (44 insertions, 104 deletions across 9 files).**

## Out of scope (kept by design)

- The one-time migration step at the top of `template-sync.sh` `main()` (the `git mv .agile-flow-*` block) — per ticket guardrails.
- `scripts/lib/env-compat.sh` — Phase 2b env-var dual-read has a different propagation model (human-set shell vars / Codespaces secrets); will be removed by its own future cleanup ticket.
- CHANGELOG entries documenting the Phase 4 rebrand — historical record.

## Test plan

- [x] `bash scripts/template-sync.test.sh` — 14 passed, 0 failed
- [x] `uv run behave features/report-issue.feature` — 10 scenarios passed, 0 failed, 5 skipped (skips are CI-environment guards unrelated to this change)
- [x] `grep -rn "\.agile-flow-version\|\.agile-flow-meta\|\.agile-flow-overrides"` returns only: the migration step in `template-sync.sh` (intentional), CHANGELOG entries (historical), and unrelated comments in env-compat.sh (out of scope)
- [ ] CI green on the PR

Closes #349