### PR TITLE
fix(bootstrap+sync): set .gembaflow-version on install; short-circuit placeholder /upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fresh forks no longer stage a no-op first `/upgrade`** (#381). `bootstrap.sh` now looks up the latest upstream release tag via `gh release view` and sets `.gembaflow-version` `version` alongside `installedAt` on first install. If the lookup fails (no network, no `gh` auth), bootstrap falls back to the previous behavior and prints a warning recommending `/upgrade`. As a safety net, `scripts/template-sync.sh` now detects the fresh-fork placeholder case (`version == "0.1.0"` with `installedAt` already stamped) and short-circuits: it writes the latest tag into the manifest locally and exits 0 without generating a sync PR. Legitimately-behind forks (e.g. `version: 1.2.0`) still sync normally.
+
 ## [1.3.0] - 2026-05-28
 
 **Adds the `/eli5` slash command to the framework.** Minor version bump because this is a user-visible new operator capability.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -934,7 +934,9 @@ phase4_workflow() {
     mark_phase_complete "phase4"
     print_success "Phase 4 complete! Workflow activated."
 
-    # Stamp installedAt in the version manifest if not already set.
+    # Stamp installedAt AND set version to the latest upstream release tag on
+    # first install. Without this, every fresh fork starts at the placeholder
+    # "version": "0.1.0" and the first /upgrade generates a no-op sync PR (#381).
     local af_manifest=".gembaflow-version"
     if [ -f "$af_manifest" ]; then
         local current_val
@@ -942,9 +944,36 @@ phase4_workflow() {
         if [ "$current_val" = "null" ]; then
             local timestamp
             timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            jq --arg ts "$timestamp" '.installedAt = $ts' "$af_manifest" > "$af_manifest.tmp" \
-                && mv "$af_manifest.tmp" "$af_manifest"
-            print_success "Stamped install time: $timestamp"
+
+            # Look up the latest release tag from the upstream repo. The
+            # `upstream` field accepts either a bare "owner/repo" or a full
+            # GitHub URL (https or git@); normalize both forms.
+            local upstream
+            upstream=$(jq -r '.upstream // empty' "$af_manifest" 2>/dev/null \
+                | sed -e 's|^https://github.com/||' \
+                      -e 's|^http://github.com/||' \
+                      -e 's|^git@github.com:||' \
+                      -e 's|\.git$||' \
+                      -e 's|/$||')
+            [ -z "$upstream" ] && upstream="vibeacademy/gembaflow"
+
+            local latest_version=""
+            if command -v gh >/dev/null 2>&1; then
+                latest_version=$(gh release view --repo "$upstream" --json tagName --jq '.tagName | sub("^v"; "")' 2>/dev/null || echo "")
+            fi
+
+            if [ -n "$latest_version" ]; then
+                jq --arg ts "$timestamp" --arg ver "$latest_version" \
+                    '.installedAt = $ts | .version = $ver' "$af_manifest" > "$af_manifest.tmp" \
+                    && mv "$af_manifest.tmp" "$af_manifest"
+                print_success "Stamped install time: $timestamp; version: $latest_version"
+            else
+                # Fallback: stamp installedAt only. Template-sync.sh's
+                # placeholder short-circuit will fix version on next /upgrade.
+                jq --arg ts "$timestamp" '.installedAt = $ts' "$af_manifest" > "$af_manifest.tmp" \
+                    && mv "$af_manifest.tmp" "$af_manifest"
+                print_warning "Could not look up latest release from $upstream; version field unchanged. Run /upgrade to sync."
+            fi
         fi
     fi
 }

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -339,6 +339,40 @@ TARBALL_URL=$(echo "$RELEASE_JSON" | python3 -c "import json,sys; print(json.loa
 echo "Latest version: $LATEST_VERSION"
 
 ###############################################################################
+# 2a. Fresh-fork placeholder short-circuit (#381)
+#
+# Every fresh fork starts at ".gembaflow-version" version "0.1.0" — the template
+# placeholder. If bootstrap.sh ran but couldn't set the version (e.g. network
+# failure on `gh release view`), installedAt is stamped but version stays at
+# "0.1.0". Without this short-circuit, every such fork's first /upgrade syncs
+# from "0.1.0" to the actual latest release tag, generating a no-op PR.
+#
+# Detect this case (placeholder version + installedAt stamped) and just bump
+# the version field locally — no PR, no churn. Legitimately-behind forks
+# (version like "1.2.0" with a real installedAt) fall through to normal sync.
+###############################################################################
+INSTALLED_AT=$(python3 -c "import json; print(json.load(open('$VERSION_FILE')).get('installedAt') or '')")
+if [ "$LOCAL_VERSION" = "0.1.0" ] && [ -n "$INSTALLED_AT" ]; then
+  echo "INFO: detected fresh-fork placeholder version; setting LOCAL_VERSION to latest without sync." >&2
+  if command -v jq >/dev/null 2>&1; then
+    jq --arg ver "$LATEST_VERSION" '.version = $ver' "$VERSION_FILE" > "$VERSION_FILE.tmp" \
+      && mv "$VERSION_FILE.tmp" "$VERSION_FILE"
+  else
+    python3 - <<PY
+import json
+with open("$VERSION_FILE") as f:
+    data = json.load(f)
+data["version"] = "$LATEST_VERSION"
+with open("$VERSION_FILE", "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PY
+  fi
+  echo "Already up to date (fresh-fork initialized to v${LATEST_VERSION})."
+  exit 0
+fi
+
+###############################################################################
 # 3. Compare versions
 ###############################################################################
 if [ "$LOCAL_VERSION" = "$LATEST_VERSION" ]; then

--- a/scripts/template-sync.test.sh
+++ b/scripts/template-sync.test.sh
@@ -782,6 +782,224 @@ else
 fi
 popd >/dev/null
 
+###############################################################################
+# Scenario 7: fresh-fork placeholder short-circuit (#381)
+#
+# A fresh fork has .gembaflow-version version "0.1.0" with installedAt stamped
+# by bootstrap (network was up to stamp the timestamp but `gh release view`
+# fell through, OR this exercises template-sync's safety net regardless).
+# Expectations:
+#   - template-sync exits 0
+#   - .gembaflow-version version is rewritten to the (mocked) latest tag
+#   - no sync branch / PR is created
+#   - the INFO log line is emitted
+###############################################################################
+echo ""
+echo "Scenario 7: fresh-fork placeholder short-circuit (#381)"
+
+PLACEHOLDER_DIR="$WORK_DIR/placeholder"
+mkdir -p "$PLACEHOLDER_DIR/scripts/lib"
+cp scripts/template-sync.sh "$PLACEHOLDER_DIR/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$PLACEHOLDER_DIR/scripts/lib/overrides.sh"
+chmod +x "$PLACEHOLDER_DIR/scripts/template-sync.sh"
+: > "$PLACEHOLDER_DIR/.gembaflow-overrides"
+
+cat > "$PLACEHOLDER_DIR/.gembaflow-version" <<'JSON'
+{
+  "version": "0.1.0",
+  "upstream": "vibeacademy/gembaflow",
+  "installedAt": "2026-05-28T12:00:00Z",
+  "syncDirectories": ["./scripts"]
+}
+JSON
+
+mkdir -p "$WORK_DIR/placeholder-bin"
+cat > "$WORK_DIR/placeholder-bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"/releases/latest"* ]]; then
+  printf '{"tag_name":"v1.3.0","html_url":"https://example.invalid/release","tarball_url":"https://example.invalid/placeholder.tar.gz"}'
+  exit 0
+fi
+# Any tarball download in this scenario is a bug — short-circuit should fire
+# BEFORE the download step.
+echo "ERROR: tarball download attempted in placeholder scenario" >&2
+exit 1
+SH
+chmod +x "$WORK_DIR/placeholder-bin/curl"
+
+cat > "$WORK_DIR/placeholder-bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "gh $*" >> "$TEST_PLACEHOLDER_GH_LOG"
+if [[ "${1:-}" == "auth" && "${2:-}" == "token" ]]; then echo "fake-token"; exit 0; fi
+exit 0
+SH
+chmod +x "$WORK_DIR/placeholder-bin/gh"
+
+pushd "$PLACEHOLDER_DIR" >/dev/null
+git init >/dev/null
+git -c user.name=test -c user.email=t@t.invalid add .
+git -c user.name=test -c user.email=t@t.invalid commit -m "init placeholder" >/dev/null
+git init --bare "$WORK_DIR/placeholder-origin.git" >/dev/null
+git remote add origin "$WORK_DIR/placeholder-origin.git"
+git push -u origin HEAD >/dev/null
+
+if TEST_PLACEHOLDER_GH_LOG="$WORK_DIR/placeholder-gh.log" \
+   PATH="$WORK_DIR/placeholder-bin:$PATH" \
+   bash scripts/template-sync.sh > "$WORK_DIR/placeholder.log" 2>&1; then
+  pass "placeholder short-circuit exits 0"
+
+  PLACEHOLDER_VERSION_AFTER=$(python3 -c "import json; print(json.load(open('.gembaflow-version'))['version'])")
+  if [ "$PLACEHOLDER_VERSION_AFTER" = "1.3.0" ]; then
+    pass "placeholder: .gembaflow-version version updated to 1.3.0"
+  else
+    fail "placeholder: expected version 1.3.0, got: $PLACEHOLDER_VERSION_AFTER"
+  fi
+
+  if grep -q "detected fresh-fork placeholder version" "$WORK_DIR/placeholder.log"; then
+    pass "placeholder: INFO log line emitted"
+  else
+    fail "placeholder: expected 'detected fresh-fork placeholder version' in log"
+  fi
+
+  if grep -q "Already up to date (fresh-fork initialized to v1.3.0)" "$WORK_DIR/placeholder.log"; then
+    pass "placeholder: short-circuit message emitted"
+  else
+    fail "placeholder: expected 'Already up to date (fresh-fork initialized to v1.3.0)' in log"
+  fi
+
+  if git --git-dir "$WORK_DIR/placeholder-origin.git" show-ref --verify --quiet refs/heads/gembaflow-sync/v1.3.0; then
+    fail "placeholder: unexpected sync branch pushed to origin"
+  else
+    pass "placeholder: no sync branch created on origin"
+  fi
+
+  if ! grep -q "gh pr create" "$WORK_DIR/placeholder-gh.log" 2>/dev/null; then
+    pass "placeholder: no gh pr create call"
+  else
+    fail "placeholder: unexpected gh pr create call"
+  fi
+else
+  cat "$WORK_DIR/placeholder.log"
+  fail "placeholder scenario script exited non-zero"
+fi
+popd >/dev/null
+
+###############################################################################
+# Scenario 8: legitimately-behind fork still syncs (#381)
+#
+# version "1.2.0" with a real installedAt; latest is "1.3.0". This must
+# proceed through the normal sync flow — the placeholder short-circuit must
+# NOT fire (LOCAL_VERSION != "0.1.0").
+###############################################################################
+echo ""
+echo "Scenario 8: legitimately-behind fork (#381 negative test) — normal sync flow"
+
+BEHIND_DIR="$WORK_DIR/behind"
+mkdir -p "$BEHIND_DIR/scripts/lib"
+cp scripts/template-sync.sh "$BEHIND_DIR/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$BEHIND_DIR/scripts/lib/overrides.sh"
+chmod +x "$BEHIND_DIR/scripts/template-sync.sh"
+: > "$BEHIND_DIR/.gembaflow-overrides"
+
+cat > "$BEHIND_DIR/.gembaflow-version" <<'JSON'
+{
+  "version": "1.2.0",
+  "upstream": "vibeacademy/gembaflow",
+  "installedAt": "2026-05-25T08:00:00Z",
+  "syncDirectories": ["./scripts"]
+}
+JSON
+
+# Upstream tarball includes a non-runtime-protected file under scripts/ that
+# DIFFERS from the local copy — so the sync has real work to do and the normal
+# sync flow proceeds to gh pr create.
+mkdir -p "$WORK_DIR/behind-upstream/release/scripts/lib"
+cp scripts/template-sync.sh "$WORK_DIR/behind-upstream/release/scripts/template-sync.sh"
+cp scripts/lib/overrides.sh "$WORK_DIR/behind-upstream/release/scripts/lib/overrides.sh"
+echo "#!/usr/bin/env bash" > "$WORK_DIR/behind-upstream/release/scripts/example.sh"
+echo "echo upstream-v1.3.0" >> "$WORK_DIR/behind-upstream/release/scripts/example.sh"
+echo "#!/usr/bin/env bash" > "$BEHIND_DIR/scripts/example.sh"
+echo "echo local-v1.2.0" >> "$BEHIND_DIR/scripts/example.sh"
+chmod +x "$WORK_DIR/behind-upstream/release/scripts/example.sh" "$BEHIND_DIR/scripts/example.sh"
+tar -czf "$WORK_DIR/behind-upstream.tar.gz" -C "$WORK_DIR/behind-upstream" release
+
+mkdir -p "$WORK_DIR/behind-bin"
+cat > "$WORK_DIR/behind-bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"/releases/latest"* ]]; then
+  printf '{"tag_name":"v1.3.0","html_url":"https://example.invalid/release","tarball_url":"https://example.invalid/behind-upstream.tar.gz"}'
+  exit 0
+fi
+if [[ "$*" == *"behind-upstream.tar.gz"* ]]; then
+  out=''
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then out="$2"; shift 2; continue; fi
+    shift
+  done
+  cp "$TEST_BEHIND_TARBALL" "$out"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$WORK_DIR/behind-bin/curl"
+
+cat > "$WORK_DIR/behind-bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "gh $*" >> "$TEST_BEHIND_GH_LOG"
+if [[ "${1:-}" == "auth" && "${2:-}" == "token" ]]; then echo "fake-token"; exit 0; fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
+  echo "https://example.invalid/pr/381"
+  exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+  echo '[]'
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$WORK_DIR/behind-bin/gh"
+
+pushd "$BEHIND_DIR" >/dev/null
+git init >/dev/null
+git -c user.name=test -c user.email=t@t.invalid add .
+git -c user.name=test -c user.email=t@t.invalid commit -m "init behind" >/dev/null
+git init --bare "$WORK_DIR/behind-origin.git" >/dev/null
+git remote add origin "$WORK_DIR/behind-origin.git"
+git push -u origin HEAD >/dev/null
+
+if TEST_BEHIND_TARBALL="$WORK_DIR/behind-upstream.tar.gz" \
+   TEST_BEHIND_GH_LOG="$WORK_DIR/behind-gh.log" \
+   PATH="$WORK_DIR/behind-bin:$PATH" \
+   bash scripts/template-sync.sh > "$WORK_DIR/behind.log" 2>&1; then
+  pass "behind-fork sync exits 0"
+
+  if grep -q "detected fresh-fork placeholder version" "$WORK_DIR/behind.log"; then
+    fail "behind-fork: placeholder short-circuit fired but should NOT have"
+  else
+    pass "behind-fork: placeholder short-circuit did NOT fire"
+  fi
+
+  if grep -q "Update available: 1.2.0 -> 1.3.0" "$WORK_DIR/behind.log"; then
+    pass "behind-fork: normal sync flow entered"
+  else
+    fail "behind-fork: expected 'Update available: 1.2.0 -> 1.3.0' in log"
+  fi
+
+  if grep -q "gh pr create" "$WORK_DIR/behind-gh.log" 2>/dev/null; then
+    pass "behind-fork: gh pr create invoked"
+  else
+    fail "behind-fork: expected gh pr create call (normal sync flow)"
+  fi
+else
+  cat "$WORK_DIR/behind.log"
+  fail "behind-fork scenario script exited non-zero"
+fi
+popd >/dev/null
+
 echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
 if [ "$TESTS_FAILED" -gt 0 ]; then
   exit 1


### PR DESCRIPTION
## Summary

Two-part fix for #381 — every fresh fork starts at the placeholder `.gembaflow-version` `"version": "0.1.0"` and the first `/upgrade` generates a no-op sync PR. The fix sets `version` at install time AND adds a safety net in template-sync for forks where bootstrap couldn't reach the network.

- **`bootstrap.sh`** (lines ~937-979): on first install (when `installedAt` is null), look up the latest release via `gh release view --repo <upstream> --json tagName --jq '.tagName | sub("^v"; "")'` and set both `installedAt` and `version` in one `jq` pass. The `upstream` field is accepted as bare `owner/repo` OR a full URL (`https://`, `http://`, `git@`); normalized via `sed`. Falls back to the existing `installedAt`-only behavior with a one-line warning when `gh release view` fails (no network, no auth, no `gh`).
- **`scripts/template-sync.sh`** (lines ~341-373): after `LOCAL_VERSION` and `LATEST_VERSION` are known, detect `LOCAL_VERSION == "0.1.0"` AND `installedAt != null` — the fresh-fork placeholder case. Write `LATEST_VERSION` into `.gembaflow-version` locally, log `INFO: detected fresh-fork placeholder version; setting LOCAL_VERSION to latest without sync.`, and exit 0 with `Already up to date (fresh-fork initialized to v${LATEST_VERSION})`. Legitimately-behind forks (e.g. `version: 1.2.0` with a real `installedAt`) fall through to normal sync.
- **`CHANGELOG.md`**: entry under `[Unreleased]`.

Strict guardrails honored:
- `version` field is **not** removed or renamed anywhere.
- The placeholder `"0.1.0"` value in the template's `.gembaflow-version` is **unchanged** — that string is the marker the short-circuit looks for.
- Behind-fork sync is verified by negative test (Scenario 8).
- The fix to `template-sync.sh` doesn't reach existing forks until #371 is resolved (runtime-protected). That's known.

## Test plan

`bash scripts/template-sync.test.sh` — 39 pass, 0 fail.

- [x] **Scenario 7 (new) — fresh-fork placeholder short-circuit**: `.gembaflow-version` with `version: 0.1.0` and `installedAt: "2026-05-28T12:00:00Z"`; mocked release returns `v1.3.0`. Verifies:
  - script exits 0
  - `.gembaflow-version` `version` rewritten to `1.3.0`
  - INFO log line emitted
  - `Already up to date (fresh-fork initialized to v1.3.0)` printed
  - no sync branch pushed to origin
  - no `gh pr create` call
- [x] **Scenario 8 (new) — legitimately-behind fork**: `.gembaflow-version` with `version: 1.2.0`, `installedAt: "2026-05-25T08:00:00Z"`; mocked release returns `v1.3.0`. Verifies:
  - placeholder short-circuit does NOT fire
  - normal sync flow enters (`Update available: 1.2.0 -> 1.3.0`)
  - `gh pr create` is invoked
- [x] All 6 pre-existing scenarios (runtime-protected, bootstrap re-entry, configurable upstream + fallback, hybrid agents, package.json bump, idempotent re-run) still pass.
- [x] `uv sync --extra dev` succeeds; `uv run --extra dev ruff check .` clean.

Manual smoke is implicit in Scenario 7: a fresh fork after bootstrap with a placeholder version + stamped `installedAt` runs `/upgrade` and gets a no-PR fast-path that just updates the local version.

## Notes / surprises

- `bootstrap.sh` line range now ends at ~979 (was 949). The structure matched the ticket's code-shape suggestion exactly; the diff is additive.
- The `installedAt` already-null check at line 943 has no bug — `jq -r '.installedAt // "null"'` returns the literal string `"null"` when the JSON value is `null`, and the next `[ "$current_val" = "null" ]` test matches correctly. If `jq` itself fails (no jq), `current_val` is empty and the block is skipped — safe fallback.
- I omitted the optional Scenario 9 (`bootstrap.sh` first-install version stamp in isolation). The block lives inside `phase4_workflow` which has many side effects; extracting just the snippet would mean duplicating it in a fixture, drifting from the real code. Scenarios 7+8 cover both code paths (success: bootstrap stamps version; failure: template-sync's safety net stamps it) without that duplication.

Closes #381