### PR TITLE
fix(sync): add features/ to syncDirectories

### DIFF
--- a/.gembaflow-version
+++ b/.gembaflow-version
@@ -8,6 +8,7 @@
     ".claude/commands",
     ".claude/hooks",
     ".claude/skills",
+    "features",
     "scripts",
     "starters"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `features/` directory now in `syncDirectories` — downstream forks pick up upstream test updates via `/upgrade`. Forks that customize specific feature tests should add `features/<file>` to `.gembaflow-overrides`. (#362)
+
 ## [1.2.0] - 2026-05-27
 
 **The Gemba Flow rebrand release.** v1.1.0 was the redirect-safety enabler that let the GitHub repo rename happen transparently; v1.2.0 ships the rest of the rebrand — package names, env vars, dotfile names, all URLs, agent footers, workshop docs.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -59,6 +59,7 @@ The workflow runs the same sync script and opens a pull request.
    - `.claude/commands`
    - `.claude/hooks`
    - `.claude/skills`
+   - `features`
    - `scripts`
    - `starters`
 4. It creates a branch (`gembaflow-sync/v{VERSION}`), commits the changes,
@@ -68,6 +69,21 @@ The workflow runs the same sync script and opens a pull request.
 **Your code is safe.** Application code (`app/`, `__tests__/`), product docs
 (`PRODUCT-REQUIREMENTS.md`, `PRODUCT-ROADMAP.md`), deployment config
 (`render.yaml`), and other user-content files are never touched.
+
+### One-time effect on forks bootstrapped before `features/` was synced
+
+The `features/` directory holds the BDD test suite and is framework-owned. It
+was added to `syncDirectories` after the v1.2.0 rebrand (#362). Forks that
+were bootstrapped before that change still carry their original copy of
+`features/` from initial fork time and have never received upstream updates
+to it. On the next `/upgrade` after #362 lands, `template-sync.sh` will
+compare each file under `features/` and replace any that differ from the
+upstream release — pulling in renames such as `.agile-flow-version` →
+`.gembaflow-version` inside the BDD step files.
+
+If your fork has intentionally customized a specific feature test, add the
+path to `.gembaflow-overrides` (e.g. `features/steps/report_issue_steps.py`)
+before running `/upgrade` to keep your local version.
 
 ---
 
@@ -160,8 +176,8 @@ If the automated sync does not work for your setup, you can upgrade manually:
    [releases page](https://github.com/vibeacademy/gembaflow/releases).
 2. Extract the archive.
 3. Copy the framework directories (`.claude/agents`, `.claude/commands`,
-   `.claude/hooks`, `.claude/skills`, `scripts`, `starters`) into your
-   project, overwriting existing files.
+   `.claude/hooks`, `.claude/skills`, `features`, `scripts`, `starters`)
+   into your project, overwriting existing files.
 4. Update the `version` field in `.gembaflow-version` to match the release
    tag.
 5. Commit the changes and open a pull request for review.


### PR DESCRIPTION
## Summary

- Append `features` to `syncDirectories` in `.gembaflow-version` so `/upgrade` keeps the BDD suite in lockstep with upstream on downstream forks.
- Document the change in `CHANGELOG.md` (Unreleased) and `docs/UPGRADING.md`, including a note about the one-time replacement effect on forks bootstrapped before this change.
- No code change required in `scripts/template-sync.sh` — it loops generically over `syncDirectories`.

## Why

Downstream report #362: `features/report-issue.feature` and `features/steps/report_issue_steps.py` on forks still create `.agile-flow-version` fixtures because the upstream rebrand commits to those files were never propagated. `features/` was missing from `syncDirectories`, so `/upgrade` never touched the fork-local copies. Adding `features/` lets the next `/upgrade` pull the clean upstream tests.

## Breakdown

- `.gembaflow-version`: append `"features"` (alphabetical order preserved between `.claude/skills` and `scripts`).
- `CHANGELOG.md`: `### Changed` entry under `[Unreleased]`.
- `docs/UPGRADING.md`: include `features` in the synced-directory list and the manual-upgrade list; add a "One-time effect on forks bootstrapped before `features/` was synced" subsection explaining the `.gembaflow-overrides` escape hatch.

## Test plan

- [x] `scripts/template-sync.test.sh` continues to pass — tests use isolated `.gembaflow-version` fixtures, not the repo's real config, so they're unaffected.
- [x] Verified `scripts/template-sync.sh` iterates `SYNC_DIRS` generically (`while read sync_path ... done <<< "$SYNC_DIRS"`) and does blob-hash compare-and-replace per file. No code change needed.
- [ ] On a fork still on `.agile-flow-version` BDD references, running `/upgrade` after this lands should produce `UPDATED: features/report-issue.feature` and `UPDATED: features/steps/report_issue_steps.py` entries, replacing the stale content with upstream's clean copy.

Closes #362