### PR TITLE
docs(gate): validation log — agent-merge gate post-merge validation (#578)

### DIFF
--- a/docs/agent-merge-gate.md
+++ b/docs/agent-merge-gate.md
@@ -305,6 +305,27 @@ invocations are recommended:
 - **Deliberate failure 2** — dispatch against a non-existent PR
   number → fetch step fails → exit non-zero.
 
+### Validation log
+
+- **2026-08-01** — post-merge validation per PR #586's plan, executed
+  against this repo's own gate (the live-merge case is the *first*
+  agent-merged PR on this repository). Test artifact: branch
+  `chore/gate-validation-001` (this change). Cases:
+  - **DENY/citation** — malformed `Bead:` citation in the PR body →
+    condition 1 FAIL (dry-run dispatch).
+  - **DENY/labels** — second `safety:*` label added → condition 2 FAIL
+    (dry-run dispatch).
+  - **DENY/stale-approval** — reviewer approval bound to a pre-push
+    head commit → condition 6 FAIL naming both commit oids (dry-run
+    dispatch).
+  - **HAPPY/dry-run** — fresh approval at head, all conditions
+    satisfied → PASS with the dry-run "skipping the actual merge"
+    outcome.
+  - **LIVE** — `repository_dispatch` (`drain-merge`) through the bridge
+    → gate verified all seven conditions and squash-merged.
+
+  Run IDs for each case are recorded on issue #578.
+
 ## References
 
 - [`.github/workflows/agent-merge.yml`](../.github/workflows/agent-merge.yml) —

--- a/docs/agent-merge-gate.md
+++ b/docs/agent-merge-gate.md
@@ -324,7 +324,7 @@ invocations are recommended:
   - **LIVE** — `repository_dispatch` (`drain-merge`) through the bridge
     → gate verified all seven conditions and squash-merged.
 
-  Run IDs for each case are recorded on issue #578.
+  Run IDs for each case are recorded on issue #578 (the E4 ticket).
 
 ## References
 


### PR DESCRIPTION
Gate-validation artifact per PR #586's post-merge validation plan (epic #574 E4, issue #578). Appends the 2026-08-01 validation log to docs/agent-merge-gate.md.

Bead: gf-val1

The bead id above is synthetic — it exists to satisfy the gate's condition-1 citation regex for this validation exercise; no local tracker is initialized upstream (tracker init is a rollout decision, E5+).

This PR is itself the live-merge test case: if the validation passes, the agent-merge gate squash-merges it via the drain-merge bridge — the first agent-merged PR on this repository. Do not merge manually.

Run IDs for the case matrix are recorded on issue #578.
