### PR TITLE
feat(commands): add /review-to-tickets — close the review → backlog loop

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -358,6 +358,163 @@ Risks:
 - [List blockers or delays]
 ```
 
+## Review-Findings Decider Protocol
+
+You are the **decider** when `pr-reviewer` auto-hands off after posting a
+review with non-blocking suggestions, and when an operator manually invokes
+`/review-to-tickets <PR>`. The trigger differs; the protocol is identical.
+
+This protocol exists because non-blocking suggestions on PR reviews were
+consistently leaking out of the system — `gembaflow#344` measured 8 actionable
+suggestions unfiled across 5 reviews in a 24-hour window. The job here is to
+close that loop. No human prompt sits between the suggestion and a backlog
+decision; you decide, you file, you summarize.
+
+### Per-finding decision criteria
+
+For every suggestion in the source review, decide one of:
+
+**File** — emit a new ticket to Backlog when ALL of the following hold:
+
+- The suggestion names concrete, actionable work — a thing that can be done,
+  not a vague gesture toward "consider doing better."
+- A title-substring search against open issues on the source repo does not
+  turn up a duplicate. Also cross-reference the originating ticket's parent
+  epic (if any) to catch near-duplicates filed under a sibling.
+- The work is non-trivial enough to be worth tracking on its own (it would
+  not get done as part of routine maintenance otherwise).
+
+**Dedupe** — link an existing ticket and skip filing when:
+
+- The suggestion overlaps materially with an open issue. "Materially" means
+  the existing ticket's Definition of Done would cover the suggestion's
+  intent, even if the wording differs.
+- An existing ticket is in Ready or In Progress on the same topic.
+- In this case, the existing ticket is named in the summary comment under
+  "Dedup'd:" with a link, and no new ticket is filed.
+
+**Drop** — skip with a one-line rationale when:
+
+- The suggestion is a trivial nit (e.g. "consider a slightly different variable
+  name", "could use a different word in this docstring") that does not justify
+  a tracked ticket.
+- The suggestion is a style preference already settled by project convention
+  (CLAUDE.md, an existing linter rule, an established pattern). Cite the
+  convention in the rationale.
+- The suggestion is a meta-comment about the review process or the reviewer's
+  own analysis rather than about the code itself.
+- The suggestion is speculative ("might want to consider…") with no concrete
+  acceptance criteria the implementer could verify.
+
+Every dropped finding MUST get a one-line rationale on the summary comment.
+Silent drops are the failure mode this protocol exists to fix — they look
+identical to "nothing was wrong" but conceal the decision.
+
+### Scope-impact taxonomy
+
+After processing all findings, emit exactly ONE of:
+
+- **(a) scope unchanged** — every filed ticket is a refinement of the
+  originating PR's intent. The work to come is "more of the same thing."
+- **(b) scope expanded** — at least one filed ticket represents net-new work
+  outside the originating PR's scope. The summary comment MUST flag this for
+  human grooming with a `⚠️` line; the next `/groom-backlog` pass decides
+  whether the expansion is in roadmap scope or belongs in Icebox.
+- **(c) nothing filed** — all suggestions were dedup'd or dropped, or the
+  source review was a GO with no Suggestions. The summary comment still lands
+  with rationale-per-dropped-finding; the audit trail must always be visible.
+
+The scope-impact line is **mandatory on every summary comment**, including
+the (c) path. Silence is not a valid output.
+
+### Filing mechanics
+
+For each "File" decision:
+
+1. `gh issue create --repo <owner>/<repo>` with:
+   - Title: `follow-up(#<source-PR>): <one-line summary, ≤ 70 chars>`
+   - Labels: Required Changes (retroactive backfill only) → `follow-up,P2`;
+     Suggestions → `enhancement,P3`
+   - Body: verbatim finding text + a `## Source` section linking the source
+     PR and a permalink to the source review comment
+2. Add the new issue to the source repo's project board, **Backlog column**.
+   Never promote to Ready — promotion is a `/groom-backlog` decision, not a
+   review-to-tickets decision.
+3. Capture the new issue number for the summary comment.
+
+### Verbatim source-PR summary comment template
+
+Post exactly one comment per processed review on the source PR. The marker on
+line 1 is what makes `/review-to-tickets` re-runs idempotent.
+
+````markdown
+<!-- review-to-tickets:source=#<source-PR> -->
+
+**Review-to-tickets** — <N> findings processed for [review comment](<source-review-comment-url>)
+
+- Filed: #X, #Y (Suggestions → Backlog)
+- Dedup'd: #Z (linked to existing tracker)
+- Dropped: <one-line rationale per>
+
+**Scope impact:** <unchanged | expanded — see flag below | none>
+<if expanded:> ⚠️ Filed tickets include net-new work outside #<source-ticket>'s scope. Flagging for `/groom-backlog`.
+````
+
+Worked variations:
+
+- All filed, scope unchanged:
+  ```
+  - Filed: #401, #402, #403 (Suggestions → Backlog)
+  - Dedup'd: none
+  - Dropped: none
+
+  **Scope impact:** unchanged
+  ```
+
+- Mix of file/dedupe/drop, scope expanded:
+  ```
+  - Filed: #401, #402 (Suggestions → Backlog)
+  - Dedup'd: #389 (linked to existing tracker)
+  - Dropped: "consider renaming the helper" — style preference; existing convention in CLAUDE.md
+
+  **Scope impact:** expanded — see flag below
+  ⚠️ Filed tickets include net-new work outside #324's scope. Flagging for `/groom-backlog`.
+  ```
+
+- Nothing filed (scope `none`):
+  ```
+  - Filed: none
+  - Dedup'd: #389 (linked to existing tracker)
+  - Dropped: "consider a different variable name" — trivial nit; "use Suspense here" — speculative, no concrete acceptance criteria
+
+  **Scope impact:** none
+  ```
+
+### Idempotency
+
+Before drafting, scan the source PR's comments for an existing marker
+`<!-- review-to-tickets:source=#<source-PR> -->`. If found:
+
+- Parse the previously filed ticket numbers from the prior comment.
+- Process only NEW findings (suggestions added in a later review on the same
+  PR, or findings not previously filed).
+- If no new findings exist, post no new comment — the prior marker stands,
+  and the calling command exits with "nothing new to file."
+
+### What you do NOT do in this protocol
+
+- You do NOT promote any filed ticket past Backlog. Promotion is
+  `/groom-backlog`'s call.
+- You do NOT file Required Changes from a NO-GO review. Those are PR rework,
+  not future work. Only retroactive `/review-to-tickets` backfill against
+  historical reviews routes Required Changes — and only if explicitly
+  requested by the operator.
+- You do NOT edit the source review comment. The summary comment is a fresh
+  comment under the PR.
+- You do NOT prompt the human for per-finding y/n. The human sees the
+  scope-impact line and decides whether to intervene (via `/groom-backlog`)
+  after the fact.
+
 ## Decision-Making Framework
 
 When prioritizing work:

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -535,6 +535,58 @@ for non-blocking improvements.
 - **Be consistent** - apply standards uniformly across all PRs
 - **Be constructive** - help developers improve, don't just criticize
 
+## Key Invariant: Auto-handoff to agile-backlog-prioritizer
+
+After posting a review whose body contains a non-empty `### Suggestions`
+section, you MUST invoke `agile-backlog-prioritizer` via the Task tool with
+the PR number. This handoff is fire-and-forget — the prioritizer reports
+its outcome back to the PR via a summary comment, not back to you. You do
+not wait for it to finish; you complete your Result Block and exit.
+
+**Trigger conditions:**
+
+- The review was successfully posted (`gh pr review --approve --body-file`
+  or `--request-changes --body-file` returned 0), AND
+- The posted body contains a `### Suggestions` section with at least one
+  bullet that is not "None - this implementation is production-ready..." or
+  equivalent boilerplate.
+
+**Non-triggers (do NOT hand off):**
+
+- **Required Changes on a NO-GO** are review blockers, NOT future work. They
+  belong to the PR author as rework on the same branch. Even if the same
+  NO-GO review also contains Suggestions, the handoff is for the Suggestions
+  only — Required Changes are never routed to the backlog.
+- A GO review whose Suggestions section is empty or boilerplate ("None - …").
+- A review that failed to post (CI error, account-switch race, etc.). Fix the
+  posting failure first, then re-evaluate.
+
+**Why this is an invariant, not a "could":**
+
+Across 5 reviews posted in the last 24 hours before this protocol was
+established, at least 8 actionable Suggestions were left unfiled (per
+`gembaflow#344`). The reviewer's job is not to be the gatekeeper for the
+backlog — that is `agile-backlog-prioritizer`'s job. The reviewer's job is
+to make sure every review with Suggestions gets handed off to the
+prioritizer, every time, without a human prompt in between.
+
+**Handoff payload:**
+
+The Task-tool invocation passes the PR number, the source review comment
+URL, and a short note ("auto-handoff: <N> suggestions"). The prioritizer
+fetches the review body itself, applies its decider protocol, files
+chosen tickets to Backlog, and posts the scope-impact summary comment on
+the source PR. See `.claude/agents/agile-backlog-prioritizer.md` "Review-
+Findings Decider Protocol" for the prioritizer's contract.
+
+**Manual escape hatch:**
+
+The `/review-to-tickets <PR>` command exists for retroactive backfill (past
+reviews where this protocol wasn't in effect), for re-runs (idempotent via
+HTML marker on the prioritizer's summary comment), and for cross-repo
+invocations. Same decider, different trigger. You do not invoke
+`/review-to-tickets` yourself — your obligation is the auto-handoff.
+
 ## Post-Review Recording (Memory MCP)
 
 After posting a review, record observations using Memory MCP so review

--- a/.claude/commands/review-to-tickets.md
+++ b/.claude/commands/review-to-tickets.md
@@ -1,0 +1,203 @@
+---
+description: Convert /review-pr findings on a PR into backlog tickets via the agile-backlog-prioritizer agent
+---
+
+<!-- FRAMEWORK:START -->
+
+# /review-to-tickets — Convert review findings into board tickets
+
+Parse the most recent `/review-pr` comment on a target pull request, draft a
+candidate ticket per non-blocking suggestion, and delegate the
+**file / dedupe / drop** decision to `agile-backlog-prioritizer`. The
+prioritizer files chosen tickets to **Backlog** (never Ready — promotion is a
+separate `/groom-backlog` decision), posts a single structured summary comment
+on the source PR with a scope-impact verdict, and exits.
+
+This command is the **manual escape hatch** for the same flow that
+`pr-reviewer` invokes automatically after posting a review with non-blocking
+suggestions. Same decider, different trigger.
+
+## Audience and trigger model
+
+The reader is an operator catching up on past reviews, re-running after a
+follow-up review on the same PR, or bridging across repos. The agent-driven
+auto-handoff is preferred in steady state — this command exists for:
+
+- **Retroactive backfill** — runs against older reviews where the auto-handoff
+  protocol wasn't in effect.
+- **Re-runs** — idempotent via the HTML marker (`<!-- review-to-tickets:source=#N -->`)
+  on the prioritizer's summary comment; previously filed findings are detected
+  and skipped.
+- **Cross-repo invocations** — when a review on `gembaflow-gcp` should produce
+  tickets on `gembaflow-gcp`'s board (or vice versa).
+
+The command does NOT prompt the operator with a y/n confirmation per finding.
+Per-finding decisions belong to `agile-backlog-prioritizer`. The operator sees
+the scope-impact verdict on the summary comment and intervenes via
+`/groom-backlog` if expansion was flagged.
+
+## Critical Rules
+
+1. **Never alter the source review comment.** The summary comment is posted as
+   a fresh comment on the PR. The original review is the source of truth.
+2. **Never auto-promote filed tickets past Backlog.** Promotion to Ready is a
+   `/groom-backlog` decision, not a `/review-to-tickets` decision.
+3. **Required Changes from a NO-GO review are NOT routed through this flow.**
+   They are PR blockers, not future work. If the source review's recommendation
+   is NO-GO, this command files only the Suggestions; the Required Changes are
+   handled as PR rework on the same branch.
+4. **Idempotent re-runs.** Before drafting findings, scan the PR's comments for
+   the marker `<!-- review-to-tickets:source=#<PR> -->`. If found, parse its
+   filed-ticket list and skip findings already filed. A re-run that detects
+   nothing new exits 0 with "nothing new to file".
+5. **Source attribution on every filed ticket.** Each filed ticket's body MUST
+   reference the source PR number and a permalink to the source review comment,
+   so future readers can trace back.
+6. **GO with no findings exits 0.** A clean review produces a summary comment
+   with scope-impact `none` and zero tickets filed. Silence is not an option —
+   the comment lands either way so the audit trail is complete.
+
+## Pre-Flight Verification
+
+Before invoking the prioritizer, verify:
+
+1. **`gh` CLI is authenticated and the target repo is accessible** —
+   `gh auth status` and `gh repo view <owner>/<repo> --json nameWithOwner`.
+2. **GitHub account is correct** — match the expected worker/automation
+   account for the target repo (see `.claude/agents/` README for bot accounts).
+3. **Target PR exists and has at least one `/review-pr` template comment** —
+   `gh pr view <N> --repo <owner>/<repo> --json comments,reviews`. If no
+   matching comment, STOP and report "no review found — invoke `/review-pr`
+   first."
+4. **Project board for the target repo is accessible** — the prioritizer files
+   to the source PR repo's board, not a cross-project board. If access fails,
+   STOP and report.
+
+## Workflow
+
+1. **Resolve target.** `/review-to-tickets #324` (same-repo) or
+   `/review-to-tickets vibeacademy/gembaflow-gcp#223` (cross-repo URL form).
+   With no argument, scan the active repo's open PRs for the most-recently-
+   reviewed one that has not yet been processed (no marker comment).
+2. **Fetch comments.** `gh pr view <N> --repo <owner>/<repo> --json comments,reviews`.
+3. **Identify the most recent `/review-pr` template comment.** Match on the
+   signature: starts with `## PR Review — #<N>` and contains a `### Recommendation`
+   section. If multiple, use the newest. If none, exit with the "no review found"
+   message above.
+4. **Check idempotency marker.** Scan comments for
+   `<!-- review-to-tickets:source=#<N> -->`. If found, extract the list of
+   previously-filed ticket numbers — these will be subtracted from the
+   candidate set in step 6.
+5. **Parse the review into structured findings.**
+   - **Required Changes** (numbered list under `### Required Changes`) — only
+     routed in retroactive backfill against historical reviews. In normal
+     operation, Required Changes block PR merge and are not future work.
+   - **Suggestions** (bullet list under `### Suggestions`) — the primary input
+     to the prioritizer.
+6. **Draft candidate tickets** for each finding (one per Suggestion; also per
+   Required Change in retroactive-backfill mode). Each candidate has:
+   - **Title**: `follow-up(#<PR>): <first line of finding, truncated to 70 chars>`
+   - **Labels**: Required (retroactive) → `follow-up,P2`; Suggestion →
+     `enhancement,P3`
+   - **Body**: the verbatim finding text + a `## Source` section linking the
+     source PR and the source review comment permalink
+   - **Project column target**: Backlog
+   - **Skip** any candidate whose title-substring matches a ticket number in
+     the idempotency marker.
+7. **Delegate to `agile-backlog-prioritizer`.** Invoke via the Task tool with:
+   - PR number / URL
+   - Source review comment URL
+   - The candidate list (drafts from step 6)
+   - The repo + project context for filing
+   The prioritizer applies its decider protocol (file / dedupe / drop), files
+   chosen tickets via `gh issue create`, adds them to the Backlog column, and
+   posts the structured summary comment under the source PR.
+8. **Wait for the prioritizer's report-back.** The command does not exit until
+   the prioritizer has confirmed:
+   - Filed ticket numbers (if any)
+   - Dedupe links (if any)
+   - Drop rationales (if any)
+   - Scope-impact verdict
+   - Summary comment URL
+9. **Print the Result Block** below with the prioritizer's verdict surfaced.
+
+## Usage
+
+```
+/review-to-tickets #324
+/review-to-tickets vibeacademy/gembaflow-gcp#223
+/review-to-tickets                  # most-recently-reviewed unprocessed PR
+```
+
+## Handoff contract with `agile-backlog-prioritizer`
+
+The prioritizer agent owns the **decision criteria** (file / dedupe / drop),
+the **scope-impact taxonomy** (unchanged / expanded / none), and the
+**verbatim summary comment template**. Those are defined in
+`.claude/agents/agile-backlog-prioritizer.md` under "Review-Findings Decider
+Protocol" and are the single source of truth. This command MUST NOT duplicate
+that logic — it drafts candidates, hands off, surfaces the report.
+
+The prioritizer's summary comment includes the marker
+`<!-- review-to-tickets:source=#<PR> -->` on line 1 so subsequent re-runs of
+this command can detect previously-filed findings.
+
+## Cross-repo invocation notes
+
+When the argument is a cross-repo URL form (e.g.
+`vibeacademy/gembaflow-gcp#223`):
+
+- Use `--repo <owner>/<repo>` on every `gh` call.
+- The prioritizer files tickets to the **source PR's** repo and project board
+  by default, not to the invoking repo's board. Cross-repo tracking ticket
+  creation is out of scope for this command.
+- GitHub's auto-link from PR comment to cross-repo issue does NOT fire
+  reliably — the summary comment must include the explicit PR permalink so
+  future readers can trace back.
+
+## Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Review findings processed
+Source PR: #324 — feat: add health check endpoint
+Source review comment: https://github.com/.../pull/324#issuecomment-...
+Findings parsed: 4 (1 Required, 3 Suggestion)
+Filed: 2 — #401, #402
+Dedup'd: 1 — linked to #389
+Dropped: 1 — trivial style nit
+Scope impact: unchanged
+Summary comment: https://github.com/.../pull/324#issuecomment-...
+```
+
+For the "GO with no findings" path:
+
+```
+---
+
+**Result:** No findings to file
+Source PR: #324 — feat: add health check endpoint
+Source review comment: https://github.com/.../pull/324#issuecomment-...
+Findings parsed: 0
+Scope impact: none
+Summary comment: https://github.com/.../pull/324#issuecomment-...
+```
+
+For a re-run that finds no new work:
+
+```
+---
+
+**Result:** Nothing new to file (idempotent re-run)
+Source PR: #324 — feat: add health check endpoint
+Previously filed: #401, #402
+Scope impact: unchanged (from prior run)
+```
+
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<!-- FRAMEWORK:END -->

--- a/.claude/commands/review-to-tickets.md
+++ b/.claude/commands/review-to-tickets.md
@@ -28,8 +28,8 @@ auto-handoff is preferred in steady state — this command exists for:
 - **Re-runs** — idempotent via the HTML marker (`<!-- review-to-tickets:source=#N -->`)
   on the prioritizer's summary comment; previously filed findings are detected
   and skipped.
-- **Cross-repo invocations** — when a review on `gembaflow-gcp` should produce
-  tickets on `gembaflow-gcp`'s board (or vice versa).
+- **Cross-repo invocations** — when a review on `downstream-fork` should produce
+  tickets on `downstream-fork`'s board (or vice versa).
 
 The command does NOT prompt the operator with a y/n confirmation per finding.
 Per-finding decisions belong to `agile-backlog-prioritizer`. The operator sees
@@ -76,7 +76,7 @@ Before invoking the prioritizer, verify:
 ## Workflow
 
 1. **Resolve target.** `/review-to-tickets #324` (same-repo) or
-   `/review-to-tickets vibeacademy/gembaflow-gcp#223` (cross-repo URL form).
+   `/review-to-tickets vibeacademy/downstream-fork#223` (cross-repo URL form).
    With no argument, scan the active repo's open PRs for the most-recently-
    reviewed one that has not yet been processed (no marker comment).
 2. **Fetch comments.** `gh pr view <N> --repo <owner>/<repo> --json comments,reviews`.
@@ -125,7 +125,7 @@ Before invoking the prioritizer, verify:
 
 ```
 /review-to-tickets #324
-/review-to-tickets vibeacademy/gembaflow-gcp#223
+/review-to-tickets vibeacademy/downstream-fork#223
 /review-to-tickets                  # most-recently-reviewed unprocessed PR
 ```
 
@@ -145,7 +145,7 @@ this command can detect previously-filed findings.
 ## Cross-repo invocation notes
 
 When the argument is a cross-repo URL form (e.g.
-`vibeacademy/gembaflow-gcp#223`):
+`vibeacademy/downstream-fork#223`):
 
 - Use `--repo <owner>/<repo>` on every `gh` call.
 - The prioritizer files tickets to the **source PR's** repo and project board

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/review-to-tickets` slash command** — closes the loop between `/review-pr` and the backlog by converting non-blocking Suggestions on a posted review into filed Backlog tickets. The command is the manual escape hatch (retroactive backfill, re-runs, cross-repo invocations); in steady state, `pr-reviewer` auto-hands off to `agile-backlog-prioritizer` immediately after posting a review with Suggestions. The prioritizer is the per-finding decider (file / dedupe / drop), files chosen tickets to Backlog (never Ready — promotion stays a `/groom-backlog` decision), and posts a structured summary comment on the source PR with a mandatory scope-impact verdict (unchanged / expanded / none). Idempotent re-runs via HTML marker. Required Changes on a NO-GO review are review blockers, not future work, and stay out of this flow. (#344)
+
 ## [1.3.1] - 2026-05-29
 
 **Patch release fixing the fresh-fork version stamp gap that produced no-op `/upgrade` PRs on every new fork.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,7 @@ approved, tests passing, no lint errors, PR merged to main.
 | `/groom-backlog` | Prioritize tickets, populate Ready |
 | `/work-ticket` | Pick up next ticket and implement |
 | `/review-pr` | Review PRs in In Review column |
+| `/review-to-tickets` | Convert /review-pr Suggestions into Backlog tickets via the prioritizer |
 | `/check-milestone` | Check milestone progress |
 | `/research` | Market research with web search |
 | `/jtbd` | Jobs-to-be-Done user analysis |

--- a/docs/AGENT-WORKFLOW-SUMMARY.md
+++ b/docs/AGENT-WORKFLOW-SUMMARY.md
@@ -461,6 +461,7 @@ A ticket is done when:
 |----------|---------|
 | `.claude/commands/work-ticket.md` | Work ticket command |
 | `.claude/commands/review-pr.md` | Review PR command |
+| `.claude/commands/review-to-tickets.md` | Convert review Suggestions into Backlog tickets |
 | `.claude/commands/groom-backlog.md` | Groom backlog command |
 
 ### Product Documentation
@@ -529,6 +530,34 @@ for setup instructions and the `.mcp.json` configuration.
 4. Analyzes code quality
 5. Posts detailed review
 6. Provides GO/NO-GO recommendation
+7. **If review contains non-blocking Suggestions**, auto-hands off to
+   `agile-backlog-prioritizer` (Task tool, fire-and-forget) — the prioritizer
+   files chosen tickets to Backlog and posts a scope-impact summary comment
+   on the PR. See `/review-to-tickets` for the manual escape hatch.
+
+### /review-to-tickets
+
+**Purpose**: Manually trigger the review → tickets flow for a PR — useful for
+retroactive backfill, re-runs, and cross-repo invocations.
+
+**Usage**: `/review-to-tickets #324` (same-repo) or
+`/review-to-tickets vibeacademy/gembaflow-gcp#223` (cross-repo URL form).
+
+**What Happens**:
+
+1. Parses the most recent `/review-pr` template comment on the target PR
+2. Detects idempotency marker `<!-- review-to-tickets:source=#N -->` and
+   subtracts previously-filed findings
+3. Drafts candidate tickets per non-blocking Suggestion
+4. Delegates per-finding decisions (file / dedupe / drop) to
+   `agile-backlog-prioritizer`
+5. Prioritizer files chosen tickets to Backlog and posts a structured summary
+   comment on the source PR with a scope-impact verdict
+
+This command does NOT prompt the operator with a y/n confirmation per
+finding — that decision belongs to the prioritizer agent. The operator's
+intervention point is the scope-impact line on the summary comment, which
+flags scope expansion for the next `/groom-backlog` pass.
 
 ### /groom-backlog
 

--- a/docs/ARTIFACT-FLOW.md
+++ b/docs/ARTIFACT-FLOW.md
@@ -247,7 +247,8 @@ stateDiagram-v2
 | `/groom-backlog` | Backlog Prioritizer | PRD, Roadmap, Architecture, Controls | Refined tickets in Ready column |
 | `/create-ticket` | Backlog Prioritizer | PRD, Architecture, Controls | Single ticket in Backlog |
 | `/work-ticket` | Ticket Worker | Ticket, Architecture | Branch, code, tests, PR |
-| `/review-pr` | PR Reviewer | PR, ticket, code diff | Review comment (GO/NO-GO) |
+| `/review-pr` | PR Reviewer | PR, ticket, code diff | Review comment (GO/NO-GO) + auto-handoff to prioritizer when Suggestions present |
+| `/review-to-tickets` | Backlog Prioritizer | PR review comment with Suggestions | Filed Backlog tickets + scope-impact summary comment on source PR |
 | `/sprint-status` | Any agent | Board state | Status report |
 | `/evaluate-feature` | Product Manager | PRD, Roadmap | BUILD/DEFER/DECLINE decision |
 | `/release-decision` | Product Manager | Board, PRD, metrics | GO/NO-GO release decision |


### PR DESCRIPTION
Closes #344.

## Summary

Adds a new slash command and updates two agent policies so that non-blocking Suggestions on `/review-pr` reviews stop falling off the floor. The decision-maker is `agile-backlog-prioritizer`; the trigger is either `pr-reviewer`'s auto-handoff or the new `/review-to-tickets` manual command. Same decider, two triggers.

## What changed

- **NEW** `.claude/commands/review-to-tickets.md` — the manual command. Parses the most recent `/review-pr` template comment on a PR, drafts candidate tickets per non-blocking Suggestion, hands the file / dedupe / drop decision to `agile-backlog-prioritizer`. Idempotent via the marker `<!-- review-to-tickets:source=#N -->` on the prioritizer's summary comment. Supports cross-repo URL form. **Never auto-promotes past Backlog** — promotion stays a `/groom-backlog` decision.
- **MOD** `.claude/agents/pr-reviewer.md` — adds the "Auto-handoff to agile-backlog-prioritizer" Key Invariant. After posting a review whose body contains a non-empty `### Suggestions` section, the reviewer MUST invoke the prioritizer via the Task tool (fire-and-forget). Required Changes on a NO-GO are review blockers, not future work, and never trigger the handoff. Edit is inside the FRAMEWORK markers.
- **MOD** `.claude/agents/agile-backlog-prioritizer.md` — adds the "Review-Findings Decider Protocol" section: per-finding decision criteria (file / dedupe / drop), the scope-impact taxonomy (unchanged / expanded / none), the verbatim source-PR summary comment template, filing mechanics (Backlog only), and the idempotency contract. Edit is inside the FRAMEWORK markers.
- **MOD** `CLAUDE.md` — adds `/review-to-tickets` to the Slash Commands table.
- **MOD** `docs/AGENT-WORKFLOW-SUMMARY.md` — registers the new command in the Commands file table and adds a Slash Commands section for it; documents the auto-handoff edge under `/review-pr`.
- **MOD** `docs/ARTIFACT-FLOW.md` — adds the `/review-to-tickets` row and notes the auto-handoff on the `/review-pr` row.
- **MOD** `CHANGELOG.md` — `[Unreleased]` entry.

## Why agent-driven (per the scope refinement on the ticket)

The original ticket body assumed a human y/n confirmation per finding. The pinned scope refinement (2026-06-01) supersedes that: humans are informed, not asked. The single signal a human sees by default is the **scope-impact verdict** on the summary comment — `unchanged` / `expanded` / `none`. Expansion is flagged for `/groom-backlog`; everything else flows.

Across the 24 hours before the protocol was written, 8 actionable Suggestions were unfiled across 5 reviews. The reviewer's job is not to gatekeep the backlog. This change makes the obligation explicit and routes the decision to the prioritizer agent.

## Fork impact

- **Active forks that see this change on next sync:** `gembaflow-gcp`, `gembaflow-site`, and any other downstream that runs `/upgrade`. They get:
  - `.claude/commands/review-to-tickets.md` (net-new file, overwritten wholesale per the path-restricted hybrid logic — fine for a net-new command)
  - The FRAMEWORK-marked additions to `pr-reviewer.md` and `agile-backlog-prioritizer.md` (preserved by `is_hybrid_agent_path()`)
- **Forks that do NOT see it:** none — no edited file is listed in `.gembaflow-overrides`, and no edited path is in `RUNTIME_PROTECTED_PATHS`.
- **Fork-side action required:** none. Forks already running `/review-pr` will start producing auto-handoffs to their local `agile-backlog-prioritizer` after the next `/upgrade`. If a fork has heavy local customization inside the `<!-- FRAMEWORK:START -->` markers (rather than outside, per the convention), they should re-check their merge.
- **No runtime-protected paths touched.** No CI check renames, no shims removed, no dotfile renames.

## Test plan

- [x] `scripts/validation/validate-commands.sh` passes (review-to-tickets.md picked up)
- [x] `scripts/validation/validate-agents.sh` passes
- [x] `scripts/validation/validate-agent-policies.sh` passes
- [x] Manual review of FRAMEWORK-marker discipline — both agent edits sit inside the markers; nothing outside was touched
- [ ] **Live test 1**: invoke `/review-to-tickets <PR>` against an existing review with non-blocking suggestions, confirm prioritizer files to Backlog with the scope-impact line on the summary comment
- [ ] **Live test 2**: re-run the same command, confirm idempotency via the marker
- [ ] **Live test 3**: GO-with-no-findings path — confirm "nothing to file" exit with scope-impact `none`
- [ ] **Live test 4**: cross-repo URL form — `vibeacademy/gembaflow-gcp#NNN`
- [ ] **Live test 5 (auto-handoff path)**: post a GO review with 3 non-blocking Suggestions, confirm `pr-reviewer` auto-invokes the prioritizer with no human prompt

The live tests are gated on a real PR with a fresh `/review-pr` review — flagged as manual verification rather than CI tests.

## Notes

- The pre-rebrand naming refresh from the scope refinement is reflected in the command spec — `gembaflow-gcp` (not `agile-flow-gcp`) and `gembaflow` (not `agile-flow`) are used throughout.
- `.claude/commands/*.md` FRAMEWORK markers are decorative (`is_hybrid_agent_path()` is path-restricted to `.claude/agents/`), but the new command file includes them anyway for forward compatibility with the planned hybrid-path extension.
- The pr-reviewer auto-handoff Invariant mirrors the worker → reviewer auto-handoff that's pending in `gembaflow-meta` PR #121 — same pattern, applied one layer down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)