### PR TITLE
fix(docs): use ### headers instead of dash-banners in TICKET-FORMAT.md example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - **Nested-subagent limitation documented in auto-handoff invariants** — both `github-ticket-worker.md` (worker → reviewer handoff) and `pr-reviewer.md` (reviewer → prioritizer handoff) now carry a "Known limitation: nested subagent contexts" subsection. The auto-handoffs silently no-op when the agent is itself a nested subagent (the Task tool is unavailable below the orchestrator in this Claude Code setup), which bites `/swarm` runs and orchestrator-driven multi-ticket batches. The new note names the fallback: include an explicit handoff-recommendation line in the Result Block so the orchestrator one level up can spawn the next link manually. Documentation-only; no behavioral change. Paired with the meta-side note in `gembaflow-meta#127`. (gembaflow-meta#126)
+- **`docs/TICKET-FORMAT.md` example uses `###` headers instead of dash-banners** — the Concrete Example section's four Power-Section markers were `--- A. Environment Context ---` style. That style is harmless inside the surrounding code fence but renders as horizontal rules if anyone copies the example out as a template, and is inconsistent with the `###` (or `##`) headers real ticket bodies actually use. Switched to `### A. Environment Context` etc. so the example is copy-paste-safe and matches the conventions tickets in the wild follow. Content unchanged. (#235)
 
 ## [1.4.0] - 2026-05-31
 

--- a/docs/TICKET-FORMAT.md
+++ b/docs/TICKET-FORMAT.md
@@ -75,7 +75,7 @@ Parent Epic: INFRA-010 (Observability and Health Checks)
 Effort Estimate: XS
 Priority: P1
 
---- A. Environment Context ---
+### A. Environment Context
 - Stack: Next.js 15 / React 19 / TypeScript (see TECHNICAL-ARCHITECTURE.md)
 - Integration points: Render health-check configuration (render.yaml)
 - Existing pattern: follow app/api/health/route.ts for route structure
@@ -83,21 +83,21 @@ Priority: P1
     - CREATE app/api/ping/route.ts
     - CREATE __tests__/ping.test.ts
 
---- B. Guardrails ---
+### B. Guardrails
 - Do NOT add authentication to this endpoint (it must be publicly reachable).
 - Do NOT import any database or ORM modules; this endpoint must have zero
   downstream dependencies.
 - Response time must be < 10ms at p99.
 - Do NOT modify any existing routes or middleware.
 
---- C. Happy Path ---
+### C. Happy Path
 1. Client sends GET /api/ping with no body and no auth headers.
 2. Next.js App Router routes to the ping handler.
 3. Handler returns HTTP 200 with body: {"ping": "pong"}
    Content-Type: application/json
 4. No database call, no logging side-effect, no cache hit.
 
---- D. Definition of Done ---
+### D. Definition of Done
 - ping.test.ts asserts GET /api/ping returns 200 with body {"ping": "pong"}.
 - ping.test.ts asserts response Content-Type is application/json.
 - `npm run lint` returns zero errors.


### PR DESCRIPTION
## Summary

Closes #235.

Replaces the four `--- A. Environment Context ---` style section markers in `docs/TICKET-FORMAT.md`'s Concrete Example block with `### A. Environment Context` etc.

## Caveat the ticket framing got slightly wrong

The ticket says the dash-banner lines "render as horizontal rules in GitHub Markdown." That's not literally true for the file as it stands today — they sit inside a code fence (lines 65–107), so they render as plain text. **But** the underlying ask is still valid:

- The example exists to be **copied out and used as a ticket template**. The moment anyone copies it into a real ticket body, those `--- ... ---` lines DO render as horizontal rules in GitHub's issue view.
- The dash style is inconsistent with the headers actual ticket bodies in this project use (`##` / `###`).
- The ticket's own Happy Path explicitly says "Headers use either `###` markdown syntax or `**bold**` formatting" — so the end state described in the DoD is the right one regardless of the rendering claim.

Going with `###` to align with the ticket author's stated preference.

## Verification

```
$ grep -n "^---\|^###" docs/TICKET-FORMAT.md | grep -E "78|86|93|100"
78:### A. Environment Context
86:### B. Guardrails
93:### C. Happy Path
100:### D. Definition of Done
```

No content changed inside any section — only the header syntax for the four Power Section markers.

## Fork impact

- **Active forks that see this change on next sync:** all forks that take `docs/` updates from the framework. `docs/TICKET-FORMAT.md` is a framework-owned doc.
- **Forks that do NOT see it:** any fork that overrides `docs/TICKET-FORMAT.md` via `.gembaflow-overrides`.
- **Fork-side action required:** none. Pure cosmetic improvement to the example.

## Test plan

- [ ] Confirm lines 78/86/93/100 use `### X. ...` syntax (verified above)
- [ ] Confirm no other lines were touched
- [ ] Confirm CHANGELOG entry under `[Unreleased]` → `### Documentation` (H3 per `feedback_changelog_heading_levels.md`)

