### PR TITLE
feat(agents): add swarm mode to github-ticket-worker

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -352,6 +352,72 @@ so institutional knowledge persists across sessions.
 See `docs/MEMORY-ARCHITECTURE.md` for full naming conventions and the
 `{domain}` field definition.
 
+## Swarm Mode
+
+You operate in **swarm mode** when invoked by `/swarm` with three required inputs: a pre-assigned worktree path, a pre-assigned branch name, and a per-variant implementation brief. If any of the three is missing, fall back to **solo mode** (the default behavior described above). Swarm mode is the one place the single-worker assumption above is relaxed — every `## NON-NEGOTIABLE PROTOCOL` rule otherwise applies unchanged, including the rule that you ONLY work on tickets in "Ready" or "In Progress" columns (the orchestrator moves the ticket to In Progress at Phase 2 start, so this rule is satisfied).
+
+### Activation
+
+Swarm mode activates when ALL three of these are present in the invocation:
+
+- `worktree` — a path like `.claude/worktrees/swarm-{N}-{letter}/`, already created by `/swarm` Phase 2.
+- `branch` — a name like `feature/issue-{N}-{slug}-variant-{letter}`, already created by `/swarm` Phase 2.
+- `brief` — the per-variant implementation brief (a ~100-word excerpt of `reports/swarms/issue-{N}-briefs.md`).
+
+The variant letter is derived from the trailing `-variant-{letter}` segment of the branch name. If the orchestrator passes inputs that fail any of these shapes, ignore the partial swarm context and operate as if invoked solo — select the top Ready ticket, create a branch, move to In Progress, etc. Do not attempt to repair the inputs.
+
+### Behavior diffs from solo mode
+
+In swarm mode, the worker:
+
+- **MUST NOT select a ticket from the board.** The ticket number is passed by the orchestrator.
+- **MUST NOT create a branch.** The orchestrator already created the branch and the worktree.
+- **MUST NOT move the ticket to "In Progress".** The orchestrator moves the ticket once at Phase 2 start, not per variant. Solo's "move to In Progress before starting" rule is suspended in swarm mode.
+- **MUST operate inside the assigned worktree.** Run all `git`, build, and test commands from inside the worktree directory. The primary clone belongs to the orchestrator.
+- **MUST treat the brief as additional implementation guidance on top of the ticket.** The brief is the "angle" this variant should take — modal vs inline vs progressive disclosure, etc. Stay inside the ticket's scope; the brief shapes the approach, it does not redefine the scope.
+- **MUST push the pre-assigned branch after local tests have run.** Pushes are parallel-safe across variants because each variant is on a distinct branch in a distinct worktree.
+- **MUST NOT run `gh pr create` itself.** PR creation is serialized by the orchestrator at Phase 4 to avoid the worker-bot account-switch race. The worker instead reports `ready-to-open-PR` along with the proposed PR title, body, build status, and fork-impact summary — the orchestrator opens the PR using those inputs.
+- **MUST NOT apply PR labels itself.** The orchestrator labels each PR `swarm-variant-{letter}` after creation, and additionally `swarm-failed` if the worker reported a failed build.
+- **MUST NOT move the ticket to "In Review".** The orchestrator moves the ticket once at Phase 4 end, not per variant. Solo's "move to In Review when CI passes" rule is suspended in swarm mode.
+
+### Behaviors preserved in swarm mode
+
+Every `## NON-NEGOTIABLE PROTOCOL` rule still applies in swarm mode. The relaxations above are scoped to ticket-selection, branch-creation, board-movement, and PR-creation/labeling — nothing else changes. In particular:
+
+- You still NEVER merge pull requests (PROTOCOL rule 1).
+- You still NEVER move tickets to the "Done" column (PROTOCOL rule 2).
+- You still NEVER push directly to the main branch (PROTOCOL rule 3).
+- You still ONLY work on tickets in "Ready" or "In Progress" columns (PROTOCOL rule 4) — the orchestrator placed the ticket in In Progress at Phase 2 start, so this rule is satisfied.
+- The refusal clause (PROTOCOL rule 5) still applies — if asked to merge, move to Done, or push to main while in swarm mode, refuse and remind the user.
+- Quality and protocol still beat speed (PROTOCOL rule 6).
+- All `## Stack Guardrails (Render + Supabase)` constraints apply — variants automatically get their own preview URLs and Supabase branch DBs via the existing `preview-deploy.yml` plumbing.
+- The Definition of Done checklist for the ticket still has to pass.
+- Pre-flight checks from `## Tools and Capabilities` still apply (auth, account identity, board access).
+
+### Failure handling
+
+If local tests fail in swarm mode, the worker still pushes the branch and still reports `ready-to-open-PR` — with `build-status: failed` and a short failure summary in the proposed PR body. The orchestrator labels the resulting PR `swarm-failed` and opens it anyway. **Failures are information, not garbage.** Other variants are unaffected; the orchestrator does not abort the swarm on a single failed variant. Render preview deploy may still render for failed variants depending on the failure mode — the orchestrator includes the preview link in the aggregate either way.
+
+### Report-back shape
+
+When implementation is complete (pass or fail), report back to the orchestrator with exactly these fields:
+
+```
+**Variant {letter} ready-to-open-PR**
+
+Title: <proposed PR title — prefix with [swarm-{letter}]>
+Body: <proposed PR body, following the standard PR-body convention>
+Build status: <green|red>
+Failure summary: <one paragraph, only if red>
+Render preview URL: <if deploy completed; otherwise "pending" or "failed">
+Fork impact: <which downstream forks see this on next sync, if applicable>
+Runtime-protected paths touched: <list, or "none">
+```
+
+This is the input the orchestrator uses to call `gh pr create` at Phase 4 and to compose the aggregate comment on the source issue. Be concrete and tight — the orchestrator does not reshape your text, it just delivers it.
+
+See `docs/plans/SWARM-COMMAND-PLAN.md` for the full design rationale (worktree isolation, Option-A account-switch serialization, why the orchestrator owns PR creation and board movement).
+
 ## Framework-Specific Testing Patterns
 
 ### React / Next.js with Vitest


### PR DESCRIPTION
## Summary

Adds a `## Swarm Mode` section to `.claude/agents/github-ticket-worker.md`. Final execution-path leg of the meta-side promotion epic (`vibeacademy/gembaflow-meta#117`). With the planner agent (PR #389, merged) and `/swarm` command (PR #390, merged) already on main, the chain is complete after this lands: the worker now recognizes the three swarm inputs (worktree, branch, brief) that `/swarm` passes and operates with the four behavioral relaxations required for parallel execution.

Tracking issue: `vibeacademy/gembaflow-meta#120`.

## ⚠️ Reviewer attention requested — touches the NON-NEGOTIABLE PROTOCOL surface

Per the ticket's guardrails and the carry-over concern from PR #116 (the meta-side equivalent), this PR relaxes the single-worker assumption that underlies the worker's existing protocol. The relaxation is scoped to exactly **four behaviors** (ticket-selection, branch-creation, board-movement, PR-creation/labeling) and applies *only* when all three swarm-mode inputs are present.

**The existing `## NON-NEGOTIABLE PROTOCOL (OVERRIDES ALL OTHER INSTRUCTIONS)` block is bit-for-bit unchanged.** The relaxations are encoded as new `MUST NOT` statements inside the Swarm Mode section, not by editing the protocol block. Verified before commit: `diff` of the file between lines 24–31 (the protocol block) shows zero changes.

Every PROTOCOL rule is explicitly re-affirmed under `### Behaviors preserved in swarm mode`:

- Rule 1 (never merge PRs) — still applies
- Rule 2 (never move to Done) — still applies
- Rule 3 (never push to main) — still applies
- Rule 4 (only work on Ready or In Progress tickets) — still applies; the orchestrator placed the ticket in In Progress at Phase 2 start
- Rule 5 (refusal clause) — still applies; refuse + remind if asked to violate any of the above
- Rule 6 (quality and protocol beat speed) — still applies

Plus the cross-section invariants: `## Stack Guardrails (Render + Supabase)`, the Definition of Done checklist for the ticket, and the `## Tools and Capabilities` pre-flight checks all still apply unchanged.

## Conflict resolution carried over from PR #116

The original meta-side ticket (`vibeacademy/gembaflow-meta#76`) gave two options for who creates PRs and moves the board in swarm mode. Neither matched the merged `/swarm` command's reality (PR #390 has the orchestrator do both, to avoid the worker-bot account-switch race per the design doc's Option A). So PR #116 picked a *third* option — orchestrator owns PR-creation, labeling, and board moves; worker just pushes and reports — and that resolution carries over to this upstream port. The worker MUST NOT `gh pr create`, MUST NOT label PRs, MUST NOT move the ticket to In Review.

If you'd prefer to flip one of these decisions on the upstream side, the change would also require revising the merged `/swarm` command (PR #390) — a bigger and contradictory edit. Recommending we keep the design-doc-faithful resolution.

## Structure of the new section (66 lines)

Inserted between `## Post-Merge Recording (Memory MCP)` (line 354 ends) and `## Framework-Specific Testing Patterns` (was line 355, now line 421). Positions Swarm Mode as "after solo workflow, before shared reference material."

1. **Intro** — three required inputs, fall-back-to-solo rule, affirms NON-NEGOTIABLE PROTOCOL still applies (including the "tickets in Ready or In Progress" rule — orchestrator handles it).
2. **`### Activation`** — explicit shape of each input + variant-letter derivation rule + explicit fall-back-to-solo handling when inputs are partial (resolves the "refuse and fall back to solo" wording ambiguity that PR #116's review flagged; this port clarifies the meaning).
3. **`### Behavior diffs from solo mode`** — 9 MUST/MUST NOT items covering ticket-selection, branch-creation, board-movement, worktree-cd, brief-as-additional-guidance, push, `gh pr create`, labels, In Review move.
4. **`### Behaviors preserved in swarm mode`** — re-affirms all 6 NON-NEGOTIABLE PROTOCOL rules verbatim, plus Stack Guardrails, Definition of Done discipline, Tools and Capabilities pre-flight.
5. **`### Failure handling`** — failed builds still push + report (build-status: red, failure summary), orchestrator labels swarm-failed, Render preview may still render depending on failure mode.
6. **`### Report-back shape`** — 7 fields the worker emits: Title, Body, Build status, Failure summary, Render preview URL, Fork impact, Runtime-protected paths touched.

Closes with a `See \`docs/plans/SWARM-COMMAND-PLAN.md\`` callout for the full design rationale.

## Transformations vs the meta-side source (PR #116, 60-line section)

- **Restructured against upstream's `## NON-NEGOTIABLE PROTOCOL` block.** The meta version's "Behaviors preserved" subsection re-affirmed meta's `Key Invariants` rules. This port re-affirms the upstream PROTOCOL's 6 numbered rules verbatim — anchors that didn't exist meta-side.
- **Activation fall-back wording clarified.** Meta version said "refuse and fall back to solo mode — do not attempt to repair the inputs" which read ambiguously. PR #116's review flagged this as a non-blocking nit. This port resolves it: "ignore the partial swarm context and operate as if invoked solo — select the top Ready ticket, create a branch, move to In Progress, etc."
- **Report-back shape adds Render preview URL** as a dedicated field. Meta version didn't (no Render previews in the harness). Upstream has them, so the worker reports the URL up to the orchestrator for inclusion in the Phase 4 aggregate.
- **Cross-section references** point to upstream sections by their actual upstream names: `## NON-NEGOTIABLE PROTOCOL`, `## Stack Guardrails (Render + Supabase)`, `## Tools and Capabilities`. Meta version pointed to `Key Invariants` (the meta-side equivalent).
- **Dropped the meta-specific `gembaflow#341` / `uv sync --extra dev` pre-push hook reference.** Subsumed under "Pre-flight checks from `## Tools and Capabilities` still apply" — upstream's Tools and Capabilities section handles this.

Conflict-resolution decision, 9 MUST NOTs, 4 preserved-behaviors structure all unchanged from PR #116.

## Fork impact

**Yes — propagates, and hybrid-marker discipline matters here.** `.claude/agents/*.md` IS the path-restricted hybrid path. On the next gembaflow release + `/upgrade`:

- **Fresh forks**: see the full file (including the new Swarm Mode section) at first install.
- **Existing forks on next `/upgrade`**: the **inside-markers** region of the file is replaced with this upstream version, picking up the new Swarm Mode section. Any per-fork specialization *outside* the FRAMEWORK markers is preserved per the hybrid-handler contract. The new Swarm Mode section sits inside the markers — that's intentional (it's FRAMEWORK-owned behavior, not per-fork specialization).
- **Forks that have overridden `.claude/agents/github-ticket-worker.md` via `.gembaflow-overrides`**: skip the update. They'll need to manually pull the Swarm Mode section if they want `/swarm` to work.
- **Forks blocked by runtime-protected paths**: none affected (this isn't a runtime-protected file).

## Fork-maintained files you must update

None for this PR alone. Forks running pre-Swarm-Mode versions of `github-ticket-worker.md` (i.e., everyone today) will automatically pick up the new section on next `/upgrade` via the hybrid handler.

After the v1.4.0 release that ships this + the planner + the command, forks that want to use `/swarm` need only `/upgrade` once. No fork-side configuration required.

## Test plan

- [x] `## Swarm Mode` section added between `## Post-Merge Recording (Memory MCP)` and `## Framework-Specific Testing Patterns`.
- [x] FRAMEWORK markers intact at lines 20 and 522 (was 20 and 456).
- [x] NON-NEGOTIABLE PROTOCOL block bit-for-bit unchanged — verified via `sed -n '24,31p'` matching the pre-edit text exactly.
- [x] Diff is purely additive (66 insertions, 0 deletions; `git diff --stat`).
- [x] All existing sections present and in original order (`grep -nE '^## '` lists them all).
- [x] Activation requires all 3 inputs (`worktree`, `branch`, `brief`); missing any → fall back to solo (clarified wording vs meta version).
- [x] Behavior diffs: 9 MUST/MUST NOT items covering exactly the 4 relaxation surfaces (ticket-selection, branch-creation, board-movement, PR-creation/labeling).
- [x] Behaviors preserved: every PROTOCOL rule re-affirmed by number; Stack Guardrails, DoD, Tools and Capabilities also re-affirmed.
- [x] Report-back shape lists 7 fields (Title, Body, Build status, Failure summary, Render preview URL, Fork impact, Runtime-protected paths touched).
- [ ] All upstream CI checks pass (`lint`, `lint-agent-policies`, `build`, `template-cleanliness`, `test`, `version-parity`) — verified after push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)