### PR TITLE
docs(report-issue): document board-canonical priority convention (#337)

### DIFF
--- a/.claude/commands/report-issue.md
+++ b/.claude/commands/report-issue.md
@@ -8,6 +8,13 @@ File a structured bug report or feedback item against the upstream Gemba Flow re
 from this downstream fork. The report is delivered as a GitHub issue with a
 `downstream-report` label so upstream maintainers can triage it automatically.
 
+**Severity vs priority:** the `severity` field you'll be prompted for (p1/p2/p3)
+is recorded in the report's YAML front matter, not applied as a repo label on
+the upstream issue. **Priority is canonical on the upstream project board's
+Priority field**, not on the issue itself — see `docs/TICKET-FORMAT.md`. If the
+new issue belongs on the board, the upstream maintainer (or you, if you have
+project access) adds it there and sets the Priority field.
+
 ## When to use this command
 
 Use `/report-issue` when you have found:

--- a/docs/TICKET-FORMAT.md
+++ b/docs/TICKET-FORMAT.md
@@ -21,7 +21,7 @@ Each ticket has **Standard Fields** followed by **4 Power Sections**.
 | **Problem Statement** | What is broken or missing, and why it matters. 2-3 sentences max. |
 | **Parent Epic** | Link to the parent epic, if applicable. Omit if standalone. |
 | **Effort Estimate** | XS (< 1 hr), S (1-4 hr), M (4-8 hr), L (1-3 days), XL (3+ days). |
-| **Priority** | P0 (drop everything), P1 (current sprint), P2 (next sprint), P3 (backlog). |
+| **Priority** | P0 (drop everything), P1 (current sprint), P2 (next sprint), P3 (backlog). Set on the project board's Priority field — **not** as a repo label on the issue. Issue bodies may render `Priority: P1` as documentation, but the board field is the canonical source. |
 
 ### Power Section A: Environment Context
 

--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -591,6 +591,11 @@ if command -v gh >/dev/null 2>&1; then
       echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
       echo "Issue filed successfully."
       echo "Report saved: $REPORT_FILE"
+      echo ""
+      echo "Severity ($SEVERITY) is recorded in the report's YAML front matter,"
+      echo "not as a repo label. Priority is canonical on the upstream project"
+      echo "board, not on this issue. If this issue should be tracked there,"
+      echo "add it to the board and set its Priority field."
       echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
       exit 0
     fi
@@ -609,6 +614,11 @@ if command -v gh >/dev/null 2>&1; then
       echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
       echo "Issue filed successfully."
       echo "Report saved: $REPORT_FILE"
+      echo ""
+      echo "Severity ($SEVERITY) is recorded in the report's YAML front matter,"
+      echo "not as a repo label. Priority is canonical on the upstream project"
+      echo "board, not on this issue. If this issue should be tracked there,"
+      echo "add it to the board and set its Priority field."
       echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
       exit 0
     fi


### PR DESCRIPTION
## Summary

Closes #337.

Addresses #337 with a minimal scope-disciplined change: document that priority is canonical on the project board's Priority field, not as a repo label, and route the priority signal through the report-issue flow accordingly. **Deferred DoD items #2 and #5 are captured as follow-up tickets** (see "Deferred" below) so closing #337 on merge does not lose that scope.

**Important finding while reading the code:** the ticket's literal premise — that `scripts/report-issue.sh` and the issue/PR templates "currently auto-apply P0/P1/P2/P3 labels" — is **empirically false at current HEAD**. Verified by:

- Reading the full `scripts/report-issue.sh` — only ever applies `downstream-report` (lines 585 and 603); the only place P0/P1/P2/P3 appear is the severity input-validation case statement on line 308 (`p1|p2|p3) ;;`).
- Reading `.claude/commands/report-issue.md` — no label logic, just invokes the script.
- `ls .github/ISSUE_TEMPLATE/` — directory does not exist.
- `ls .github/*.md` — no PR template either.
- `git log -p -- scripts/report-issue.sh | grep --label` — historical diffs only show `--label "downstream-report"` lines; no P-label was ever applied.

So DoD items #1 ("script no longer passes P0/P1/P2/P3 to `gh issue create --label`") and #4 ("no P-label references in any issue/PR template") are already satisfied. This PR addresses the positive side of the ticket — making the board-canonical-priority convention explicit and routing the priority signal there.

## Changes

- **`scripts/report-issue.sh`** — after a successful `gh issue create` (both labeled and unlabeled success paths), print a 4-line reminder that severity is recorded in the report's YAML front matter (not as a label) and priority is canonical on the upstream project board. Generic wording — no hardcoded board ID, since this script propagates to forks via template-sync and not every fork uses the same board.
- **`.claude/commands/report-issue.md`** — add a "Severity vs priority" paragraph in the intro section explaining the convention; cross-link to `docs/TICKET-FORMAT.md`.
- **`docs/TICKET-FORMAT.md`** — extend the Priority row in the Standard Fields table (line 24) to make the convention explicit: priority is set on the project board's Priority field, not as a repo label. The body may render `Priority: P1` as documentation, but the board field is canonical.

## DoD walkthrough

| DoD item | Status |
|---|---|
| 1. Script no longer passes P0/P1/P2/P3 to `gh issue create --label` | already true at HEAD (pre-existed) — no change needed |
| 2. Script adds issue to project #13 and sets Priority field | **deferred to follow-up ticket** — needs board-ID config in `.gembaflow-version` to avoid breaking forks with different boards |
| 3. Skip P-label + print "set Priority on board manually" hint | **done** — script now prints the reminder after successful issue creation |
| 4. No P-label refs in any issue/PR template | already true (no templates exist) — verified `ls .github/ISSUE_TEMPLATE/` and `ls .github/*.md` |
| 5. Manual end-to-end test (severity=p2 → board priority=P2, no P2 label on issue) | **deferred to follow-up ticket** — meaningful only once DoD #2 is implemented; can't be tested with the current minimal print-reminder change |
| 6. Document the new convention | **done** — convention added to `docs/TICKET-FORMAT.md` and `.claude/commands/report-issue.md` |

## Deferred to follow-up tickets

1. **DoD #2 — auto-add to board + set Priority field.** This needs board-ID config in `.gembaflow-version` (or equivalent) since `scripts/report-issue.sh` propagates to forks and each fork may track its own board. Hardcoding `PVT_kwDODjeGB84BPbD4` (Gemba Flow Meta) into the upstream script would route every fork's `/report-issue` output to the meta board, which isn't what downstream forks want. Will file a separate ticket immediately so this is not lost on merge.
2. **`.github/workflows/auto-triage.yml` still auto-applies `P1`** (line 76, `labels: ['P1']`). The #337 ticket doesn't name this file, but it's the actual auto-application site in the repo — `report-issue` paths were already clean. If the maintainer's board-hygiene initiative wants to also delete the `P1` label from the repo, `auto-triage.yml` will start erroring on issue-create. Will file a separate ticket immediately.

## Fork impact

- **Active downstream forks (`gembaflow-gcp`, etc.):** `scripts/report-issue.sh`, `.claude/commands/report-issue.md`, and `docs/TICKET-FORMAT.md` are NOT in `gembaflow-gcp`'s `.gembaflow-overrides`. They are NOT in `RUNTIME_PROTECTED_PATHS` either. → These edits will propagate cleanly to forks on next `/upgrade` / `/pull-upstream`.
- **Behavior change for fork users:** after `/report-issue` succeeds, they'll see 4 extra lines of output reminding them about the board-canonical-priority convention. No code behavior change.
- **Upstream-vs-fork wording in the reminder:** the script reads `UPSTREAM_REPO` from `.gembaflow-version`, so the printed text correctly says "the upstream project board" regardless of which fork runs the script.

## Test plan

- [x] `uv run --extra dev ruff check .` — clean
- [x] `bash -n scripts/report-issue.sh` — syntax OK
- [x] `bash scripts/report-issue.sh --dry-run --severity p2 --component docs --title "preview test" --body "..."` — dry-run runs to completion, exits 0, no behavior change (reminder only fires after real `gh issue create` succeeds)
- [x] `grep -E 'P0|P1|P2|P3' scripts/report-issue.sh` — only the `p1|p2|p3` severity validation case statement and the `Priority: P2` placeholder example in the slash-command doc remain; no P-labels applied
- [ ] Reviewer: read the convention statement in `docs/TICKET-FORMAT.md` line 24 and confirm it aligns with the board-hygiene initiative direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)