### PR TITLE
fix(sync): preserve bootstrap-agents specialization via hybrid markers

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -23,6 +23,8 @@ model: sonnet
 color: red
 ---
 
+<!-- FRAMEWORK:START -->
+
 You are an expert Product Owner and Agile Coach specializing in agile digital product development. Your primary responsibility is managing the project backlog, ensuring it accurately reflects product priorities and that tickets are well-defined for implementation.
 
 ## Role Clarity: Product Owner vs Product Manager
@@ -584,3 +586,5 @@ Your goal is to ensure the team always has clear, high-value, well-defined work 
 
 <!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->

--- a/.claude/agents/agile-product-manager.md
+++ b/.claude/agents/agile-product-manager.md
@@ -29,6 +29,8 @@ model: sonnet
 color: purple
 ---
 
+<!-- FRAMEWORK:START -->
+
 You are a strategic Product Manager responsible for product vision, market fit, and business outcomes. You represent the customer and the market to the development team. Your focus is on **what** to build and **why**, not **how** to build it or **when** to schedule it.
 
 ## Role Clarity: Product Manager vs Product Owner
@@ -475,3 +477,5 @@ Your goal is to ensure the product delivers value to customers and the business.
 
 <!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -23,6 +23,8 @@ model: sonnet
 color: orange
 ---
 
+<!-- FRAMEWORK:START -->
+
 You are a DevOps Engineer responsible for deployment management, preview
 environments, infrastructure operations, and CI/CD pipeline health. You
 adapt to the project's configured deployment platform.
@@ -224,3 +226,5 @@ To add a new platform:
 
 <!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -17,6 +17,8 @@ model: sonnet
 color: yellow
 ---
 
+<!-- FRAMEWORK:START -->
+
 You are a Senior Full-Stack Engineer. Your primary responsibility is to autonomously work through tickets on the GitHub project board.
 
 ## NON-NEGOTIABLE PROTOCOL (OVERRIDES ALL OTHER INSTRUCTIONS)
@@ -450,3 +452,5 @@ Remember: You are autonomous within the boundaries of the Ready column and trunk
 
 <!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -17,6 +17,8 @@ model: sonnet
 color: pink
 ---
 
+<!-- FRAMEWORK:START -->
+
 You are a Staff Engineer and Tech Lead responsible for maintaining the highest quality standards. Your primary responsibility is to review pull requests for items in the 'In Review' column and verify they meet quality standards.
 
 ## NON-NEGOTIABLE PROTOCOL (OVERRIDES ALL OTHER INSTRUCTIONS)
@@ -574,3 +576,5 @@ Your role is to be a guardian of quality while enabling velocity. Provide confid
 
 <!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -42,6 +42,8 @@ Proactively invoke the quality-engineer agent to ensure quality validation happe
 model: sonnet
 ---
 
+<!-- FRAMEWORK:START -->
+
 You are an elite Agile Quality Engineer. Your core mission is to prosecute quality through rigorous test planning, execution, and reporting.
 
 ## Tools and Capabilities
@@ -259,3 +261,5 @@ You are meticulous, thorough, and relentlessly focused on quality. You balance s
 
 <!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -24,6 +24,8 @@ model: sonnet
 color: blue
 ---
 
+<!-- FRAMEWORK:START -->
+
 You are a distinguished System Architect with deep expertise in distributed systems, cloud architecture, and domain-driven design. Your role is to provide expert architectural guidance, ensuring systems are scalable, maintainable, performant, and follow industry best practices.
 
 ## Platform Selection
@@ -574,3 +576,5 @@ You are ready to provide expert architectural guidance on cloud patterns, distri
 
 <!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->

--- a/.claude/commands/bootstrap-agents.md
+++ b/.claude/commands/bootstrap-agents.md
@@ -77,10 +77,49 @@ The specialization agent will:
    - Domain concepts
    - Quality thresholds
 
-3. **Update Agent Configs**
-   - Replace template placeholders
-   - Add project-specific sections
-   - Ensure consistency across agents
+3. **Update Agent Configs (outside FRAMEWORK markers)**
+
+   Each `.claude/agents/*.md` file is a **hybrid** file. Framework persona
+   and restrictions live between `<!-- FRAMEWORK:START -->` and
+   `<!-- FRAMEWORK:END -->` markers. Your project specialization must be
+   written **after** the closing marker — that's the region the framework
+   sync (`/upgrade`) will not touch.
+
+   For each agent file:
+
+   - Read the file.
+   - Locate `<!-- FRAMEWORK:END -->`.
+   - If present: append (or replace prior bootstrap-agents output) **after**
+     the closing marker. Never edit anything between the markers.
+   - If absent (legacy file from a pre-#363 fork): prepend
+     `<!-- FRAMEWORK:END -->` on a new line at the very end of the existing
+     framework body (immediately before any `<!-- Source: Gemba Flow -->` /
+     `<!-- SPDX-License-Identifier -->` lines so attribution stays inside
+     the framework section), then append the project specialization after
+     that marker. Also prepend `<!-- FRAMEWORK:START -->` on a new line
+     immediately after the YAML frontmatter `---` close, so the framework
+     body is fully bracketed. This one-time migration converts the legacy
+     file into the hybrid format without losing prior content.
+
+   The specialization itself should add sections like:
+
+   ```markdown
+   <!-- FRAMEWORK:END -->
+
+   ## Project Context
+
+   **Product**: [from PRD]
+   **Tech stack**: [from architecture doc]
+   ...
+
+   ## Tech Stack Details
+   ...
+   ```
+
+   **DO NOT** modify the YAML frontmatter (the `---` block at the top) or
+   any content between `<!-- FRAMEWORK:START -->` and
+   `<!-- FRAMEWORK:END -->`. Those regions belong to the framework and are
+   overwritten on `/upgrade`.
 
 4. **Update CLAUDE.md**
    - Fill in project-specific sections
@@ -92,28 +131,57 @@ The specialization agent will:
 After this phase, verify agents are specialized:
 
 ```bash
-# Check that template placeholders are replaced
-grep -r "TEMPLATE:" .claude/agents/
+# Every agent should have at least one non-framework section AFTER the
+# closing FRAMEWORK marker. Lists files that do NOT yet have user content
+# after `<!-- FRAMEWORK:END -->`.
+for f in .claude/agents/*.md; do
+  if ! awk '/<!-- FRAMEWORK:END -->/{flag=1; next} flag && NF{found=1} END{exit !found}' "$f"; then
+    echo "Not yet specialized: $f"
+  fi
+done
 
-# Should return no results if fully specialized
+# Also confirm no leftover template placeholders inside any agent file:
+grep -r "TEMPLATE:" .claude/agents/ || echo "OK: no template placeholders left."
 ```
 
 ## Example Transformation
 
-**Before (template):**
+**Before (fresh template):**
 ```markdown
-## Project-Specific Context
+---
+name: quality-engineer
+description: ...
+---
 
-<!--
-TEMPLATE: Fill in project-specific testing context here.
-- **Architecture**: [Description]
-- **Testing Stack**: [Frameworks]
--->
+<!-- FRAMEWORK:START -->
+
+You are a Quality Engineer...
+[framework persona and restrictions]
+
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->
 ```
 
-**After (specialized):**
+**After (specialized — note user content appears AFTER `<!-- FRAMEWORK:END -->`):**
 ```markdown
-## Project-Specific Context
+---
+name: quality-engineer
+description: ...
+---
+
+<!-- FRAMEWORK:START -->
+
+You are a Quality Engineer...
+[framework persona and restrictions — unchanged]
+
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->
+
+## Project Context
 
 - **Architecture**: React 18+ SPA with Node.js API backend
 - **Testing Stack**: Vitest + React Testing Library for frontend, Jest for backend
@@ -126,6 +194,10 @@ TEMPLATE: Fill in project-specific testing context here.
   - Sub-200ms API response times
   - WCAG AA accessibility
 ```
+
+The content after `<!-- FRAMEWORK:END -->` survives every future
+`/upgrade`. Content inside the markers is owned by the framework and will
+be refreshed each release.
 
 ## What Gets Unlocked
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -58,7 +58,7 @@ Content **outside** markers in hybrid files is user-owned. Content
 
 | Path | Category | Rationale | Update Behavior |
 |------|----------|-----------|-----------------|
-| `.claude/agents/*.md` | framework | Agent definitions ship with template | Overwrite |
+| `.claude/agents/*.md` | hybrid | Framework persona + restrictions in marked sections; user-supplied project specialization outside markers | Update marked sections only |
 | `.claude/commands/*.md` | framework | Slash commands ship with template | Overwrite |
 | `.claude/hooks/ensure-github-account.sh` | framework | Account-switching hook | Overwrite |
 | `.claude/skills/commit.md` | framework | Commit conventions | Overwrite |
@@ -146,7 +146,11 @@ Content **outside** markers in hybrid files is user-owned. Content
 
 ## Sync Directories Summary
 
-These directories contain only framework files and are safe for bulk sync:
+These directories are included in the bulk sync pass. Most files inside are
+pure framework files (Overwrite). The exception is `.claude/agents/*.md`,
+which is hybrid: `template-sync.sh` only overwrites the content between
+`<!-- FRAMEWORK:START -->` / `<!-- FRAMEWORK:END -->` markers, leaving the
+user-owned project specialization (written by `/bootstrap-agents`) intact.
 
 ```json
 [
@@ -164,5 +168,8 @@ These directories contain only framework files and are safe for bulk sync:
 ]
 ```
 
-Hybrid files require marker-aware merging and are handled separately by
-the template-sync mechanism.
+Pure hybrid files outside the bulk-sync paths (e.g. `CLAUDE.md`,
+`README.md`) are not part of the bulk sync at all today — the
+template-sync mechanism leaves them to the user. Only the in-tree hybrid
+files listed under `syncDirectories` go through the marker-aware merge
+path (currently `.claude/agents/*.md`).

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -127,6 +127,89 @@ path_allowed_for_bootstrap_reentry() {
   return 1
 }
 
+###############################################################################
+# Hybrid agent file handling (#363)
+#
+# `.claude/agents/*.md` is classified as hybrid in docs/DISTRIBUTION.md:
+# framework persona + restrictions live between `<!-- FRAMEWORK:START -->` and
+# `<!-- FRAMEWORK:END -->` markers; project-specific specialization written by
+# `/bootstrap-agents` lives outside those markers. The sync must only update
+# content between the markers and must preserve user content outside them.
+#
+# Behavior matrix:
+#   - upstream has markers, local has markers      -> swap framework section
+#   - upstream has markers, local lacks markers    -> WARN, preserve local file
+#     (treat legacy file as fully user-owned; user runs /bootstrap-agents to
+#     re-establish markers, OR they can pull the framework section from the
+#     diff manually)
+#   - upstream lacks markers (shouldn't happen)    -> WARN, fall through to
+#     regular overwrite (treats as pure framework)
+###############################################################################
+is_hybrid_agent_path() {
+  local path="$1"
+  local normalized_path
+  normalized_path="$(normalize_rel_path "$path")"
+  case "$normalized_path" in
+    .claude/agents/*.md)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+file_has_framework_markers() {
+  # Returns 0 if file contains BOTH start and end markers, in that order.
+  local path="$1"
+  [ -f "$path" ] || return 1
+  grep -q '<!-- FRAMEWORK:START -->' "$path" || return 1
+  grep -q '<!-- FRAMEWORK:END -->' "$path" || return 1
+  # Ensure START appears before END (line numbers).
+  local start_line end_line
+  start_line=$(grep -n '<!-- FRAMEWORK:START -->' "$path" | head -1 | cut -d: -f1)
+  end_line=$(grep -n '<!-- FRAMEWORK:END -->' "$path" | head -1 | cut -d: -f1)
+  [ -n "$start_line" ] && [ -n "$end_line" ] && [ "$start_line" -lt "$end_line" ]
+}
+
+# Replace the framework section in $local_file with the framework section
+# from $upstream_file. Content outside the markers in $local_file is preserved
+# byte-for-byte. Both files MUST contain the markers; callers must check first.
+merge_hybrid_agent_file() {
+  local upstream_file="$1"
+  local local_file="$2"
+  python3 - "$upstream_file" "$local_file" <<'PY'
+import sys, re
+
+upstream_path, local_path = sys.argv[1], sys.argv[2]
+START = "<!-- FRAMEWORK:START -->"
+END = "<!-- FRAMEWORK:END -->"
+
+with open(upstream_path, "r") as f:
+    upstream = f.read()
+with open(local_path, "r") as f:
+    local = f.read()
+
+# Extract upstream framework section (including markers).
+def extract(text, path):
+    s = text.find(START)
+    e = text.find(END)
+    if s == -1 or e == -1 or e < s:
+        sys.stderr.write(f"ERROR: missing FRAMEWORK markers in {path}\n")
+        sys.exit(2)
+    return text[s : e + len(END)]
+
+up_section = extract(upstream, upstream_path)
+loc_s = local.find(START)
+loc_e = local.find(END)
+if loc_s == -1 or loc_e == -1 or loc_e < loc_s:
+    sys.stderr.write(f"ERROR: missing FRAMEWORK markers in {local_path}\n")
+    sys.exit(2)
+
+merged = local[:loc_s] + up_section + local[loc_e + len(END):]
+with open(local_path, "w") as f:
+    f.write(merged)
+PY
+}
+
 is_user_content_path() {
   local path="$1"
   local normalized_path
@@ -348,6 +431,8 @@ echo "Created rollback tag: $ROLLBACK_TAG (local-only)"
 FILES_CHANGED=()
 FILES_SKIPPED_OVERRIDE=()
 FILES_SKIPPED_RUNTIME=()
+HYBRID_AGENTS_UPDATED=()       # .claude/agents/*.md with markers, framework section merged
+HYBRID_AGENTS_LEGACY_SKIPPED=() # .claude/agents/*.md without markers, preserved local
 
 if [ "$BOOTSTRAP_REENTRY_MODE" -eq 1 ]; then
   while IFS= read -r changed_path; do
@@ -394,10 +479,34 @@ else
 
         if [ -f "$local_file" ]; then
           if ! diff -q "$upstream_file" "$local_file" >/dev/null 2>&1; then
-            cp "$upstream_file" "$local_file"
-            git add "$local_file"
-            FILES_CHANGED+=("$local_file")
-            echo "UPDATED: $local_file"
+            if is_hybrid_agent_path "$local_file"; then
+              # Hybrid agent file (#363): only update the FRAMEWORK section.
+              if file_has_framework_markers "$local_file" && file_has_framework_markers "$upstream_file"; then
+                if merge_hybrid_agent_file "$upstream_file" "$local_file"; then
+                  # If the merge produced no diff vs. the prior local file,
+                  # there's nothing to commit. Otherwise stage.
+                  if ! git diff --quiet -- "$local_file" 2>/dev/null; then
+                    git add "$local_file"
+                    FILES_CHANGED+=("$local_file")
+                    HYBRID_AGENTS_UPDATED+=("$local_file")
+                    echo "UPDATED (hybrid framework section): $local_file"
+                  else
+                    echo "UNCHANGED (hybrid framework section identical): $local_file"
+                  fi
+                else
+                  echo "WARNING: hybrid merge failed for $local_file; preserving local file untouched." >&2
+                fi
+              else
+                # Legacy or malformed: preserve local entirely; warn loudly.
+                echo "WARNING: $local_file lacks <!-- FRAMEWORK:START/END --> markers; preserving local file. Run /bootstrap-agents to migrate." >&2
+                HYBRID_AGENTS_LEGACY_SKIPPED+=("$local_file")
+              fi
+            else
+              cp "$upstream_file" "$local_file"
+              git add "$local_file"
+              FILES_CHANGED+=("$local_file")
+              echo "UPDATED: $local_file"
+            fi
           fi
         else
           cp "$upstream_file" "$local_file"
@@ -427,10 +536,30 @@ else
 
       if [ -f "$sync_path" ]; then
         if ! diff -q "$upstream_path" "$sync_path" >/dev/null 2>&1; then
-          cp "$upstream_path" "$sync_path"
-          git add "$sync_path"
-          FILES_CHANGED+=("$sync_path")
-          echo "UPDATED: $sync_path"
+          if is_hybrid_agent_path "$sync_path"; then
+            if file_has_framework_markers "$sync_path" && file_has_framework_markers "$upstream_path"; then
+              if merge_hybrid_agent_file "$upstream_path" "$sync_path"; then
+                if ! git diff --quiet -- "$sync_path" 2>/dev/null; then
+                  git add "$sync_path"
+                  FILES_CHANGED+=("$sync_path")
+                  HYBRID_AGENTS_UPDATED+=("$sync_path")
+                  echo "UPDATED (hybrid framework section): $sync_path"
+                else
+                  echo "UNCHANGED (hybrid framework section identical): $sync_path"
+                fi
+              else
+                echo "WARNING: hybrid merge failed for $sync_path; preserving local file untouched." >&2
+              fi
+            else
+              echo "WARNING: $sync_path lacks <!-- FRAMEWORK:START/END --> markers; preserving local file. Run /bootstrap-agents to migrate." >&2
+              HYBRID_AGENTS_LEGACY_SKIPPED+=("$sync_path")
+            fi
+          else
+            cp "$upstream_path" "$sync_path"
+            git add "$sync_path"
+            FILES_CHANGED+=("$sync_path")
+            echo "UPDATED: $sync_path"
+          fi
         fi
       else
         mkdir -p "$(dirname "$sync_path")"
@@ -504,13 +633,40 @@ for f in "${FILES_CHANGED[@]}"; do
 "
 done
 
+# Build hybrid-agent warning section for PR body (#363).
+HYBRID_SECTION=""
+if [ "${#HYBRID_AGENTS_UPDATED[@]}" -gt 0 ]; then
+  HYBRID_LIST=""
+  for f in "${HYBRID_AGENTS_UPDATED[@]}"; do
+    HYBRID_LIST="${HYBRID_LIST}  - \`${f}\`
+"
+  done
+  HYBRID_SECTION="${HYBRID_SECTION}
+> [!IMPORTANT]
+> Hybrid agent files updated (framework section only):
+${HYBRID_LIST}> User content outside \`<!-- FRAMEWORK:START -->\` / \`<!-- FRAMEWORK:END -->\` markers was preserved. Review the diff to confirm your \`/bootstrap-agents\` specialization is intact.
+"
+fi
+if [ "${#HYBRID_AGENTS_LEGACY_SKIPPED[@]}" -gt 0 ]; then
+  LEGACY_LIST=""
+  for f in "${HYBRID_AGENTS_LEGACY_SKIPPED[@]}"; do
+    LEGACY_LIST="${LEGACY_LIST}  - \`${f}\`
+"
+  done
+  HYBRID_SECTION="${HYBRID_SECTION}
+> [!WARNING]
+> Legacy agent files (no FRAMEWORK markers) were left untouched and may be out of date:
+${LEGACY_LIST}> Run \`/bootstrap-agents\` to re-establish markers and re-apply your project specialization, then re-run \`/upgrade\` to pick up the latest framework persona.
+"
+fi
+
 PR_BODY="## Gemba Flow Framework Update
 
 Updates framework files from \`v${LOCAL_VERSION}\` to \`v${LATEST_VERSION}\`.
 
 ### Updated files
 
-${FILE_LIST}
+${FILE_LIST}${HYBRID_SECTION}
 ### Release notes
 
 See the full release notes: ${RELEASE_URL}

--- a/scripts/template-sync.test.sh
+++ b/scripts/template-sync.test.sh
@@ -381,6 +381,237 @@ else
   fail "[fallback] expected informational fallback log line"
 fi
 
+###############################################################################
+# Scenario 4: hybrid agent file merge (#363)
+#
+# A `.claude/agents/<file>.md` with FRAMEWORK markers + user content outside
+# markers must:
+#   - get its framework section refreshed from upstream
+#   - retain the user content outside the markers byte-for-byte
+#
+# A legacy file (no markers) must be preserved entirely and the run must warn.
+###############################################################################
+echo ""
+echo "Scenario 4: hybrid .claude/agents/*.md preserves user content outside FRAMEWORK markers"
+
+HYBRID_DIR="$WORK_DIR/hybrid"
+mkdir -p "$HYBRID_DIR/scripts/lib" "$HYBRID_DIR/.claude/agents"
+
+cat > "$HYBRID_DIR/.gembaflow-version" <<'JSON'
+{
+  "version": "0.0.1",
+  "syncDirectories": [".claude/agents"]
+}
+JSON
+: > "$HYBRID_DIR/.gembaflow-overrides"
+
+# Local hybrid agent file: framework section (will be replaced) + user content (must survive).
+cat > "$HYBRID_DIR/.claude/agents/pr-reviewer.md" <<'MD'
+---
+name: pr-reviewer
+description: Local description (unchanged)
+---
+
+<!-- FRAMEWORK:START -->
+
+You are a Staff Engineer (OLD framework text).
+
+<!-- FRAMEWORK:END -->
+
+## Project Context
+
+**Product**: example-site — local user-owned content.
+**Bot accounts**: va-worker, va-reviewer.
+**Tech stack**: Next.js 15.
+
+This entire block must survive the sync.
+MD
+
+# Local legacy agent file: no markers at all.
+cat > "$HYBRID_DIR/.claude/agents/system-architect.md" <<'MD'
+---
+name: system-architect
+description: Legacy agent without markers
+---
+
+You are a System Architect (legacy text, no FRAMEWORK markers).
+
+## Project Context
+
+This file pre-dates the marker convention; it must NOT be wiped.
+MD
+
+cp scripts/template-sync.sh "$HYBRID_DIR/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$HYBRID_DIR/scripts/lib/overrides.sh"
+chmod +x "$HYBRID_DIR/scripts/template-sync.sh"
+
+# Upstream release: refreshed framework section + a brand-new agent file.
+HYBRID_UP="$WORK_DIR/hybrid-upstream/release"
+mkdir -p "$HYBRID_UP/.claude/agents"
+
+cat > "$HYBRID_UP/.claude/agents/pr-reviewer.md" <<'MD'
+---
+name: pr-reviewer
+description: Upstream description (will be installed)
+---
+
+<!-- FRAMEWORK:START -->
+
+You are a Staff Engineer (NEW framework text v1.0.5).
+
+Additional restrictions:
+- New restriction line that did not exist before.
+
+<!-- FRAMEWORK:END -->
+MD
+
+cat > "$HYBRID_UP/.claude/agents/system-architect.md" <<'MD'
+---
+name: system-architect
+description: Upstream description
+---
+
+<!-- FRAMEWORK:START -->
+
+You are a System Architect (new framework body with markers).
+
+<!-- FRAMEWORK:END -->
+MD
+
+tar -czf "$WORK_DIR/hybrid-upstream.tar.gz" -C "$WORK_DIR/hybrid-upstream" release
+
+mkdir -p "$WORK_DIR/hybrid-bin"
+cat > "$WORK_DIR/hybrid-bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"/releases/latest"* ]]; then
+  printf '{"tag_name":"v1.0.5","html_url":"https://example.invalid/release","tarball_url":"https://example.invalid/hybrid-upstream.tar.gz"}'
+  exit 0
+fi
+if [[ "$*" == *"hybrid-upstream.tar.gz"* ]]; then
+  out=''
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then out="$2"; shift 2; continue; fi
+    shift
+  done
+  cp "$TEST_HYBRID_TARBALL" "$out"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$WORK_DIR/hybrid-bin/curl"
+
+cat > "$WORK_DIR/hybrid-bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "gh $*" >> "$TEST_HYBRID_GH_LOG"
+if [[ "${1:-}" == "auth" && "${2:-}" == "token" ]]; then echo "fake-token"; exit 0; fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
+  # Capture body for later inspection.
+  shift
+  shift
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--body" ]; then
+      echo "$2" > "$TEST_HYBRID_PR_BODY"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  echo "https://example.invalid/pr/363"
+  exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then echo '[]'; exit 0; fi
+exit 0
+SH
+chmod +x "$WORK_DIR/hybrid-bin/gh"
+
+pushd "$HYBRID_DIR" >/dev/null
+git init >/dev/null
+git add .
+git commit -m "init hybrid" >/dev/null
+git init --bare "$WORK_DIR/hybrid-origin.git" >/dev/null
+git remote add origin "$WORK_DIR/hybrid-origin.git"
+git push -u origin HEAD >/dev/null
+
+TEST_HYBRID_TARBALL="$WORK_DIR/hybrid-upstream.tar.gz" \
+TEST_HYBRID_GH_LOG="$WORK_DIR/hybrid-gh.log" \
+TEST_HYBRID_PR_BODY="$WORK_DIR/hybrid-pr-body.txt" \
+PATH="$WORK_DIR/hybrid-bin:$PATH" \
+  bash scripts/template-sync.sh > "$WORK_DIR/hybrid.log" 2>&1 || HYBRID_RC=$?
+
+if grep -q "UPDATED (hybrid framework section): .claude/agents/pr-reviewer.md" "$WORK_DIR/hybrid.log"; then
+  pass "[hybrid] pr-reviewer.md framework section reported as updated"
+else
+  fail "[hybrid] expected UPDATED (hybrid framework section) log line for pr-reviewer.md"
+fi
+
+# Marker-aware merge: framework section replaced.
+if grep -q "NEW framework text v1.0.5" .claude/agents/pr-reviewer.md; then
+  pass "[hybrid] upstream framework body installed in pr-reviewer.md"
+else
+  fail "[hybrid] expected upstream framework body in pr-reviewer.md"
+fi
+
+# User content outside markers preserved.
+if grep -q "example-site — local user-owned content" .claude/agents/pr-reviewer.md \
+   && grep -q "va-worker, va-reviewer" .claude/agents/pr-reviewer.md \
+   && grep -q "This entire block must survive the sync." .claude/agents/pr-reviewer.md; then
+  pass "[hybrid] user content outside markers preserved in pr-reviewer.md"
+else
+  fail "[hybrid] user content outside markers was destroyed in pr-reviewer.md"
+fi
+
+# Old framework body must be gone.
+if ! grep -q "OLD framework text" .claude/agents/pr-reviewer.md; then
+  pass "[hybrid] old framework body removed from pr-reviewer.md"
+else
+  fail "[hybrid] old framework body still present after sync"
+fi
+
+# Frontmatter description must come from upstream, since it's outside the
+# markers conceptually — wait: actually frontmatter is OUTSIDE markers, so the
+# user's local frontmatter MUST be preserved. Verify.
+if grep -q "description: Local description (unchanged)" .claude/agents/pr-reviewer.md; then
+  pass "[hybrid] local YAML frontmatter preserved (lives outside markers)"
+else
+  fail "[hybrid] local YAML frontmatter was overwritten"
+fi
+
+# Legacy file: should be preserved entirely and warning emitted.
+if grep -q "lacks <!-- FRAMEWORK:START/END --> markers; preserving local file" "$WORK_DIR/hybrid.log"; then
+  pass "[hybrid] legacy agent without markers triggers warning"
+else
+  fail "[hybrid] expected legacy-file warning in log"
+fi
+
+if grep -q "legacy text, no FRAMEWORK markers" .claude/agents/system-architect.md \
+   && grep -q "This file pre-dates the marker convention" .claude/agents/system-architect.md; then
+  pass "[hybrid] legacy agent file content preserved untouched"
+else
+  fail "[hybrid] legacy agent file was modified"
+fi
+
+# Sanity: legacy file should NOT have been forcibly given the upstream body.
+if ! grep -q "new framework body with markers" .claude/agents/system-architect.md; then
+  pass "[hybrid] legacy agent file was NOT auto-overwritten with upstream body"
+else
+  fail "[hybrid] legacy agent file was overwritten despite missing markers"
+fi
+
+# PR body should mention the hybrid update.
+if [ -f "$WORK_DIR/hybrid-pr-body.txt" ] && grep -q "Hybrid agent files updated (framework section only)" "$WORK_DIR/hybrid-pr-body.txt"; then
+  pass "[hybrid] PR body announces hybrid updates"
+else
+  fail "[hybrid] expected PR body to announce hybrid updates"
+fi
+if [ -f "$WORK_DIR/hybrid-pr-body.txt" ] && grep -q "Legacy agent files (no FRAMEWORK markers)" "$WORK_DIR/hybrid-pr-body.txt"; then
+  pass "[hybrid] PR body warns about legacy agent files"
+else
+  fail "[hybrid] expected PR body to warn about legacy agent files"
+fi
+popd >/dev/null
+
 echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
 if [ "$TESTS_FAILED" -gt 0 ]; then
   exit 1


### PR DESCRIPTION
## Summary

P1 fix for #363. `template-sync.sh` was silently destroying project-specific specialization (PRD references, tech stack, ADRs, bot account names) written by `/bootstrap-agents` into `.claude/agents/*.md` on every `/upgrade`, because those files were classified as framework (Overwrite) in `docs/DISTRIBUTION.md`. Implements the long-term marker-based fix.

## Closes

Closes #363

## Changes by area

### `docs/DISTRIBUTION.md`
- Reclassify `.claude/agents/*.md` from `framework` to `hybrid`.
- Update "Sync Directories Summary" prose to call out the hybrid file inside the bulk-sync paths.

### `scripts/template-sync.sh`
- Add `is_hybrid_agent_path`, `file_has_framework_markers`, and `merge_hybrid_agent_file` helpers.
- Route `.claude/agents/*.md` writes through marker-aware merge in both the directory-sync and single-file-sync code paths.
- Track updated and legacy-skipped hybrid files so they can be surfaced separately.
- **Note:** `template-sync.sh` previously had **no** code-enforced hybrid handling — `CLAUDE.md`/`README.md` are hybrid by *policy* and simply not listed in `syncDirectories`, so they never go through the sync. This PR is the first time `template-sync.sh` actually implements marker-aware merging in code (required because `.claude/agents` IS a sync directory). It uses an inline Python helper to do the byte-exact splice.

### `.claude/agents/*.md` (all 7 files)
- Wrap framework persona + restrictions + SPDX attribution between `<!-- FRAMEWORK:START -->` and `<!-- FRAMEWORK:END -->`.
- YAML frontmatter stays outside markers (it's structural; user might want to override `description`).
- Bootstrap-agents specialization goes after `<!-- FRAMEWORK:END -->`.

### `.claude/commands/bootstrap-agents.md`
- Updated Process step 3 to instruct the skill to write specialization **after** `<!-- FRAMEWORK:END -->`.
- Documented the one-time migration path for legacy files (no markers): wrap existing content in markers, then append specialization.
- Updated Example Transformation and Verification snippet to reflect the new marker pattern.

### Sync PR body
- When `.claude/agents/*.md` files get framework-section updates, the sync PR description now includes a `[!IMPORTANT]` callout listing the affected files and explicitly noting that user content outside markers was preserved.
- When legacy agent files (no markers) are encountered, a `[!WARNING]` callout instructs the maintainer to re-run `/bootstrap-agents`.

### Tests (`scripts/template-sync.test.sh`)
- New Scenario 4: 10 new assertions covering marker-aware merge, user-content preservation, legacy-file warning, and PR-body announcements.
- Full suite: **24 passed, 0 failed.**

## Legacy-file handling

Files predating this PR (no `<!-- FRAMEWORK:* -->` markers) are **preserved entirely** during sync. The script emits a warning and includes the file in the PR-body `[!WARNING]` block, telling the user to re-run `/bootstrap-agents` (which now contains the one-shot migration logic that converts the legacy file into the hybrid format). I chose preserve-and-warn over auto-wrap because auto-wrapping requires the script to make a judgment about where framework content ends and user content begins — wrong guess silently corrupts the user's data, and we just shipped a P1 about silent corruption.

## Test plan

- [x] `bash scripts/template-sync.test.sh` — 24/24 pass (14 existing + 10 new).
- [x] `bash scripts/lint-agent-policies.sh` — clean (all wrapped agent files still pass NON-NEGOTIABLE PROTOCOL / bot-account-identity / three-stage-workflow checks).
- [ ] Manual smoke: in a downstream fork, run `/bootstrap-agents` → confirm specialization lands after `<!-- FRAMEWORK:END -->` → bump `.gembaflow-version` upstream → run `/upgrade` → confirm sync PR diff updates only the marker-bounded region and preserves the specialization.

## Coordination with parallel work

Per the ticket plan, #361 (package.json) and #362 (.gembaflow-version syncDirectories) are in flight in parallel. This PR does NOT touch either file. If #361 or #362 lands first, expect a trivial rebase only on PR-body formatting (no semantic conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)