### PR TITLE
chore(changelog): backfill v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [1.5.0] - 2026-06-13
+
+**Major release. Headline pairing: `/drain` ships AND the upgrade pipeline can actually deliver it.** Lands the four-ticket drain port (T1–T4) plus the keystone self-healing-sync fix (#371) that closes the long-standing upgrade-pipeline gap. 28 PRs ship between v1.4.0 (2026-06-01) and v1.5.0 (2026-06-13).
+
+**Migration: every existing fork needs a one-time manual refresh of `scripts/template-sync.sh` and `scripts/lib/overrides.sh` on first `/upgrade` to v1.5.0** — see the v1.5.0 GitHub Release notes § "Propagation note" for the exact commands. Fresh forks (provisioned after v1.5.0) get the self-heal automatically. Subsequent runtime-protected fixes propagate without manual intervention.
+
+**Branch-protected forks must also add `json-validate` to their required-status-checks list on the `main` ruleset** (#471 split the `version-parity` umbrella job). Existing `version-parity` entry stays.
+
+Full release narrative + per-PR detail: [v1.5.0 release notes](https://github.com/vibeacademy/gembaflow/releases/tag/v1.5.0). Per-entry detail below.
+
 ### Added
 
 - **`scripts/template-sync.sh` self-heals runtime-protected files after the sync loop — closes the self-upgrade gap** — until now, bug fixes landed in `scripts/template-sync.sh` or `scripts/lib/overrides.sh` (the two `RUNTIME_PROTECTED_PATHS` entries) could not reach forks via the normal sync. The main sync loop correctly skips these files because the running script cannot safely overwrite itself mid-execution; but that meant every fork bootstrapped before #361 (package.json auto-bump) hit red CI on its first `/upgrade` because the bumped-script was stuck on the pre-fix version. New post-sync-loop block in `template-sync.sh` (between the main loop and `WORK_DIR` cleanup) re-copies each runtime-protected file from the already-extracted release tarball IF (a) the local file differs from the tarball version AND (b) the path is NOT in `.gembaflow-overrides`. The currently-running script process is unaffected — it's in memory; only the on-disk file is updated, so the next `/upgrade` invocation reads the refreshed code. Refreshed files appear in `FILES_CHANGED`, ride the same sync PR, and surface in a new `> [!IMPORTANT] Runtime-protected files refreshed` callout on the PR body. Operators reviewing the sync PR see the refresh explicitly and can decide. `scripts/template-sync.test.sh` gains 2 new scenarios (Scenario 9 positive: both runtime-protected files refresh + PR body callout; Scenario 9b negative: file listed in `.gembaflow-overrides` is preserved while the non-overridden file still refreshes) plus updated assertions on Scenario 1 to reflect the post-#371 contract — 48 total test assertions PASS. Fork operators bootstrapped before #361 will see this PR's sync update both `template-sync.sh` and `overrides.sh` cleanly on their first `/upgrade` to this version; subsequent fixes to either file propagate normally. (#371)


### PR DESCRIPTION
Backfills the CHANGELOG entry for v1.5.0. The release was cut via `gh release create --notes-file` per the platform release flow; this PR brings the canonical CHANGELOG in sync.

## What's here

- New `## [1.5.0] - 2026-06-13` block at the top of CHANGELOG.md, inserted between the now-empty `## [Unreleased]` and the prior `## [1.4.0]` entry.
- The block summarizes the release (drain stack T1-T4 + #371 self-heal as the headline pairing) and links out to the GitHub Release for the full narrative.
- All prior `[Unreleased]` entries (28 PRs since v1.4.0) are preserved under the new `## [1.5.0]` heading — each entry that was previously in `[Unreleased]` is now in the version block where it belongs.
- The `[Unreleased]` block now reads "_No unreleased changes._" — fresh slate for the next release window.

## Cross-references

- Release: https://github.com/vibeacademy/gembaflow/releases/tag/v1.5.0
- Tag: `v1.5.0` (created at HEAD of `main` immediately before this PR was opened)

## Why a backfill PR

Direct push to `main` is blocked by branch protection. The cut-release flow (`/cut-release` skill in `gembaflow-meta`) opens the tag via `gh release create --notes-file` first, then opens this PR to land the CHANGELOG entry. The two steps are sequenced this way so the release notes can be edited if a typo lands in the tag without needing to rotate the tag itself.

## Test plan

- [x] Local: markdownlint-cli2 passes on the modified CHANGELOG.md.
- [x] The new `## [1.5.0]` block uses H3 subsections (`### Added`, `### Changed`, `### Removed`, etc.) per the CHANGELOG H3 invariant.
- [x] The `[Unreleased]` block is cleanly empty (no stale entries left over).
- [ ] CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)