### PR TITLE
docs(release): require "Fork-maintained files you must update" section in every release notes

### DIFF
--- a/.claude/commands/release-decision.md
+++ b/.claude/commands/release-decision.md
@@ -30,6 +30,7 @@ Launch the agile-product-manager agent to evaluate release readiness and make a 
 
 ### 4. Communication Readiness Assessment
 - Release notes prepared
+- **Release notes include a "Fork-maintained files you must update" section** (required on every release per `docs/SDLC.md`; reads "None required" if the release introduces no fork-side edits — the absence is made explicit, never omitted)
 - Customer communication planned
 - Internal stakeholders informed
 - Documentation updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Root `.gitignore` now covers framework-generated artifacts** — `.gembaflow-reports/` (the directory `/report-issue` writes into), the legacy `.agile-flow-reports/` (pre-rebrand name, still present on some forks), and the legacy `.agile-flow-version` dotfile (transitional safety net — the current canonical `.gembaflow-version` is intentionally NOT ignored) are now recognized as ignorable. Removes the recurring `/upgrade` clean-tree precheck failure on every fork that has ever run `/report-issue`. The clean-tree check itself is unchanged — this only adds the ignore patterns the check is supposed to honor. (#372)
+- **Release notes now require a "Fork-maintained files you must update" section** — `docs/SDLC.md`'s release process gains a step 4 obligating maintainers to add this section to every release's GitHub Release body. The section calls out concrete edits a fork maintainer must apply by hand after `/upgrade` (removed shims, renamed CI checks, branch-protection rule expectations, workflow file deltas). If a release introduces no fork-required edits, the section reads "None required" — never omitted, so the absence is meaningful information. `VERSIONING.md` cross-links the convention. `.claude/commands/release-decision.md` adds the section to its Communication Readiness checklist. Retroactive backfill applied to the published v1.2.0 and v1.2.1 GitHub Releases. (#373)
 
 ### Documentation
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -33,6 +33,7 @@ MAJOR.MINOR.PATCH
 1. All changes land on `main` via pull request.
 2. When ready to release, a maintainer creates an annotated tag (`git tag -a vX.Y.Z`).
 3. Pushing the tag triggers the GitHub Release workflow, which publishes a release with the relevant `CHANGELOG.md` section.
+4. **The release notes MUST include a "Fork-maintained files you must update" section** — see [docs/SDLC.md](./docs/SDLC.md#fork-maintained-files-you-must-update-required-section-in-every-release-notes-file) for the template and rationale. If the release introduces no fork-required edits, the section reads "None required" — the absence is made explicit.
 
 ## Current Version
 

--- a/docs/SDLC.md
+++ b/docs/SDLC.md
@@ -360,6 +360,69 @@ passing.
    - Pushes tag: `git push origin vX.Y.Z`
 3. The `release.yml` workflow fires on the tag, extracts the CHANGELOG
    section, and creates a GitHub Release.
+4. The maintainer **edits the published GitHub Release** to add the
+   "Fork-maintained files you must update" section (see template below).
+   The workflow generates the release from the CHANGELOG section, which
+   describes synced framework changes — fork-maintained file edits that
+   downstream consumers must apply manually require a separate, explicit
+   call-out so they aren't lost in the CHANGELOG bullets.
+
+### "Fork-maintained files you must update" (required section in every release notes file)
+
+When a release changes behavior that's only enforced through a *synced*
+artifact while the *related* fork-maintained artifact stays behind, forks
+silently drift. This section makes that drift visible at release time.
+
+**The section is required on every release**, even if the answer is
+"None required". The absence of fork-required edits is meaningful
+information — it tells consumers they can run `/upgrade` without
+preparation.
+
+What belongs in the section:
+
+- **Removed compatibility shims** — e.g. "`report-issue.sh` no longer
+  reads `.agile-flow-version` — update your `features/` BDD tests if you
+  have any that reference it."
+- **Renamed CI check names** — e.g. "`typecheck` → `version-parity` in
+  `.github/workflows/ci.yml`. Update your branch-protection ruleset to
+  match, or sync PRs will block on a check that no longer reports."
+- **Workflow file deltas** — `.github/workflows/` is fork-maintained, not
+  synced. Any expectation the framework has of those workflows (job
+  names, required outputs, secrets) belongs here.
+- **Branch-protection rule expectations** — required-status-check name
+  changes, force-push policy changes, anything the fork's ruleset would
+  need to mirror.
+- **Anything else where a synced framework file references a
+  fork-maintained counterpart whose name or behavior must match.**
+
+What does NOT belong:
+
+- Migration steps the framework's own scripts handle automatically (e.g.
+  dotfile renames done by `template-sync.sh`'s migration step). Those go
+  in "Migration notes" / "Upgrade notes", not here.
+- New features or fixes — those are CHANGELOG entries.
+
+### Release notes template — Fork-maintained files section
+
+```markdown
+## Fork-maintained files you must update
+
+> **What this section is:** edits a fork maintainer must apply by hand
+> after `/upgrade` — file paths and rule names whose synced framework
+> counterpart changed, but which themselves are not synced.
+
+- **`<file or rule>`** — `<what changed in the synced counterpart>`. Edit
+  required: `<concrete diff or instruction>`. Skip if `<condition>`.
+- **`<file or rule>`** — ...
+
+(If none: `**None required.** This release does not change any
+fork-maintained file expectations.`)
+```
+
+**Authoritative source for what's synced vs not:** `.gembaflow-version`'s
+`syncDirectories` list + `docs/DISTRIBUTION.md` classification (per path:
+`framework`, `user-content`, or `hybrid`). Anything not in
+`syncDirectories` or marked `user-content` is fork-maintained.
 
 ### Downstream obligations after a release
 


### PR DESCRIPTION
## Summary

Closes #373.

Adopts a new convention: **every gembaflow release's GitHub Release body MUST include a "Fork-maintained files you must update" section**, even when the answer is "None required". The absence of fork-required edits is meaningful information.

This addresses the silent-drift pattern that's already bit two recent releases:
- **v1.2.0** removed a Phase 4 dual-read shim → forks' `features/` BDD tests (NOT synced) broke. No warning in release notes.
- **v1.2.1** renamed CI check `typecheck` → `version-parity` → forks' branch-protection rules (fork-maintained) needed manual edit. Warning existed but was **buried** inside the "Changed" section. Same drift bit `gembaflow#399` today (2026-06-02).

## Changes in this PR

| File | What changed |
|---|---|
| `docs/SDLC.md` | Adds step 4 to "Release process" + full "Fork-maintained files you must update" subsection with rationale, template, what-belongs-vs-not, and authoritative source (`.gembaflow-version`'s `syncDirectories` + `docs/DISTRIBUTION.md`) |
| `VERSIONING.md` | Adds step 4 to "Release Process" cross-linking the SDLC.md section |
| `.claude/commands/release-decision.md` | Adds the section to "Communication Readiness Assessment" checklist |
| `CHANGELOG.md` | Entry under `[Unreleased]` → `### Changed` |

## Out-of-band changes (already live)

Per the ticket DoD, the retroactive backfill of the v1.2.0 and v1.2.1 GitHub Release notes is **already applied** (GitHub releases are state, not files — applied via `gh release edit`):

- **v1.2.0:** https://github.com/vibeacademy/gembaflow/releases/tag/v1.2.0 — section added before "Changed". Documents the `features/` BDD breakage that hit gembaflow-site.
- **v1.2.1:** https://github.com/vibeacademy/gembaflow/releases/tag/v1.2.1 — section added before "Fixed". Lifts the previously-buried typecheck rename warning into the new prominent position. Original "Changed" entry preserved for historical accuracy.

Both backfilled bodies are marked with a `> **Backfilled 2026-06-02**` callout so future readers understand the provenance.

## Note on file placement

The ticket assumed `docs/RELEASE-PROCESS.md` exists. It doesn't — the release process lives across `VERSIONING.md` (semver + numbered steps) and `docs/SDLC.md` (full process + downstream obligations). Rather than create a new doc, this PR adds the convention to both existing homes so it's discoverable from either entry point.

## Fork impact

- **Active forks that see this change on next sync:** all forks that take `docs/SDLC.md`, `VERSIONING.md`, `CHANGELOG.md`, and `.claude/commands/release-decision.md` updates. All four are framework-owned.
- **Forks that do NOT see it:** any fork that overrides those files via `.gembaflow-overrides` (none expected).
- **Fork-side action required:** **none for the in-repo docs.** For the *next* release that forks consume, they'll see a new mandatory section in the release notes — that's the whole point.
- **Will this PR's release notes include a "Fork-maintained files you must update" section?** Yes, this PR has zero fork-maintained file impact — the convention takes effect the next time `/cut-release` runs.

## Test plan

- [ ] Confirm `docs/SDLC.md`'s release-process section now has step 4 + the new subsection
- [ ] Confirm `VERSIONING.md` cross-links the SDLC section
- [ ] Confirm `release-decision.md` checklist includes the new item
- [ ] Confirm CHANGELOG entry uses `###` (under existing `### Changed`)
- [ ] Confirm v1.2.0 and v1.2.1 release notes on GitHub now have the section (links above)

